### PR TITLE
Fix route output coverage validation

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -66,6 +66,7 @@ pub struct EntryDecl {
     pub emits: EmitSpec,
     pub body: String,
     pub routes: Vec<RouteCall>,
+    pub terminal_route_sets: Vec<Vec<RouteCall>>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -165,6 +165,7 @@ impl<'a> Model<'a> {
             self.actor_state(&route.actor)?;
             self.validate_route_allowed(actor, entry, route)?;
         }
+        self.validate_route_coverage(actor, entry)?;
         Ok(())
     }
 
@@ -225,6 +226,79 @@ impl<'a> Model<'a> {
                 }
             }
         }
+    }
+
+    fn validate_route_coverage(&self, actor: &ActorDecl, entry: &EntryDecl) -> Result<()> {
+        match &entry.emits {
+            EmitSpec::None => Ok(()),
+            EmitSpec::One { .. } => self.validate_single_output_coverage(actor, entry),
+            EmitSpec::Outputs(outputs) => self.validate_named_output_coverage(actor, entry, outputs),
+        }
+    }
+
+    fn validate_single_output_coverage(&self, actor: &ActorDecl, entry: &EntryDecl) -> Result<()> {
+        if entry.terminal_route_sets.is_empty() {
+            return Err(ArgentError::new(format!(
+                "entry `{}::{}` declares `emits one` but has no terminal `become` route",
+                actor.name, entry.name
+            )));
+        }
+
+        for (path_idx, routes) in entry.terminal_route_sets.iter().enumerate() {
+            if routes.len() != 1 || routes[0].output.is_some() {
+                return Err(ArgentError::new(format!(
+                    "entry `{}::{}` terminal path {} must validate exactly one unnamed output for `emits one`",
+                    actor.name, entry.name, path_idx
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_named_output_coverage(&self, actor: &ActorDecl, entry: &EntryDecl, outputs: &[EmitOutput]) -> Result<()> {
+        if outputs.is_empty() {
+            return Ok(());
+        }
+        if entry.terminal_route_sets.is_empty() {
+            return Err(ArgentError::new(format!(
+                "entry `{}::{}` declares {} outputs but has no terminal `become` route",
+                actor.name,
+                entry.name,
+                outputs.len()
+            )));
+        }
+
+        let declared = outputs.iter().map(|output| output.name.as_str()).collect::<BTreeSet<_>>();
+        for (path_idx, routes) in entry.terminal_route_sets.iter().enumerate() {
+            let mut seen = BTreeSet::new();
+            for route in routes {
+                let output = route.output.as_deref().ok_or_else(|| {
+                    ArgentError::new(format!(
+                        "entry `{}::{}` terminal path {} has an unnamed route but declares named outputs",
+                        actor.name, entry.name, path_idx
+                    ))
+                })?;
+                if !declared.contains(output) {
+                    continue;
+                }
+                if !seen.insert(output) {
+                    return Err(ArgentError::new(format!(
+                        "entry `{}::{}` terminal path {} validates output `{}` more than once",
+                        actor.name, entry.name, path_idx, output
+                    )));
+                }
+            }
+
+            for output in outputs {
+                if !seen.contains(output.name.as_str()) {
+                    return Err(ArgentError::new(format!(
+                        "entry `{}::{}` terminal path {} does not validate output `{}`",
+                        actor.name, entry.name, path_idx, output.name
+                    )));
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1234,10 +1308,67 @@ mod tests {
             actors: vec!["Player".to_string(), "Game".to_string()],
             auth_index: 0,
         }]);
-        program.modules[0].actors[0].entries[0].routes =
-            vec![RouteCall { output: Some("next".to_string()), actor: "Game".to_string(), state: "next_game".to_string() }];
+        let route = RouteCall { output: Some("next".to_string()), actor: "Game".to_string(), state: "next_game".to_string() };
+        program.modules[0].actors[0].entries[0].routes = vec![route.clone()];
+        program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![route]];
 
         Model::from_program(&program).expect("route should be accepted");
+    }
+
+    #[test]
+    fn rejects_missing_named_output_coverage() {
+        let mut program = test_program();
+        program.modules[0].actors[0].entries[0].emits = EmitSpec::Outputs(vec![
+            EmitOutput { name: "a".to_string(), actors: vec!["Player".to_string()], auth_index: 0 },
+            EmitOutput { name: "b".to_string(), actors: vec!["Player".to_string()], auth_index: 1 },
+        ]);
+        let route = RouteCall { output: Some("a".to_string()), actor: "Player".to_string(), state: "next_a".to_string() };
+        program.modules[0].actors[0].entries[0].routes = vec![route.clone()];
+        program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![route]];
+
+        let err = Model::from_program(&program).expect_err("missing output coverage must be rejected");
+        assert!(err.to_string().contains("does not validate output `b`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_source_with_missing_named_output_coverage() {
+        let module = crate::parser::parse_module(
+            PathBuf::from("test.ag"),
+            r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry step() emits {
+                    a: Foo;
+                    b: Foo;
+                } {
+                    become a <- Foo(next_a);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+            "#
+            .to_string(),
+        )
+        .expect("source parses");
+        let program = Program { root: PathBuf::from("test.ag"), modules: vec![module] };
+
+        let err = Model::from_program(&program).expect_err("missing output coverage must be rejected");
+        assert!(err.to_string().contains("does not validate output `b`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_named_output_coverage() {
+        let mut program = test_program();
+        let first = RouteCall { output: Some("next".to_string()), actor: "Player".to_string(), state: "next_player".to_string() };
+        let second = RouteCall { output: Some("next".to_string()), actor: "Player".to_string(), state: "other_player".to_string() };
+        program.modules[0].actors[0].entries[0].routes = vec![first.clone(), second.clone()];
+        program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![first, second]];
+
+        let err = Model::from_program(&program).expect_err("duplicate output coverage must be rejected");
+        assert!(err.to_string().contains("validates output `next` more than once"), "unexpected error: {err}");
     }
 
     #[test]
@@ -1280,6 +1411,7 @@ mod tests {
                             }]),
                             body: String::new(),
                             routes: Vec::new(),
+                            terminal_route_sets: Vec::new(),
                         }],
                     },
                     ActorDecl { name: "Game".to_string(), state: "GameState".to_string(), entries: Vec::new() },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::ast::*;
 use crate::error::{ArgentError, Result};
 use crate::lexer::{Token, TokenKind, lex};
-use crate::routes::collect_routes;
+use crate::routes::analyze_routes;
 
 pub fn parse_module(path: PathBuf, source: String) -> Result<Module> {
     let tokens = lex(&source).map_err(|err| ArgentError { path: Some(path.clone()), message: err.message })?;
@@ -136,8 +136,17 @@ impl Parser {
         self.expect_ident("emits")?;
         let emits = self.parse_emits()?;
         let body = self.consume_block_text()?;
-        let routes = collect_routes(&body).map_err(|err| ArgentError::at(&self.path, err.message))?;
-        Ok(EntryDecl { kind: EntryKind::Leader, name, params, consumes, emits, body, routes })
+        let route_analysis = analyze_routes(&body).map_err(|err| ArgentError::at(&self.path, err.message))?;
+        Ok(EntryDecl {
+            kind: EntryKind::Leader,
+            name,
+            params,
+            consumes,
+            emits,
+            body,
+            routes: route_analysis.routes,
+            terminal_route_sets: route_analysis.terminal_route_sets,
+        })
     }
 
     fn parse_delegate(&mut self) -> Result<EntryDecl> {
@@ -146,8 +155,17 @@ impl Parser {
         let params = self.parse_param_list()?;
         let consumes = if self.check_ident("consumes") { self.parse_consumes()? } else { Vec::new() };
         let body = self.consume_block_text()?;
-        let routes = collect_routes(&body).map_err(|err| ArgentError::at(&self.path, err.message))?;
-        Ok(EntryDecl { kind: EntryKind::Delegate, name, params, consumes, emits: EmitSpec::None, body, routes })
+        let route_analysis = analyze_routes(&body).map_err(|err| ArgentError::at(&self.path, err.message))?;
+        Ok(EntryDecl {
+            kind: EntryKind::Delegate,
+            name,
+            params,
+            consumes,
+            emits: EmitSpec::None,
+            body,
+            routes: route_analysis.routes,
+            terminal_route_sets: route_analysis.terminal_route_sets,
+        })
     }
 
     fn parse_app(&mut self) -> Result<AppDecl> {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -2,57 +2,134 @@ use crate::ast::RouteCall;
 use crate::error::{ArgentError, Result};
 use crate::lexer::{Token, TokenKind, lex};
 
+#[derive(Debug, Clone)]
+pub struct RouteAnalysis {
+    pub routes: Vec<RouteCall>,
+    pub terminal_route_sets: Vec<Vec<RouteCall>>,
+}
+
 pub fn collect_routes(body: &str) -> Result<Vec<RouteCall>> {
+    analyze_routes(body).map(|analysis| analysis.routes)
+}
+
+pub fn analyze_routes(body: &str) -> Result<RouteAnalysis> {
     let tokens = lex(body)?;
-    validate_terminal_becomes(body, &tokens)?;
-    let mut parser = RouteParser { body, tokens, pos: 0, routes: Vec::new() };
-    parser.parse()?;
-    Ok(parser.routes)
+    let mut parser = TerminalParser { body, tokens: &tokens, pos: 0 };
+    let info = parser.parse_sequence(None)?;
+    let routes = info.terminal_route_sets.iter().flatten().cloned().collect();
+    Ok(RouteAnalysis { routes, terminal_route_sets: info.terminal_route_sets })
 }
 
-fn validate_terminal_becomes(body: &str, tokens: &[Token]) -> Result<()> {
-    let mut parser = TerminalParser { body, tokens, pos: 0 };
-    parser.parse_sequence(None)?;
-    Ok(())
-}
-
-struct RouteParser<'a> {
+struct TerminalParser<'a> {
     body: &'a str,
-    tokens: Vec<Token>,
+    tokens: &'a [Token],
     pos: usize,
-    routes: Vec<RouteCall>,
 }
 
-impl RouteParser<'_> {
-    fn parse(&mut self) -> Result<()> {
-        while !self.is_eof() {
-            if self.consume_ident("become") {
-                self.parse_become()?;
-            } else {
-                self.advance();
-            }
-        }
-        Ok(())
+#[derive(Debug, Clone, Copy)]
+struct TerminalInfo {
+    contains_become: bool,
+    all_paths_terminal: bool,
+}
+
+impl TerminalInfo {
+    fn empty() -> Self {
+        Self { contains_become: false, all_paths_terminal: false }
     }
 
-    fn parse_become(&mut self) -> Result<()> {
+    fn terminal(routes: Vec<RouteCall>) -> TerminalResult {
+        TerminalResult { info: Self { contains_become: true, all_paths_terminal: true }, terminal_route_sets: vec![routes] }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TerminalResult {
+    info: TerminalInfo,
+    terminal_route_sets: Vec<Vec<RouteCall>>,
+}
+
+impl TerminalResult {
+    fn empty() -> Self {
+        Self { info: TerminalInfo::empty(), terminal_route_sets: Vec::new() }
+    }
+}
+
+impl TerminalParser<'_> {
+    fn parse_sequence(&mut self, end: Option<char>) -> Result<TerminalResult> {
+        let mut result = TerminalResult::empty();
+        while !self.is_eof() && !end.is_some_and(|symbol| self.check_symbol(symbol)) {
+            let stmt = self.parse_statement()?;
+            result.info.contains_become |= stmt.info.contains_become;
+            result.terminal_route_sets.extend(stmt.terminal_route_sets);
+
+            if stmt.info.all_paths_terminal {
+                while self.consume_symbol(';') {}
+                if self.is_eof() || end.is_some_and(|symbol| self.check_symbol(symbol)) {
+                    result.info.all_paths_terminal = true;
+                    break;
+                }
+                return Err(self.error("`become` must be terminal; move following code into an explicit `else` branch"));
+            }
+            if stmt.info.contains_become {
+                return Err(self.error("conditional `become` must be terminal on every branch; add an explicit `else` branch"));
+            }
+        }
+        Ok(result)
+    }
+
+    fn parse_statement(&mut self) -> Result<TerminalResult> {
+        if self.consume_ident("if") {
+            self.expect_symbol('(')?;
+            self.skip_balanced('(', ')')?;
+            let then_info = self.parse_block_or_statement()?;
+            let else_info = if self.consume_ident("else") { self.parse_block_or_statement()? } else { TerminalResult::empty() };
+            let contains_become = then_info.info.contains_become || else_info.info.contains_become;
+            let all_paths_terminal = then_info.info.all_paths_terminal && else_info.info.all_paths_terminal;
+            let mut terminal_route_sets = then_info.terminal_route_sets;
+            terminal_route_sets.extend(else_info.terminal_route_sets);
+
+            Ok(TerminalResult { info: TerminalInfo { contains_become, all_paths_terminal }, terminal_route_sets })
+        } else if self.consume_ident("become") {
+            let routes = self.parse_become_tail()?;
+            Ok(TerminalInfo::terminal(routes))
+        } else if self.consume_symbol('{') {
+            let result = self.parse_sequence(Some('}'))?;
+            self.expect_symbol('}')?;
+            Ok(result)
+        } else {
+            self.skip_statement()?;
+            Ok(TerminalResult::empty())
+        }
+    }
+
+    fn parse_block_or_statement(&mut self) -> Result<TerminalResult> {
         if self.consume_symbol('{') {
+            let result = self.parse_sequence(Some('}'))?;
+            self.expect_symbol('}')?;
+            Ok(result)
+        } else {
+            self.parse_statement()
+        }
+    }
+
+    fn parse_become_tail(&mut self) -> Result<Vec<RouteCall>> {
+        if self.consume_symbol('{') {
+            let mut routes = Vec::new();
             while !self.check_symbol('}') && !self.is_eof() {
                 if self.check_ident("become") {
                     return Err(self.error("nested `become` blocks are not supported yet"));
                 }
-                let route = self.parse_route()?;
-                self.routes.push(route);
+                routes.push(self.parse_route()?);
                 self.consume_symbol(';');
             }
             self.expect_symbol('}')?;
             self.consume_symbol(';');
-        } else {
-            let route = self.parse_route()?;
-            self.routes.push(route);
-            self.consume_symbol(';');
+            return Ok(routes);
         }
-        Ok(())
+
+        let route = self.parse_route()?;
+        self.consume_symbol(';');
+        Ok(vec![route])
     }
 
     fn parse_route(&mut self) -> Result<RouteCall> {
@@ -108,141 +185,6 @@ impl RouteParser<'_> {
             }
             _ => Err(self.error("expected identifier in `become` route")),
         }
-    }
-
-    fn expect_symbol(&mut self, expected: char) -> Result<()> {
-        match self.current().kind {
-            TokenKind::Symbol(actual) if actual == expected => {
-                self.advance();
-                Ok(())
-            }
-            _ => Err(self.error(format!("expected `{expected}` in `become` route"))),
-        }
-    }
-
-    fn consume_ident(&mut self, expected: &str) -> bool {
-        match &self.current().kind {
-            TokenKind::Ident(actual) if actual == expected => {
-                self.advance();
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn check_ident(&self, expected: &str) -> bool {
-        matches!(&self.current().kind, TokenKind::Ident(actual) if actual == expected)
-    }
-
-    fn consume_symbol(&mut self, expected: char) -> bool {
-        match self.current().kind {
-            TokenKind::Symbol(actual) if actual == expected => {
-                self.advance();
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn check_symbol(&self, expected: char) -> bool {
-        matches!(self.current().kind, TokenKind::Symbol(actual) if actual == expected)
-    }
-
-    fn current(&self) -> &Token {
-        &self.tokens[self.pos]
-    }
-
-    fn peek_kind(&self, offset: usize) -> Option<&TokenKind> {
-        self.tokens.get(self.pos + offset).map(|token| &token.kind)
-    }
-
-    fn advance(&mut self) {
-        if !self.is_eof() {
-            self.pos += 1;
-        }
-    }
-
-    fn is_eof(&self) -> bool {
-        matches!(self.current().kind, TokenKind::Eof)
-    }
-
-    fn error(&self, message: impl Into<String>) -> ArgentError {
-        ArgentError::new(format!("{} at body byte {}", message.into(), self.current().span.start))
-    }
-}
-
-struct TerminalParser<'a> {
-    body: &'a str,
-    tokens: &'a [Token],
-    pos: usize,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct TerminalInfo {
-    contains_become: bool,
-}
-
-impl TerminalInfo {
-    fn empty() -> Self {
-        Self { contains_become: false }
-    }
-}
-
-impl TerminalParser<'_> {
-    fn parse_sequence(&mut self, end: Option<char>) -> Result<TerminalInfo> {
-        let mut info = TerminalInfo::empty();
-        while !self.is_eof() && !end.is_some_and(|symbol| self.check_symbol(symbol)) {
-            let stmt = self.parse_statement()?;
-            info.contains_become |= stmt.contains_become;
-            if stmt.contains_become {
-                while self.consume_symbol(';') {}
-                if self.is_eof() || end.is_some_and(|symbol| self.check_symbol(symbol)) {
-                    break;
-                }
-                return Err(self.error("`become` must be terminal; move following code into an explicit `else` branch"));
-            }
-        }
-        Ok(info)
-    }
-
-    fn parse_statement(&mut self) -> Result<TerminalInfo> {
-        if self.consume_ident("if") {
-            self.expect_symbol('(')?;
-            self.skip_balanced('(', ')')?;
-            let then_info = self.parse_block_or_statement()?;
-            let else_info = if self.consume_ident("else") { self.parse_block_or_statement()? } else { TerminalInfo::empty() };
-            Ok(TerminalInfo { contains_become: then_info.contains_become || else_info.contains_become })
-        } else if self.consume_ident("become") {
-            self.skip_become_tail()?;
-            Ok(TerminalInfo { contains_become: true })
-        } else if self.consume_symbol('{') {
-            let info = self.parse_sequence(Some('}'))?;
-            self.expect_symbol('}')?;
-            Ok(info)
-        } else {
-            self.skip_statement()?;
-            Ok(TerminalInfo::empty())
-        }
-    }
-
-    fn parse_block_or_statement(&mut self) -> Result<TerminalInfo> {
-        if self.consume_symbol('{') {
-            let info = self.parse_sequence(Some('}'))?;
-            self.expect_symbol('}')?;
-            Ok(info)
-        } else {
-            self.parse_statement()
-        }
-    }
-
-    fn skip_become_tail(&mut self) -> Result<()> {
-        if self.consume_symbol('{') {
-            self.skip_balanced_after_open('{', '}')?;
-            self.consume_symbol(';');
-            return Ok(());
-        }
-
-        self.skip_until_statement_end()
     }
 
     fn skip_statement(&mut self) -> Result<()> {
@@ -320,6 +262,10 @@ impl TerminalParser<'_> {
         }
     }
 
+    fn check_ident(&self, expected: &str) -> bool {
+        matches!(&self.current().kind, TokenKind::Ident(actual) if actual == expected)
+    }
+
     fn consume_symbol(&mut self, expected: char) -> bool {
         match self.current().kind {
             TokenKind::Symbol(actual) if actual == expected => {
@@ -336,6 +282,10 @@ impl TerminalParser<'_> {
 
     fn current(&self) -> &Token {
         &self.tokens[self.pos]
+    }
+
+    fn peek_kind(&self, offset: usize) -> Option<&TokenKind> {
+        self.tokens.get(self.pos + offset).map(|token| &token.kind)
     }
 
     fn advance(&mut self) {
@@ -410,6 +360,20 @@ mod tests {
         .expect_err("fallthrough after conditional become must be rejected");
 
         assert!(err.to_string().contains("must be terminal"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_one_sided_conditional_become() {
+        let err = collect_routes(
+            r#"
+            if (done) {
+                become next <- Done(ticket);
+            }
+            "#,
+        )
+        .expect_err("one-sided conditional become must be rejected");
+
+        assert!(err.to_string().contains("explicit `else`"), "unexpected error: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is a small defensive validation patch around `emits` / terminal `become` coverage.

* Track terminal `become` route sets per entry so validation can reason about each terminal path.
* Reject `emits one` entries without exactly one unnamed terminal route per path.
* Reject named `emits` entries when any terminal path misses a declared output handle or validates the same handle more than once.
* Reject one-sided conditional `become` instead of treating the whole `if` as terminal.

## Rationale

While reading through the compiler, I noticed one place where the source-level shape can become slightly stronger than what the generated Silverscript actually proves.

My understanding is:

```mermaid
flowchart TD
    A["Argent source: emits"] --> B["Declares authorised successor-output shape"]
    B --> C["Compiler binds/counts authorised outputs"]
    C --> D["Terminal become routes"]
    D --> E["Generated successor-state validation"]
```

The important bit is that `emits` declares the output shape, but terminal `become` statements are where Argent actually emits the successor-state validation. So validation needs to work in both directions:

```mermaid
flowchart LR
    A["Declared emits handles"] -->|"must be covered"| B["Terminal become routes"]
    B -->|"must be allowed by"| A
```

Previously, the compiler checked that discovered `become` routes were allowed by `emits`, but it did not fully check the reverse condition: that every declared authorised output handle is validated exactly once on every terminal path.

For example, this shape should not be accepted:

```ag
entry step() emits {
    a: Foo;
    b: Foo;
} {
    become a <- Foo(next_a);
}
```

Here the entry declares both `a` and `b`, but only `a` receives a terminal successor validation. That means the generated script may bind/count the authorised outputs while leaving one declared successor output without the matching state/template check.

The same issue appears path-sensitively with one-sided conditionals:

```ag
if (done) {
    become next <- Done(ticket);
}
```

If this is treated as terminal without an `else`, the false branch can fall through without running the expected successor validation.

This PR keeps the fix deliberately narrow: it only tightens route/output coverage validation and adds the corresponding negative cases. It does not try to touch the broader builder, route commitment, ABI, or type-system questions.

(I may have misunderstood some intended Argent semantics here though, so happy to adjust the approach if you had a different model in mind.)

## Validation

* `cargo +1.94.0 fmt --check`
* `cargo +1.94.0 test`
* `cargo +1.94.0 clippy --all-targets -- -D warnings`
* `cargo +1.94.0 run -- build examples/stones/app.ag --out /tmp/argent-p0-stones`
* `cargo +1.94.0 run -- build examples/tickets.ag --out /tmp/argent-p0-tickets`
