### PR TITLE
Harden generated name hygiene

### DIFF
--- a/build/stones/manifest.json
+++ b/build/stones/manifest.json
@@ -1,19 +1,19 @@
 {
   "app": "Stones",
-  "root": "/home/michael/kaspanet/argent/examples/stones/app.ag",
+  "root": "/Users/arthur/RustroverProjects/argent/examples/stones/app.ag",
   "modules": [
-    "/home/michael/kaspanet/argent/examples/stones/app.ag",
-    "/home/michael/kaspanet/argent/examples/stones/types.ag",
-    "/home/michael/kaspanet/argent/examples/stones/league.ag",
-    "/home/michael/kaspanet/argent/examples/stones/player.ag",
-    "/home/michael/kaspanet/argent/examples/stones/game.ag",
-    "/home/michael/kaspanet/argent/examples/stones/settle.ag"
+    "/Users/arthur/RustroverProjects/argent/examples/stones/app.ag",
+    "/Users/arthur/RustroverProjects/argent/examples/stones/types.ag",
+    "/Users/arthur/RustroverProjects/argent/examples/stones/league.ag",
+    "/Users/arthur/RustroverProjects/argent/examples/stones/player.ag",
+    "/Users/arthur/RustroverProjects/argent/examples/stones/game.ag",
+    "/Users/arthur/RustroverProjects/argent/examples/stones/settle.ag"
   ],
   "templates": [
-    { "actor": "League", "symbol": "template_league", "hash": null },
-    { "actor": "Player", "symbol": "template_player", "hash": null },
-    { "actor": "StonesGame", "symbol": "template_stones_game", "hash": null },
-    { "actor": "StonesSettle", "symbol": "template_stones_settle", "hash": null }
+    { "actor": "League", "symbol": "__argent_template_league", "hash": null },
+    { "actor": "Player", "symbol": "__argent_template_player", "hash": null },
+    { "actor": "StonesGame", "symbol": "__argent_template_stones_game", "hash": null },
+    { "actor": "StonesSettle", "symbol": "__argent_template_stones_settle", "hash": null }
   ],
   "actors": [
     {

--- a/build/stones/manifest.json
+++ b/build/stones/manifest.json
@@ -1,19 +1,19 @@
 {
   "app": "Stones",
-  "root": "/Users/arthur/RustroverProjects/argent/examples/stones/app.ag",
+  "root": "examples/stones/app.ag",
   "modules": [
-    "/Users/arthur/RustroverProjects/argent/examples/stones/app.ag",
-    "/Users/arthur/RustroverProjects/argent/examples/stones/types.ag",
-    "/Users/arthur/RustroverProjects/argent/examples/stones/league.ag",
-    "/Users/arthur/RustroverProjects/argent/examples/stones/player.ag",
-    "/Users/arthur/RustroverProjects/argent/examples/stones/game.ag",
-    "/Users/arthur/RustroverProjects/argent/examples/stones/settle.ag"
+    "examples/stones/app.ag",
+    "examples/stones/types.ag",
+    "examples/stones/league.ag",
+    "examples/stones/player.ag",
+    "examples/stones/game.ag",
+    "examples/stones/settle.ag"
   ],
   "templates": [
-    { "actor": "League", "symbol": "__argent_template_league", "hash": null },
-    { "actor": "Player", "symbol": "__argent_template_player", "hash": null },
-    { "actor": "StonesGame", "symbol": "__argent_template_stones_game", "hash": null },
-    { "actor": "StonesSettle", "symbol": "__argent_template_stones_settle", "hash": null }
+    { "actor": "League", "symbol": "gen__template_league", "hash": null },
+    { "actor": "Player", "symbol": "gen__template_player", "hash": null },
+    { "actor": "StonesGame", "symbol": "gen__template_stones_game", "hash": null },
+    { "actor": "StonesSettle", "symbol": "gen__template_stones_settle", "hash": null }
   ],
   "actors": [
     {

--- a/build/stones/sil/League.sil
+++ b/build/stones/sil/League.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract League(
-    byte[32] __argent_init_template_league,
-    byte[32] __argent_init_template_player,
-    byte[32] __argent_init_template_stones_game,
-    byte[32] __argent_init_template_stones_settle,
+    byte[32] gen__init_template_league,
+    byte[32] gen__init_template_player,
+    byte[32] gen__init_template_stones_game,
+    byte[32] gen__init_template_stones_settle,
     byte[32] init_admin,
     int init_default_pile,
     int init_default_max_take
@@ -21,10 +21,10 @@ contract League(
 
     // State layouts
     struct PlayerState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] owner;
         byte[32] player_id;
@@ -34,10 +34,10 @@ contract League(
         int losses;
     }
     struct GameState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -46,10 +46,10 @@ contract League(
         int turn;
     }
     struct SettleState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract League(
     }
 
     // Template capability table
-    byte[32] __argent_template_league = __argent_init_template_league;
-    byte[32] __argent_template_player = __argent_init_template_player;
-    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
-    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
+    byte[32] gen__template_league = gen__init_template_league;
+    byte[32] gen__template_player = gen__init_template_player;
+    byte[32] gen__template_stones_game = gen__init_template_stones_game;
+    byte[32] gen__template_stones_settle = gen__init_template_stones_settle;
 
     // League state fields
     byte[32] admin = init_admin;
@@ -97,24 +97,24 @@ contract League(
     int default_max_take = init_default_max_take;
 
     // Entrypoints
-    entrypoint function register_player(sig owner_sig, pubkey owner_pk, byte[] __argent_league_prefix, byte[] __argent_league_suffix, byte[] __argent_player_prefix, byte[] __argent_player_suffix) {
-        int __argent_league_prefix_len = __argent_league_prefix.length;
-        int __argent_league_suffix_len = __argent_league_suffix.length;
-        int __argent_player_prefix_len = __argent_player_prefix.length;
-        int __argent_player_suffix_len = __argent_player_suffix.length;
+    entrypoint function register_player(sig owner_sig, pubkey owner_pk, byte[] gen__league_prefix, byte[] gen__league_suffix, byte[] gen__player_prefix, byte[] gen__player_suffix) {
+        int gen__league_prefix_len = gen__league_prefix.length;
+        int gen__league_suffix_len = gen__league_suffix.length;
+        int gen__player_prefix_len = gen__player_prefix.length;
+        int gen__player_suffix_len = gen__player_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
-        int __argent_lane_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output lane: League
-        int __argent_player_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player: Player
+        int gen__lane_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output lane: League
+        int gen__player_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player: Player
 
         require(checkSig(owner_sig, owner_pk));
         byte[32] owner = blake2b(owner_pk);
         byte[32] player_id = blake2b(bytes("StonesPlayer") + OpOutpointTxId(this.activeInputIndex) + byte[4](OpOutpointIndex(this.activeInputIndex)));
         PlayerState next_player = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             owner: owner,
             player_id: player_id,
@@ -123,20 +123,20 @@ contract League(
             wins: 0,
             losses: 0,
         };
-        require(tx.outputs[__argent_lane_output_idx].value == tx.inputs[this.activeInputIndex].value);
-        require(tx.outputs[__argent_player_output_idx].value > 0);
-        State __argent_generated_lane_state = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+        require(tx.outputs[gen__lane_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[gen__player_output_idx].value > 0);
+        State gen__state_lane_state = {
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             admin: admin,
             default_pile: default_pile,
             default_max_take: default_max_take,
         };
-        validateOutputStateWithTemplate(__argent_lane_output_idx, __argent_generated_lane_state, __argent_league_prefix, __argent_league_suffix, __argent_template_league);
-        validateOutputStateWithTemplate(__argent_player_output_idx, next_player, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
+        validateOutputStateWithTemplate(gen__lane_output_idx, gen__state_lane_state, gen__league_prefix, gen__league_suffix, gen__template_league);
+        validateOutputStateWithTemplate(gen__player_output_idx, next_player, gen__player_prefix, gen__player_suffix, gen__template_player);
     }
 
 }

--- a/build/stones/sil/League.sil
+++ b/build/stones/sil/League.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract League(
-    byte[32] init_template_league,
-    byte[32] init_template_player,
-    byte[32] init_template_stones_game,
-    byte[32] init_template_stones_settle,
+    byte[32] __argent_init_template_league,
+    byte[32] __argent_init_template_player,
+    byte[32] __argent_init_template_stones_game,
+    byte[32] __argent_init_template_stones_settle,
     byte[32] init_admin,
     int init_default_pile,
     int init_default_max_take
@@ -21,10 +21,10 @@ contract League(
 
     // State layouts
     struct PlayerState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] owner;
         byte[32] player_id;
@@ -34,10 +34,10 @@ contract League(
         int losses;
     }
     struct GameState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -46,10 +46,10 @@ contract League(
         int turn;
     }
     struct SettleState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract League(
     }
 
     // Template capability table
-    byte[32] template_league = init_template_league;
-    byte[32] template_player = init_template_player;
-    byte[32] template_stones_game = init_template_stones_game;
-    byte[32] template_stones_settle = init_template_stones_settle;
+    byte[32] __argent_template_league = __argent_init_template_league;
+    byte[32] __argent_template_player = __argent_init_template_player;
+    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
+    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
 
     // League state fields
     byte[32] admin = init_admin;
@@ -97,24 +97,24 @@ contract League(
     int default_max_take = init_default_max_take;
 
     // Entrypoints
-    entrypoint function register_player(sig owner_sig, pubkey owner_pk, byte[] league_prefix, byte[] league_suffix, byte[] player_prefix, byte[] player_suffix) {
-        int league_prefix_len = league_prefix.length;
-        int league_suffix_len = league_suffix.length;
-        int player_prefix_len = player_prefix.length;
-        int player_suffix_len = player_suffix.length;
+    entrypoint function register_player(sig owner_sig, pubkey owner_pk, byte[] __argent_league_prefix, byte[] __argent_league_suffix, byte[] __argent_player_prefix, byte[] __argent_player_suffix) {
+        int __argent_league_prefix_len = __argent_league_prefix.length;
+        int __argent_league_suffix_len = __argent_league_suffix.length;
+        int __argent_player_prefix_len = __argent_player_prefix.length;
+        int __argent_player_suffix_len = __argent_player_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
-        int lane_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output lane: League
-        int player_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player: Player
+        int __argent_lane_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output lane: League
+        int __argent_player_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player: Player
 
         require(checkSig(owner_sig, owner_pk));
         byte[32] owner = blake2b(owner_pk);
         byte[32] player_id = blake2b(bytes("StonesPlayer") + OpOutpointTxId(this.activeInputIndex) + byte[4](OpOutpointIndex(this.activeInputIndex)));
         PlayerState next_player = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             owner: owner,
             player_id: player_id,
@@ -123,20 +123,20 @@ contract League(
             wins: 0,
             losses: 0,
         };
-        require(tx.outputs[lane_output_idx].value == tx.inputs[this.activeInputIndex].value);
-        require(tx.outputs[player_output_idx].value > 0);
-        State generated_lane_state = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+        require(tx.outputs[__argent_lane_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[__argent_player_output_idx].value > 0);
+        State __argent_generated_lane_state = {
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             admin: admin,
             default_pile: default_pile,
             default_max_take: default_max_take,
         };
-        validateOutputStateWithTemplate(lane_output_idx, generated_lane_state, league_prefix, league_suffix, template_league);
-        validateOutputStateWithTemplate(player_output_idx, next_player, player_prefix, player_suffix, template_player);
+        validateOutputStateWithTemplate(__argent_lane_output_idx, __argent_generated_lane_state, __argent_league_prefix, __argent_league_suffix, __argent_template_league);
+        validateOutputStateWithTemplate(__argent_player_output_idx, next_player, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
     }
 
 }

--- a/build/stones/sil/Player.sil
+++ b/build/stones/sil/Player.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract Player(
-    byte[32] init_template_league,
-    byte[32] init_template_player,
-    byte[32] init_template_stones_game,
-    byte[32] init_template_stones_settle,
+    byte[32] __argent_init_template_league,
+    byte[32] __argent_init_template_player,
+    byte[32] __argent_init_template_stones_game,
+    byte[32] __argent_init_template_stones_settle,
     byte[32] init_owner,
     byte[32] init_player_id,
     int init_open_games,
@@ -24,20 +24,20 @@ contract Player(
 
     // State layouts
     struct LeagueState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] admin;
         int default_pile;
         int default_max_take;
     }
     struct GameState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -46,10 +46,10 @@ contract Player(
         int turn;
     }
     struct SettleState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract Player(
     }
 
     // Template capability table
-    byte[32] template_league = init_template_league;
-    byte[32] template_player = init_template_player;
-    byte[32] template_stones_game = init_template_stones_game;
-    byte[32] template_stones_settle = init_template_stones_settle;
+    byte[32] __argent_template_league = __argent_init_template_league;
+    byte[32] __argent_template_player = __argent_init_template_player;
+    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
+    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
 
     // Player state fields
     byte[32] owner = init_owner;
@@ -100,21 +100,21 @@ contract Player(
     int losses = init_losses;
 
     // Entrypoints
-    entrypoint function start_game(sig owner_sig, pubkey owner_pk, int first_turn, int pile, int max_take, byte[] player_prefix, byte[] player_suffix, byte[] stones_game_prefix, byte[] stones_game_suffix) {
-        int player_prefix_len = player_prefix.length;
-        int player_suffix_len = player_suffix.length;
-        int stones_game_prefix_len = stones_game_prefix.length;
-        int stones_game_suffix_len = stones_game_suffix.length;
+    entrypoint function start_game(sig owner_sig, pubkey owner_pk, int first_turn, int pile, int max_take, byte[] __argent_player_prefix, byte[] __argent_player_suffix, byte[] __argent_stones_game_prefix, byte[] __argent_stones_game_suffix) {
+        int __argent_player_prefix_len = __argent_player_prefix.length;
+        int __argent_player_suffix_len = __argent_player_suffix.length;
+        int __argent_stones_game_prefix_len = __argent_stones_game_prefix.length;
+        int __argent_stones_game_suffix_len = __argent_stones_game_suffix.length;
 
-        byte[32] cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(cov_id) == 2);
-        require(OpCovInputIdx(cov_id, 0) == this.activeInputIndex);
-        int opponent_input_idx = OpCovInputIdx(cov_id, 1); // input Player at cov[1]
-        State opponent = readInputStateWithTemplate(opponent_input_idx, player_prefix_len, player_suffix_len, template_player);
+        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(__argent_cov_id) == 2);
+        require(OpCovInputIdx(__argent_cov_id, 0) == this.activeInputIndex);
+        int __argent_opponent_input_idx = OpCovInputIdx(__argent_cov_id, 1); // input Player at cov[1]
+        State opponent = readInputStateWithTemplate(__argent_opponent_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
         require(OpAuthOutputCount(this.activeInputIndex) == 3);
-        int self_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output self_out: Player
-        int opponent_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output opponent_out: Player
-        int game_output_idx = OpAuthOutputIdx(this.activeInputIndex, 2); // output game: StonesGame
+        int __argent_self_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output self_out: Player
+        int __argent_opponent_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output opponent_out: Player
+        int __argent_game_output_idx = OpAuthOutputIdx(this.activeInputIndex, 2); // output game: StonesGame
 
         require(blake2b(owner_pk) == owner);
         require(checkSig(owner_sig, owner_pk));
@@ -125,10 +125,10 @@ contract Player(
         byte[32] self_ref = player_ref(owner, player_id);
         byte[32] opponent_ref = player_ref(opponent.owner, opponent.player_id);
         State next_self = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             owner: owner,
             player_id: player_id,
@@ -138,10 +138,10 @@ contract Player(
             losses: losses,
         };
         State next_opponent = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             owner: opponent.owner,
             player_id: opponent.player_id,
@@ -151,10 +151,10 @@ contract Player(
             losses: opponent.losses,
         };
         GameState next_game = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             player_a: self_ref,
             player_b: opponent_ref,
@@ -162,23 +162,23 @@ contract Player(
             max_take: max_take,
             turn: first_turn,
         };
-        require(tx.outputs[self_out_output_idx].value == tx.inputs[this.activeInputIndex].value);
-        require(tx.outputs[opponent_out_output_idx].value == tx.inputs[opponent_input_idx].value);
-        require(tx.outputs[game_output_idx].value > 0);
-        validateOutputStateWithTemplate(self_out_output_idx, next_self, player_prefix, player_suffix, template_player);
-        validateOutputStateWithTemplate(opponent_out_output_idx, next_opponent, player_prefix, player_suffix, template_player);
-        validateOutputStateWithTemplate(game_output_idx, next_game, stones_game_prefix, stones_game_suffix, template_stones_game);
+        require(tx.outputs[__argent_self_out_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[__argent_opponent_out_output_idx].value == tx.inputs[__argent_opponent_input_idx].value);
+        require(tx.outputs[__argent_game_output_idx].value > 0);
+        validateOutputStateWithTemplate(__argent_self_out_output_idx, next_self, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
+        validateOutputStateWithTemplate(__argent_opponent_out_output_idx, next_opponent, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
+        validateOutputStateWithTemplate(__argent_game_output_idx, next_game, __argent_stones_game_prefix, __argent_stones_game_suffix, __argent_template_stones_game);
     }
 
-    entrypoint function accept_start(sig owner_sig, pubkey owner_pk, byte[] player_prefix, byte[] player_suffix) {
-        int player_prefix_len = player_prefix.length;
-        int player_suffix_len = player_suffix.length;
+    entrypoint function accept_start(sig owner_sig, pubkey owner_pk, byte[] __argent_player_prefix, byte[] __argent_player_suffix) {
+        int __argent_player_prefix_len = __argent_player_prefix.length;
+        int __argent_player_suffix_len = __argent_player_suffix.length;
 
-        byte[32] cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(cov_id) >= 2);
-        require(OpCovInputIdx(cov_id, 0) != this.activeInputIndex);
-        int starter_input_idx = OpCovInputIdx(cov_id, 0); // input Player at cov[0]
-        State starter = readInputStateWithTemplate(starter_input_idx, player_prefix_len, player_suffix_len, template_player);
+        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(__argent_cov_id) >= 2);
+        require(OpCovInputIdx(__argent_cov_id, 0) != this.activeInputIndex);
+        int __argent_starter_input_idx = OpCovInputIdx(__argent_cov_id, 0); // input Player at cov[0]
+        State starter = readInputStateWithTemplate(__argent_starter_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
         require(OpAuthOutputCount(this.activeInputIndex) == 0);
 
         require(blake2b(owner_pk) == owner);
@@ -186,15 +186,15 @@ contract Player(
         require(starter.player_id != player_id);
     }
 
-    entrypoint function settle(byte[] stones_settle_prefix, byte[] stones_settle_suffix) {
-        int stones_settle_prefix_len = stones_settle_prefix.length;
-        int stones_settle_suffix_len = stones_settle_suffix.length;
+    entrypoint function settle(byte[] __argent_stones_settle_prefix, byte[] __argent_stones_settle_suffix) {
+        int __argent_stones_settle_prefix_len = __argent_stones_settle_prefix.length;
+        int __argent_stones_settle_suffix_len = __argent_stones_settle_suffix.length;
 
-        byte[32] cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(cov_id) >= 2);
-        require(OpCovInputIdx(cov_id, 0) != this.activeInputIndex);
-        int settle_input_idx = OpCovInputIdx(cov_id, 0); // input StonesSettle at cov[0]
-        SettleState settle = readInputStateWithTemplate(settle_input_idx, stones_settle_prefix_len, stones_settle_suffix_len, template_stones_settle);
+        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(__argent_cov_id) >= 2);
+        require(OpCovInputIdx(__argent_cov_id, 0) != this.activeInputIndex);
+        int __argent_settle_input_idx = OpCovInputIdx(__argent_cov_id, 0); // input StonesSettle at cov[0]
+        SettleState settle = readInputStateWithTemplate(__argent_settle_input_idx, __argent_stones_settle_prefix_len, __argent_stones_settle_suffix_len, __argent_template_stones_settle);
         require(OpAuthOutputCount(this.activeInputIndex) == 0);
 
         byte[32] self_ref = player_ref(owner, player_id);

--- a/build/stones/sil/Player.sil
+++ b/build/stones/sil/Player.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract Player(
-    byte[32] __argent_init_template_league,
-    byte[32] __argent_init_template_player,
-    byte[32] __argent_init_template_stones_game,
-    byte[32] __argent_init_template_stones_settle,
+    byte[32] gen__init_template_league,
+    byte[32] gen__init_template_player,
+    byte[32] gen__init_template_stones_game,
+    byte[32] gen__init_template_stones_settle,
     byte[32] init_owner,
     byte[32] init_player_id,
     int init_open_games,
@@ -24,20 +24,20 @@ contract Player(
 
     // State layouts
     struct LeagueState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] admin;
         int default_pile;
         int default_max_take;
     }
     struct GameState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -46,10 +46,10 @@ contract Player(
         int turn;
     }
     struct SettleState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract Player(
     }
 
     // Template capability table
-    byte[32] __argent_template_league = __argent_init_template_league;
-    byte[32] __argent_template_player = __argent_init_template_player;
-    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
-    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
+    byte[32] gen__template_league = gen__init_template_league;
+    byte[32] gen__template_player = gen__init_template_player;
+    byte[32] gen__template_stones_game = gen__init_template_stones_game;
+    byte[32] gen__template_stones_settle = gen__init_template_stones_settle;
 
     // Player state fields
     byte[32] owner = init_owner;
@@ -100,21 +100,21 @@ contract Player(
     int losses = init_losses;
 
     // Entrypoints
-    entrypoint function start_game(sig owner_sig, pubkey owner_pk, int first_turn, int pile, int max_take, byte[] __argent_player_prefix, byte[] __argent_player_suffix, byte[] __argent_stones_game_prefix, byte[] __argent_stones_game_suffix) {
-        int __argent_player_prefix_len = __argent_player_prefix.length;
-        int __argent_player_suffix_len = __argent_player_suffix.length;
-        int __argent_stones_game_prefix_len = __argent_stones_game_prefix.length;
-        int __argent_stones_game_suffix_len = __argent_stones_game_suffix.length;
+    entrypoint function start_game(sig owner_sig, pubkey owner_pk, int first_turn, int pile, int max_take, byte[] gen__player_prefix, byte[] gen__player_suffix, byte[] gen__stones_game_prefix, byte[] gen__stones_game_suffix) {
+        int gen__player_prefix_len = gen__player_prefix.length;
+        int gen__player_suffix_len = gen__player_suffix.length;
+        int gen__stones_game_prefix_len = gen__stones_game_prefix.length;
+        int gen__stones_game_suffix_len = gen__stones_game_suffix.length;
 
-        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(__argent_cov_id) == 2);
-        require(OpCovInputIdx(__argent_cov_id, 0) == this.activeInputIndex);
-        int __argent_opponent_input_idx = OpCovInputIdx(__argent_cov_id, 1); // input Player at cov[1]
-        State opponent = readInputStateWithTemplate(__argent_opponent_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
+        byte[32] gen__cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(gen__cov_id) == 2);
+        require(OpCovInputIdx(gen__cov_id, 0) == this.activeInputIndex);
+        int gen__opponent_input_idx = OpCovInputIdx(gen__cov_id, 1); // input Player at cov[1]
+        State opponent = readInputStateWithTemplate(gen__opponent_input_idx, gen__player_prefix_len, gen__player_suffix_len, gen__template_player);
         require(OpAuthOutputCount(this.activeInputIndex) == 3);
-        int __argent_self_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output self_out: Player
-        int __argent_opponent_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output opponent_out: Player
-        int __argent_game_output_idx = OpAuthOutputIdx(this.activeInputIndex, 2); // output game: StonesGame
+        int gen__self_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output self_out: Player
+        int gen__opponent_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output opponent_out: Player
+        int gen__game_output_idx = OpAuthOutputIdx(this.activeInputIndex, 2); // output game: StonesGame
 
         require(blake2b(owner_pk) == owner);
         require(checkSig(owner_sig, owner_pk));
@@ -125,10 +125,10 @@ contract Player(
         byte[32] self_ref = player_ref(owner, player_id);
         byte[32] opponent_ref = player_ref(opponent.owner, opponent.player_id);
         State next_self = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             owner: owner,
             player_id: player_id,
@@ -138,10 +138,10 @@ contract Player(
             losses: losses,
         };
         State next_opponent = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             owner: opponent.owner,
             player_id: opponent.player_id,
@@ -151,10 +151,10 @@ contract Player(
             losses: opponent.losses,
         };
         GameState next_game = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             player_a: self_ref,
             player_b: opponent_ref,
@@ -162,23 +162,23 @@ contract Player(
             max_take: max_take,
             turn: first_turn,
         };
-        require(tx.outputs[__argent_self_out_output_idx].value == tx.inputs[this.activeInputIndex].value);
-        require(tx.outputs[__argent_opponent_out_output_idx].value == tx.inputs[__argent_opponent_input_idx].value);
-        require(tx.outputs[__argent_game_output_idx].value > 0);
-        validateOutputStateWithTemplate(__argent_self_out_output_idx, next_self, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
-        validateOutputStateWithTemplate(__argent_opponent_out_output_idx, next_opponent, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
-        validateOutputStateWithTemplate(__argent_game_output_idx, next_game, __argent_stones_game_prefix, __argent_stones_game_suffix, __argent_template_stones_game);
+        require(tx.outputs[gen__self_out_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[gen__opponent_out_output_idx].value == tx.inputs[gen__opponent_input_idx].value);
+        require(tx.outputs[gen__game_output_idx].value > 0);
+        validateOutputStateWithTemplate(gen__self_out_output_idx, next_self, gen__player_prefix, gen__player_suffix, gen__template_player);
+        validateOutputStateWithTemplate(gen__opponent_out_output_idx, next_opponent, gen__player_prefix, gen__player_suffix, gen__template_player);
+        validateOutputStateWithTemplate(gen__game_output_idx, next_game, gen__stones_game_prefix, gen__stones_game_suffix, gen__template_stones_game);
     }
 
-    entrypoint function accept_start(sig owner_sig, pubkey owner_pk, byte[] __argent_player_prefix, byte[] __argent_player_suffix) {
-        int __argent_player_prefix_len = __argent_player_prefix.length;
-        int __argent_player_suffix_len = __argent_player_suffix.length;
+    entrypoint function accept_start(sig owner_sig, pubkey owner_pk, byte[] gen__player_prefix, byte[] gen__player_suffix) {
+        int gen__player_prefix_len = gen__player_prefix.length;
+        int gen__player_suffix_len = gen__player_suffix.length;
 
-        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(__argent_cov_id) >= 2);
-        require(OpCovInputIdx(__argent_cov_id, 0) != this.activeInputIndex);
-        int __argent_starter_input_idx = OpCovInputIdx(__argent_cov_id, 0); // input Player at cov[0]
-        State starter = readInputStateWithTemplate(__argent_starter_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
+        byte[32] gen__cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(gen__cov_id) >= 2);
+        require(OpCovInputIdx(gen__cov_id, 0) != this.activeInputIndex);
+        int gen__starter_input_idx = OpCovInputIdx(gen__cov_id, 0); // input Player at cov[0]
+        State starter = readInputStateWithTemplate(gen__starter_input_idx, gen__player_prefix_len, gen__player_suffix_len, gen__template_player);
         require(OpAuthOutputCount(this.activeInputIndex) == 0);
 
         require(blake2b(owner_pk) == owner);
@@ -186,15 +186,15 @@ contract Player(
         require(starter.player_id != player_id);
     }
 
-    entrypoint function settle(byte[] __argent_stones_settle_prefix, byte[] __argent_stones_settle_suffix) {
-        int __argent_stones_settle_prefix_len = __argent_stones_settle_prefix.length;
-        int __argent_stones_settle_suffix_len = __argent_stones_settle_suffix.length;
+    entrypoint function settle(byte[] gen__stones_settle_prefix, byte[] gen__stones_settle_suffix) {
+        int gen__stones_settle_prefix_len = gen__stones_settle_prefix.length;
+        int gen__stones_settle_suffix_len = gen__stones_settle_suffix.length;
 
-        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(__argent_cov_id) >= 2);
-        require(OpCovInputIdx(__argent_cov_id, 0) != this.activeInputIndex);
-        int __argent_settle_input_idx = OpCovInputIdx(__argent_cov_id, 0); // input StonesSettle at cov[0]
-        SettleState settle = readInputStateWithTemplate(__argent_settle_input_idx, __argent_stones_settle_prefix_len, __argent_stones_settle_suffix_len, __argent_template_stones_settle);
+        byte[32] gen__cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(gen__cov_id) >= 2);
+        require(OpCovInputIdx(gen__cov_id, 0) != this.activeInputIndex);
+        int gen__settle_input_idx = OpCovInputIdx(gen__cov_id, 0); // input StonesSettle at cov[0]
+        SettleState settle = readInputStateWithTemplate(gen__settle_input_idx, gen__stones_settle_prefix_len, gen__stones_settle_suffix_len, gen__template_stones_settle);
         require(OpAuthOutputCount(this.activeInputIndex) == 0);
 
         byte[32] self_ref = player_ref(owner, player_id);

--- a/build/stones/sil/StonesGame.sil
+++ b/build/stones/sil/StonesGame.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract StonesGame(
-    byte[32] init_template_league,
-    byte[32] init_template_player,
-    byte[32] init_template_stones_game,
-    byte[32] init_template_stones_settle,
+    byte[32] __argent_init_template_league,
+    byte[32] __argent_init_template_player,
+    byte[32] __argent_init_template_stones_game,
+    byte[32] __argent_init_template_stones_settle,
     byte[32] init_player_a,
     byte[32] init_player_b,
     int init_pile,
@@ -23,20 +23,20 @@ contract StonesGame(
 
     // State layouts
     struct LeagueState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] admin;
         int default_pile;
         int default_max_take;
     }
     struct PlayerState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] owner;
         byte[32] player_id;
@@ -46,10 +46,10 @@ contract StonesGame(
         int losses;
     }
     struct SettleState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract StonesGame(
     }
 
     // Template capability table
-    byte[32] template_league = init_template_league;
-    byte[32] template_player = init_template_player;
-    byte[32] template_stones_game = init_template_stones_game;
-    byte[32] template_stones_settle = init_template_stones_settle;
+    byte[32] __argent_template_league = __argent_init_template_league;
+    byte[32] __argent_template_player = __argent_init_template_player;
+    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
+    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
 
     // StonesGame state fields
     byte[32] player_a = init_player_a;
@@ -99,14 +99,14 @@ contract StonesGame(
     int turn = init_turn;
 
     // Entrypoints
-    entrypoint function take(int amount, byte[32] player_id, sig move_sig, pubkey move_pk, byte[] stones_game_prefix, byte[] stones_game_suffix, byte[] stones_settle_prefix, byte[] stones_settle_suffix) {
-        int stones_game_prefix_len = stones_game_prefix.length;
-        int stones_game_suffix_len = stones_game_suffix.length;
-        int stones_settle_prefix_len = stones_settle_prefix.length;
-        int stones_settle_suffix_len = stones_settle_suffix.length;
+    entrypoint function take(int amount, byte[32] player_id, sig move_sig, pubkey move_pk, byte[] __argent_stones_game_prefix, byte[] __argent_stones_game_suffix, byte[] __argent_stones_settle_prefix, byte[] __argent_stones_settle_suffix) {
+        int __argent_stones_game_prefix_len = __argent_stones_game_prefix.length;
+        int __argent_stones_game_suffix_len = __argent_stones_game_suffix.length;
+        int __argent_stones_settle_prefix_len = __argent_stones_settle_prefix.length;
+        int __argent_stones_settle_suffix_len = __argent_stones_settle_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: StonesGame | StonesSettle
+        int __argent_next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: StonesGame | StonesSettle
 
         require(pile > 0);
         require(amount >= 1);
@@ -117,25 +117,25 @@ contract StonesGame(
         require(actor_ref == expected_ref);
         require(checkSig(move_sig, move_pk));
         int next_pile = pile - amount;
-        require(tx.outputs[next_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[__argent_next_output_idx].value == tx.inputs[this.activeInputIndex].value);
         if (next_pile == 0) {
             SettleState ticket = {
-                template_league: template_league,
-                template_player: template_player,
-                template_stones_game: template_stones_game,
-                template_stones_settle: template_stones_settle,
+                __argent_template_league: __argent_template_league,
+                __argent_template_player: __argent_template_player,
+                __argent_template_stones_game: __argent_template_stones_game,
+                __argent_template_stones_settle: __argent_template_stones_settle,
                 // ----------- template fields above; source state below
                 player_a: player_a,
                 player_b: player_b,
                 status: win_status(turn),
             };
-            validateOutputStateWithTemplate(next_output_idx, ticket, stones_settle_prefix, stones_settle_suffix, template_stones_settle);
+            validateOutputStateWithTemplate(__argent_next_output_idx, ticket, __argent_stones_settle_prefix, __argent_stones_settle_suffix, __argent_template_stones_settle);
         } else {
             State next_game = {
-                template_league: template_league,
-                template_player: template_player,
-                template_stones_game: template_stones_game,
-                template_stones_settle: template_stones_settle,
+                __argent_template_league: __argent_template_league,
+                __argent_template_player: __argent_template_player,
+                __argent_template_stones_game: __argent_template_stones_game,
+                __argent_template_stones_settle: __argent_template_stones_settle,
                 // ----------- template fields above; source state below
                 player_a: player_a,
                 player_b: player_b,
@@ -143,34 +143,34 @@ contract StonesGame(
                 max_take: max_take,
                 turn: other_side(turn),
             };
-            validateOutputStateWithTemplate(next_output_idx, next_game, stones_game_prefix, stones_game_suffix, template_stones_game);
+            validateOutputStateWithTemplate(__argent_next_output_idx, next_game, __argent_stones_game_prefix, __argent_stones_game_suffix, __argent_template_stones_game);
         }
     }
 
-    entrypoint function concede(byte[32] player_id, sig move_sig, pubkey move_pk, byte[] stones_settle_prefix, byte[] stones_settle_suffix) {
-        int stones_settle_prefix_len = stones_settle_prefix.length;
-        int stones_settle_suffix_len = stones_settle_suffix.length;
+    entrypoint function concede(byte[32] player_id, sig move_sig, pubkey move_pk, byte[] __argent_stones_settle_prefix, byte[] __argent_stones_settle_suffix) {
+        int __argent_stones_settle_prefix_len = __argent_stones_settle_prefix.length;
+        int __argent_stones_settle_suffix_len = __argent_stones_settle_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int settle_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output settle: StonesSettle
+        int __argent_settle_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output settle: StonesSettle
 
         byte[32] actor_ref = player_ref(blake2b(move_pk), player_id);
         byte[32] expected_ref = side_player(turn, player_a, player_b);
         require(actor_ref == expected_ref);
         require(checkSig(move_sig, move_pk));
-        require(tx.outputs[settle_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[__argent_settle_output_idx].value == tx.inputs[this.activeInputIndex].value);
         int winner = other_side(turn);
         SettleState ticket = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             player_a: player_a,
             player_b: player_b,
             status: win_status(winner),
         };
-        validateOutputStateWithTemplate(settle_output_idx, ticket, stones_settle_prefix, stones_settle_suffix, template_stones_settle);
+        validateOutputStateWithTemplate(__argent_settle_output_idx, ticket, __argent_stones_settle_prefix, __argent_stones_settle_suffix, __argent_template_stones_settle);
     }
 
 }

--- a/build/stones/sil/StonesGame.sil
+++ b/build/stones/sil/StonesGame.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract StonesGame(
-    byte[32] __argent_init_template_league,
-    byte[32] __argent_init_template_player,
-    byte[32] __argent_init_template_stones_game,
-    byte[32] __argent_init_template_stones_settle,
+    byte[32] gen__init_template_league,
+    byte[32] gen__init_template_player,
+    byte[32] gen__init_template_stones_game,
+    byte[32] gen__init_template_stones_settle,
     byte[32] init_player_a,
     byte[32] init_player_b,
     int init_pile,
@@ -23,20 +23,20 @@ contract StonesGame(
 
     // State layouts
     struct LeagueState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] admin;
         int default_pile;
         int default_max_take;
     }
     struct PlayerState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] owner;
         byte[32] player_id;
@@ -46,10 +46,10 @@ contract StonesGame(
         int losses;
     }
     struct SettleState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract StonesGame(
     }
 
     // Template capability table
-    byte[32] __argent_template_league = __argent_init_template_league;
-    byte[32] __argent_template_player = __argent_init_template_player;
-    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
-    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
+    byte[32] gen__template_league = gen__init_template_league;
+    byte[32] gen__template_player = gen__init_template_player;
+    byte[32] gen__template_stones_game = gen__init_template_stones_game;
+    byte[32] gen__template_stones_settle = gen__init_template_stones_settle;
 
     // StonesGame state fields
     byte[32] player_a = init_player_a;
@@ -99,14 +99,14 @@ contract StonesGame(
     int turn = init_turn;
 
     // Entrypoints
-    entrypoint function take(int amount, byte[32] player_id, sig move_sig, pubkey move_pk, byte[] __argent_stones_game_prefix, byte[] __argent_stones_game_suffix, byte[] __argent_stones_settle_prefix, byte[] __argent_stones_settle_suffix) {
-        int __argent_stones_game_prefix_len = __argent_stones_game_prefix.length;
-        int __argent_stones_game_suffix_len = __argent_stones_game_suffix.length;
-        int __argent_stones_settle_prefix_len = __argent_stones_settle_prefix.length;
-        int __argent_stones_settle_suffix_len = __argent_stones_settle_suffix.length;
+    entrypoint function take(int amount, byte[32] player_id, sig move_sig, pubkey move_pk, byte[] gen__stones_game_prefix, byte[] gen__stones_game_suffix, byte[] gen__stones_settle_prefix, byte[] gen__stones_settle_suffix) {
+        int gen__stones_game_prefix_len = gen__stones_game_prefix.length;
+        int gen__stones_game_suffix_len = gen__stones_game_suffix.length;
+        int gen__stones_settle_prefix_len = gen__stones_settle_prefix.length;
+        int gen__stones_settle_suffix_len = gen__stones_settle_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int __argent_next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: StonesGame | StonesSettle
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: StonesGame | StonesSettle
 
         require(pile > 0);
         require(amount >= 1);
@@ -117,25 +117,25 @@ contract StonesGame(
         require(actor_ref == expected_ref);
         require(checkSig(move_sig, move_pk));
         int next_pile = pile - amount;
-        require(tx.outputs[__argent_next_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[gen__next_output_idx].value == tx.inputs[this.activeInputIndex].value);
         if (next_pile == 0) {
             SettleState ticket = {
-                __argent_template_league: __argent_template_league,
-                __argent_template_player: __argent_template_player,
-                __argent_template_stones_game: __argent_template_stones_game,
-                __argent_template_stones_settle: __argent_template_stones_settle,
+                gen__template_league: gen__template_league,
+                gen__template_player: gen__template_player,
+                gen__template_stones_game: gen__template_stones_game,
+                gen__template_stones_settle: gen__template_stones_settle,
                 // ----------- template fields above; source state below
                 player_a: player_a,
                 player_b: player_b,
                 status: win_status(turn),
             };
-            validateOutputStateWithTemplate(__argent_next_output_idx, ticket, __argent_stones_settle_prefix, __argent_stones_settle_suffix, __argent_template_stones_settle);
+            validateOutputStateWithTemplate(gen__next_output_idx, ticket, gen__stones_settle_prefix, gen__stones_settle_suffix, gen__template_stones_settle);
         } else {
             State next_game = {
-                __argent_template_league: __argent_template_league,
-                __argent_template_player: __argent_template_player,
-                __argent_template_stones_game: __argent_template_stones_game,
-                __argent_template_stones_settle: __argent_template_stones_settle,
+                gen__template_league: gen__template_league,
+                gen__template_player: gen__template_player,
+                gen__template_stones_game: gen__template_stones_game,
+                gen__template_stones_settle: gen__template_stones_settle,
                 // ----------- template fields above; source state below
                 player_a: player_a,
                 player_b: player_b,
@@ -143,34 +143,34 @@ contract StonesGame(
                 max_take: max_take,
                 turn: other_side(turn),
             };
-            validateOutputStateWithTemplate(__argent_next_output_idx, next_game, __argent_stones_game_prefix, __argent_stones_game_suffix, __argent_template_stones_game);
+            validateOutputStateWithTemplate(gen__next_output_idx, next_game, gen__stones_game_prefix, gen__stones_game_suffix, gen__template_stones_game);
         }
     }
 
-    entrypoint function concede(byte[32] player_id, sig move_sig, pubkey move_pk, byte[] __argent_stones_settle_prefix, byte[] __argent_stones_settle_suffix) {
-        int __argent_stones_settle_prefix_len = __argent_stones_settle_prefix.length;
-        int __argent_stones_settle_suffix_len = __argent_stones_settle_suffix.length;
+    entrypoint function concede(byte[32] player_id, sig move_sig, pubkey move_pk, byte[] gen__stones_settle_prefix, byte[] gen__stones_settle_suffix) {
+        int gen__stones_settle_prefix_len = gen__stones_settle_prefix.length;
+        int gen__stones_settle_suffix_len = gen__stones_settle_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int __argent_settle_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output settle: StonesSettle
+        int gen__settle_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output settle: StonesSettle
 
         byte[32] actor_ref = player_ref(blake2b(move_pk), player_id);
         byte[32] expected_ref = side_player(turn, player_a, player_b);
         require(actor_ref == expected_ref);
         require(checkSig(move_sig, move_pk));
-        require(tx.outputs[__argent_settle_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[gen__settle_output_idx].value == tx.inputs[this.activeInputIndex].value);
         int winner = other_side(turn);
         SettleState ticket = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             player_a: player_a,
             player_b: player_b,
             status: win_status(winner),
         };
-        validateOutputStateWithTemplate(__argent_settle_output_idx, ticket, __argent_stones_settle_prefix, __argent_stones_settle_suffix, __argent_template_stones_settle);
+        validateOutputStateWithTemplate(gen__settle_output_idx, ticket, gen__stones_settle_prefix, gen__stones_settle_suffix, gen__template_stones_settle);
     }
 
 }

--- a/build/stones/sil/StonesSettle.sil
+++ b/build/stones/sil/StonesSettle.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract StonesSettle(
-    byte[32] init_template_league,
-    byte[32] init_template_player,
-    byte[32] init_template_stones_game,
-    byte[32] init_template_stones_settle,
+    byte[32] __argent_init_template_league,
+    byte[32] __argent_init_template_player,
+    byte[32] __argent_init_template_stones_game,
+    byte[32] __argent_init_template_stones_settle,
     byte[32] init_player_a,
     byte[32] init_player_b,
     int init_status
@@ -21,20 +21,20 @@ contract StonesSettle(
 
     // State layouts
     struct LeagueState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] admin;
         int default_pile;
         int default_max_take;
     }
     struct PlayerState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] owner;
         byte[32] player_id;
@@ -44,10 +44,10 @@ contract StonesSettle(
         int losses;
     }
     struct GameState {
-        byte[32] template_league;
-        byte[32] template_player;
-        byte[32] template_stones_game;
-        byte[32] template_stones_settle;
+        byte[32] __argent_template_league;
+        byte[32] __argent_template_player;
+        byte[32] __argent_template_stones_game;
+        byte[32] __argent_template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract StonesSettle(
     }
 
     // Template capability table
-    byte[32] template_league = init_template_league;
-    byte[32] template_player = init_template_player;
-    byte[32] template_stones_game = init_template_stones_game;
-    byte[32] template_stones_settle = init_template_stones_settle;
+    byte[32] __argent_template_league = __argent_init_template_league;
+    byte[32] __argent_template_player = __argent_init_template_player;
+    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
+    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
 
     // StonesSettle state fields
     byte[32] player_a = init_player_a;
@@ -97,20 +97,20 @@ contract StonesSettle(
     int status = init_status;
 
     // Entrypoints
-    entrypoint function settle(byte[] player_prefix, byte[] player_suffix) {
-        int player_prefix_len = player_prefix.length;
-        int player_suffix_len = player_suffix.length;
+    entrypoint function settle(byte[] __argent_player_prefix, byte[] __argent_player_suffix) {
+        int __argent_player_prefix_len = __argent_player_prefix.length;
+        int __argent_player_suffix_len = __argent_player_suffix.length;
 
-        byte[32] cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(cov_id) == 3);
-        require(OpCovInputIdx(cov_id, 0) == this.activeInputIndex);
-        int player_a_in_input_idx = OpCovInputIdx(cov_id, 1); // input Player at cov[1]
-        PlayerState player_a_in = readInputStateWithTemplate(player_a_in_input_idx, player_prefix_len, player_suffix_len, template_player);
-        int player_b_in_input_idx = OpCovInputIdx(cov_id, 2); // input Player at cov[2]
-        PlayerState player_b_in = readInputStateWithTemplate(player_b_in_input_idx, player_prefix_len, player_suffix_len, template_player);
+        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(__argent_cov_id) == 3);
+        require(OpCovInputIdx(__argent_cov_id, 0) == this.activeInputIndex);
+        int __argent_player_a_in_input_idx = OpCovInputIdx(__argent_cov_id, 1); // input Player at cov[1]
+        PlayerState player_a_in = readInputStateWithTemplate(__argent_player_a_in_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
+        int __argent_player_b_in_input_idx = OpCovInputIdx(__argent_cov_id, 2); // input Player at cov[2]
+        PlayerState player_b_in = readInputStateWithTemplate(__argent_player_b_in_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
-        int player_a_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output player_a_out: Player
-        int player_b_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player_b_out: Player
+        int __argent_player_a_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output player_a_out: Player
+        int __argent_player_b_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player_b_out: Player
 
         require(status == A_WIN || status == B_WIN);
         byte[32] player_a_ref = player_ref(player_a_in.owner, player_a_in.player_id);
@@ -126,19 +126,19 @@ contract StonesSettle(
         if (status == A_WIN) {
             player_a_wins = player_a_wins + 1;
             player_b_losses = player_b_losses + 1;
-            require(tx.outputs[player_a_out_output_idx].value == tx.inputs[player_a_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
-            require(tx.outputs[player_b_out_output_idx].value == tx.inputs[player_b_in_input_idx].value);
+            require(tx.outputs[__argent_player_a_out_output_idx].value == tx.inputs[__argent_player_a_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
+            require(tx.outputs[__argent_player_b_out_output_idx].value == tx.inputs[__argent_player_b_in_input_idx].value);
         } else {
             player_b_wins = player_b_wins + 1;
             player_a_losses = player_a_losses + 1;
-            require(tx.outputs[player_a_out_output_idx].value == tx.inputs[player_a_in_input_idx].value);
-            require(tx.outputs[player_b_out_output_idx].value == tx.inputs[player_b_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
+            require(tx.outputs[__argent_player_a_out_output_idx].value == tx.inputs[__argent_player_a_in_input_idx].value);
+            require(tx.outputs[__argent_player_b_out_output_idx].value == tx.inputs[__argent_player_b_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
         }
         PlayerState next_player_a = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             owner: player_a_in.owner,
             player_id: player_a_in.player_id,
@@ -148,10 +148,10 @@ contract StonesSettle(
             losses: player_a_losses,
         };
         PlayerState next_player_b = {
-            template_league: template_league,
-            template_player: template_player,
-            template_stones_game: template_stones_game,
-            template_stones_settle: template_stones_settle,
+            __argent_template_league: __argent_template_league,
+            __argent_template_player: __argent_template_player,
+            __argent_template_stones_game: __argent_template_stones_game,
+            __argent_template_stones_settle: __argent_template_stones_settle,
             // ----------- template fields above; source state below
             owner: player_b_in.owner,
             player_id: player_b_in.player_id,
@@ -160,8 +160,8 @@ contract StonesSettle(
             wins: player_b_wins,
             losses: player_b_losses,
         };
-        validateOutputStateWithTemplate(player_a_out_output_idx, next_player_a, player_prefix, player_suffix, template_player);
-        validateOutputStateWithTemplate(player_b_out_output_idx, next_player_b, player_prefix, player_suffix, template_player);
+        validateOutputStateWithTemplate(__argent_player_a_out_output_idx, next_player_a, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
+        validateOutputStateWithTemplate(__argent_player_b_out_output_idx, next_player_b, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
     }
 
 }

--- a/build/stones/sil/StonesSettle.sil
+++ b/build/stones/sil/StonesSettle.sil
@@ -4,10 +4,10 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract StonesSettle(
-    byte[32] __argent_init_template_league,
-    byte[32] __argent_init_template_player,
-    byte[32] __argent_init_template_stones_game,
-    byte[32] __argent_init_template_stones_settle,
+    byte[32] gen__init_template_league,
+    byte[32] gen__init_template_player,
+    byte[32] gen__init_template_stones_game,
+    byte[32] gen__init_template_stones_settle,
     byte[32] init_player_a,
     byte[32] init_player_b,
     int init_status
@@ -21,20 +21,20 @@ contract StonesSettle(
 
     // State layouts
     struct LeagueState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] admin;
         int default_pile;
         int default_max_take;
     }
     struct PlayerState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] owner;
         byte[32] player_id;
@@ -44,10 +44,10 @@ contract StonesSettle(
         int losses;
     }
     struct GameState {
-        byte[32] __argent_template_league;
-        byte[32] __argent_template_player;
-        byte[32] __argent_template_stones_game;
-        byte[32] __argent_template_stones_settle;
+        byte[32] gen__template_league;
+        byte[32] gen__template_player;
+        byte[32] gen__template_stones_game;
+        byte[32] gen__template_stones_settle;
         // ----------- template fields above; source state below
         byte[32] player_a;
         byte[32] player_b;
@@ -86,10 +86,10 @@ contract StonesSettle(
     }
 
     // Template capability table
-    byte[32] __argent_template_league = __argent_init_template_league;
-    byte[32] __argent_template_player = __argent_init_template_player;
-    byte[32] __argent_template_stones_game = __argent_init_template_stones_game;
-    byte[32] __argent_template_stones_settle = __argent_init_template_stones_settle;
+    byte[32] gen__template_league = gen__init_template_league;
+    byte[32] gen__template_player = gen__init_template_player;
+    byte[32] gen__template_stones_game = gen__init_template_stones_game;
+    byte[32] gen__template_stones_settle = gen__init_template_stones_settle;
 
     // StonesSettle state fields
     byte[32] player_a = init_player_a;
@@ -97,20 +97,20 @@ contract StonesSettle(
     int status = init_status;
 
     // Entrypoints
-    entrypoint function settle(byte[] __argent_player_prefix, byte[] __argent_player_suffix) {
-        int __argent_player_prefix_len = __argent_player_prefix.length;
-        int __argent_player_suffix_len = __argent_player_suffix.length;
+    entrypoint function settle(byte[] gen__player_prefix, byte[] gen__player_suffix) {
+        int gen__player_prefix_len = gen__player_prefix.length;
+        int gen__player_suffix_len = gen__player_suffix.length;
 
-        byte[32] __argent_cov_id = OpInputCovenantId(this.activeInputIndex);
-        require(OpCovInputCount(__argent_cov_id) == 3);
-        require(OpCovInputIdx(__argent_cov_id, 0) == this.activeInputIndex);
-        int __argent_player_a_in_input_idx = OpCovInputIdx(__argent_cov_id, 1); // input Player at cov[1]
-        PlayerState player_a_in = readInputStateWithTemplate(__argent_player_a_in_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
-        int __argent_player_b_in_input_idx = OpCovInputIdx(__argent_cov_id, 2); // input Player at cov[2]
-        PlayerState player_b_in = readInputStateWithTemplate(__argent_player_b_in_input_idx, __argent_player_prefix_len, __argent_player_suffix_len, __argent_template_player);
+        byte[32] gen__cov_id = OpInputCovenantId(this.activeInputIndex);
+        require(OpCovInputCount(gen__cov_id) == 3);
+        require(OpCovInputIdx(gen__cov_id, 0) == this.activeInputIndex);
+        int gen__player_a_in_input_idx = OpCovInputIdx(gen__cov_id, 1); // input Player at cov[1]
+        PlayerState player_a_in = readInputStateWithTemplate(gen__player_a_in_input_idx, gen__player_prefix_len, gen__player_suffix_len, gen__template_player);
+        int gen__player_b_in_input_idx = OpCovInputIdx(gen__cov_id, 2); // input Player at cov[2]
+        PlayerState player_b_in = readInputStateWithTemplate(gen__player_b_in_input_idx, gen__player_prefix_len, gen__player_suffix_len, gen__template_player);
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
-        int __argent_player_a_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output player_a_out: Player
-        int __argent_player_b_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player_b_out: Player
+        int gen__player_a_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output player_a_out: Player
+        int gen__player_b_out_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output player_b_out: Player
 
         require(status == A_WIN || status == B_WIN);
         byte[32] player_a_ref = player_ref(player_a_in.owner, player_a_in.player_id);
@@ -126,19 +126,19 @@ contract StonesSettle(
         if (status == A_WIN) {
             player_a_wins = player_a_wins + 1;
             player_b_losses = player_b_losses + 1;
-            require(tx.outputs[__argent_player_a_out_output_idx].value == tx.inputs[__argent_player_a_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
-            require(tx.outputs[__argent_player_b_out_output_idx].value == tx.inputs[__argent_player_b_in_input_idx].value);
+            require(tx.outputs[gen__player_a_out_output_idx].value == tx.inputs[gen__player_a_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
+            require(tx.outputs[gen__player_b_out_output_idx].value == tx.inputs[gen__player_b_in_input_idx].value);
         } else {
             player_b_wins = player_b_wins + 1;
             player_a_losses = player_a_losses + 1;
-            require(tx.outputs[__argent_player_a_out_output_idx].value == tx.inputs[__argent_player_a_in_input_idx].value);
-            require(tx.outputs[__argent_player_b_out_output_idx].value == tx.inputs[__argent_player_b_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
+            require(tx.outputs[gen__player_a_out_output_idx].value == tx.inputs[gen__player_a_in_input_idx].value);
+            require(tx.outputs[gen__player_b_out_output_idx].value == tx.inputs[gen__player_b_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
         }
         PlayerState next_player_a = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             owner: player_a_in.owner,
             player_id: player_a_in.player_id,
@@ -148,10 +148,10 @@ contract StonesSettle(
             losses: player_a_losses,
         };
         PlayerState next_player_b = {
-            __argent_template_league: __argent_template_league,
-            __argent_template_player: __argent_template_player,
-            __argent_template_stones_game: __argent_template_stones_game,
-            __argent_template_stones_settle: __argent_template_stones_settle,
+            gen__template_league: gen__template_league,
+            gen__template_player: gen__template_player,
+            gen__template_stones_game: gen__template_stones_game,
+            gen__template_stones_settle: gen__template_stones_settle,
             // ----------- template fields above; source state below
             owner: player_b_in.owner,
             player_id: player_b_in.player_id,
@@ -160,8 +160,8 @@ contract StonesSettle(
             wins: player_b_wins,
             losses: player_b_losses,
         };
-        validateOutputStateWithTemplate(__argent_player_a_out_output_idx, next_player_a, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
-        validateOutputStateWithTemplate(__argent_player_b_out_output_idx, next_player_b, __argent_player_prefix, __argent_player_suffix, __argent_template_player);
+        validateOutputStateWithTemplate(gen__player_a_out_output_idx, next_player_a, gen__player_prefix, gen__player_suffix, gen__template_player);
+        validateOutputStateWithTemplate(gen__player_b_out_output_idx, next_player_b, gen__player_prefix, gen__player_suffix, gen__template_player);
     }
 
 }

--- a/build/tickets/manifest.json
+++ b/build/tickets/manifest.json
@@ -1,12 +1,12 @@
 {
   "app": "Tickets",
-  "root": "/home/michael/kaspanet/argent/examples/tickets.ag",
+  "root": "/Users/arthur/RustroverProjects/argent/examples/tickets.ag",
   "modules": [
-    "/home/michael/kaspanet/argent/examples/tickets.ag"
+    "/Users/arthur/RustroverProjects/argent/examples/tickets.ag"
   ],
   "templates": [
-    { "actor": "Issuer", "symbol": "template_issuer", "hash": null },
-    { "actor": "Ticket", "symbol": "template_ticket", "hash": null }
+    { "actor": "Issuer", "symbol": "__argent_template_issuer", "hash": null },
+    { "actor": "Ticket", "symbol": "__argent_template_ticket", "hash": null }
   ],
   "actors": [
     {

--- a/build/tickets/manifest.json
+++ b/build/tickets/manifest.json
@@ -1,12 +1,12 @@
 {
   "app": "Tickets",
-  "root": "/Users/arthur/RustroverProjects/argent/examples/tickets.ag",
+  "root": "examples/tickets.ag",
   "modules": [
-    "/Users/arthur/RustroverProjects/argent/examples/tickets.ag"
+    "examples/tickets.ag"
   ],
   "templates": [
-    { "actor": "Issuer", "symbol": "__argent_template_issuer", "hash": null },
-    { "actor": "Ticket", "symbol": "__argent_template_ticket", "hash": null }
+    { "actor": "Issuer", "symbol": "gen__template_issuer", "hash": null },
+    { "actor": "Ticket", "symbol": "gen__template_ticket", "hash": null }
   ],
   "actors": [
     {

--- a/build/tickets/sil/Issuer.sil
+++ b/build/tickets/sil/Issuer.sil
@@ -4,15 +4,15 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract Issuer(
-    byte[32] init_template_issuer,
-    byte[32] init_template_ticket,
+    byte[32] __argent_init_template_issuer,
+    byte[32] __argent_init_template_ticket,
     byte[32] init_admin,
     int init_next_serial
 ) {
     // State layouts
     struct TicketState {
-        byte[32] template_issuer;
-        byte[32] template_ticket;
+        byte[32] __argent_template_issuer;
+        byte[32] __argent_template_ticket;
         // ----------- template fields above; source state below
         byte[32] owner;
         int serial;
@@ -20,47 +20,47 @@ contract Issuer(
     }
 
     // Template capability table
-    byte[32] template_issuer = init_template_issuer;
-    byte[32] template_ticket = init_template_ticket;
+    byte[32] __argent_template_issuer = __argent_init_template_issuer;
+    byte[32] __argent_template_ticket = __argent_init_template_ticket;
 
     // Issuer state fields
     byte[32] admin = init_admin;
     int next_serial = init_next_serial;
 
     // Entrypoints
-    entrypoint function issue(sig admin_sig, pubkey admin_pk, pubkey owner_pk, byte[] issuer_prefix, byte[] issuer_suffix, byte[] ticket_prefix, byte[] ticket_suffix) {
-        int issuer_prefix_len = issuer_prefix.length;
-        int issuer_suffix_len = issuer_suffix.length;
-        int ticket_prefix_len = ticket_prefix.length;
-        int ticket_suffix_len = ticket_suffix.length;
+    entrypoint function issue(sig admin_sig, pubkey admin_pk, pubkey owner_pk, byte[] __argent_issuer_prefix, byte[] __argent_issuer_suffix, byte[] __argent_ticket_prefix, byte[] __argent_ticket_suffix) {
+        int __argent_issuer_prefix_len = __argent_issuer_prefix.length;
+        int __argent_issuer_suffix_len = __argent_issuer_suffix.length;
+        int __argent_ticket_prefix_len = __argent_ticket_prefix.length;
+        int __argent_ticket_suffix_len = __argent_ticket_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
-        int issuer_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output issuer: Issuer
-        int ticket_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output ticket: Ticket
+        int __argent_issuer_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output issuer: Issuer
+        int __argent_ticket_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output ticket: Ticket
 
         require(blake2b(admin_pk) == admin);
         require(checkSig(admin_sig, admin_pk));
         int serial = next_serial;
         byte[32] owner = blake2b(owner_pk);
         State next_issuer = {
-            template_issuer: template_issuer,
-            template_ticket: template_ticket,
+            __argent_template_issuer: __argent_template_issuer,
+            __argent_template_ticket: __argent_template_ticket,
             // ----------- template fields above; source state below
             admin: admin,
             next_serial: next_serial + 1,
         };
         TicketState new_ticket = {
-            template_issuer: template_issuer,
-            template_ticket: template_ticket,
+            __argent_template_issuer: __argent_template_issuer,
+            __argent_template_ticket: __argent_template_ticket,
             // ----------- template fields above; source state below
             owner: owner,
             serial: serial,
             redeemed: 0,
         };
-        require(tx.outputs[issuer_output_idx].value == tx.inputs[this.activeInputIndex].value);
-        require(tx.outputs[ticket_output_idx].value > 0);
-        validateOutputStateWithTemplate(issuer_output_idx, next_issuer, issuer_prefix, issuer_suffix, template_issuer);
-        validateOutputStateWithTemplate(ticket_output_idx, new_ticket, ticket_prefix, ticket_suffix, template_ticket);
+        require(tx.outputs[__argent_issuer_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[__argent_ticket_output_idx].value > 0);
+        validateOutputStateWithTemplate(__argent_issuer_output_idx, next_issuer, __argent_issuer_prefix, __argent_issuer_suffix, __argent_template_issuer);
+        validateOutputStateWithTemplate(__argent_ticket_output_idx, new_ticket, __argent_ticket_prefix, __argent_ticket_suffix, __argent_template_ticket);
     }
 
 }

--- a/build/tickets/sil/Issuer.sil
+++ b/build/tickets/sil/Issuer.sil
@@ -4,15 +4,15 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract Issuer(
-    byte[32] __argent_init_template_issuer,
-    byte[32] __argent_init_template_ticket,
+    byte[32] gen__init_template_issuer,
+    byte[32] gen__init_template_ticket,
     byte[32] init_admin,
     int init_next_serial
 ) {
     // State layouts
     struct TicketState {
-        byte[32] __argent_template_issuer;
-        byte[32] __argent_template_ticket;
+        byte[32] gen__template_issuer;
+        byte[32] gen__template_ticket;
         // ----------- template fields above; source state below
         byte[32] owner;
         int serial;
@@ -20,47 +20,47 @@ contract Issuer(
     }
 
     // Template capability table
-    byte[32] __argent_template_issuer = __argent_init_template_issuer;
-    byte[32] __argent_template_ticket = __argent_init_template_ticket;
+    byte[32] gen__template_issuer = gen__init_template_issuer;
+    byte[32] gen__template_ticket = gen__init_template_ticket;
 
     // Issuer state fields
     byte[32] admin = init_admin;
     int next_serial = init_next_serial;
 
     // Entrypoints
-    entrypoint function issue(sig admin_sig, pubkey admin_pk, pubkey owner_pk, byte[] __argent_issuer_prefix, byte[] __argent_issuer_suffix, byte[] __argent_ticket_prefix, byte[] __argent_ticket_suffix) {
-        int __argent_issuer_prefix_len = __argent_issuer_prefix.length;
-        int __argent_issuer_suffix_len = __argent_issuer_suffix.length;
-        int __argent_ticket_prefix_len = __argent_ticket_prefix.length;
-        int __argent_ticket_suffix_len = __argent_ticket_suffix.length;
+    entrypoint function issue(sig admin_sig, pubkey admin_pk, pubkey owner_pk, byte[] gen__issuer_prefix, byte[] gen__issuer_suffix, byte[] gen__ticket_prefix, byte[] gen__ticket_suffix) {
+        int gen__issuer_prefix_len = gen__issuer_prefix.length;
+        int gen__issuer_suffix_len = gen__issuer_suffix.length;
+        int gen__ticket_prefix_len = gen__ticket_prefix.length;
+        int gen__ticket_suffix_len = gen__ticket_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
-        int __argent_issuer_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output issuer: Issuer
-        int __argent_ticket_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output ticket: Ticket
+        int gen__issuer_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output issuer: Issuer
+        int gen__ticket_output_idx = OpAuthOutputIdx(this.activeInputIndex, 1); // output ticket: Ticket
 
         require(blake2b(admin_pk) == admin);
         require(checkSig(admin_sig, admin_pk));
         int serial = next_serial;
         byte[32] owner = blake2b(owner_pk);
         State next_issuer = {
-            __argent_template_issuer: __argent_template_issuer,
-            __argent_template_ticket: __argent_template_ticket,
+            gen__template_issuer: gen__template_issuer,
+            gen__template_ticket: gen__template_ticket,
             // ----------- template fields above; source state below
             admin: admin,
             next_serial: next_serial + 1,
         };
         TicketState new_ticket = {
-            __argent_template_issuer: __argent_template_issuer,
-            __argent_template_ticket: __argent_template_ticket,
+            gen__template_issuer: gen__template_issuer,
+            gen__template_ticket: gen__template_ticket,
             // ----------- template fields above; source state below
             owner: owner,
             serial: serial,
             redeemed: 0,
         };
-        require(tx.outputs[__argent_issuer_output_idx].value == tx.inputs[this.activeInputIndex].value);
-        require(tx.outputs[__argent_ticket_output_idx].value > 0);
-        validateOutputStateWithTemplate(__argent_issuer_output_idx, next_issuer, __argent_issuer_prefix, __argent_issuer_suffix, __argent_template_issuer);
-        validateOutputStateWithTemplate(__argent_ticket_output_idx, new_ticket, __argent_ticket_prefix, __argent_ticket_suffix, __argent_template_ticket);
+        require(tx.outputs[gen__issuer_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[gen__ticket_output_idx].value > 0);
+        validateOutputStateWithTemplate(gen__issuer_output_idx, next_issuer, gen__issuer_prefix, gen__issuer_suffix, gen__template_issuer);
+        validateOutputStateWithTemplate(gen__ticket_output_idx, new_ticket, gen__ticket_prefix, gen__ticket_suffix, gen__template_ticket);
     }
 
 }

--- a/build/tickets/sil/Ticket.sil
+++ b/build/tickets/sil/Ticket.sil
@@ -4,24 +4,24 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract Ticket(
-    byte[32] init_template_issuer,
-    byte[32] init_template_ticket,
+    byte[32] __argent_init_template_issuer,
+    byte[32] __argent_init_template_ticket,
     byte[32] init_owner,
     int init_serial,
     int init_redeemed
 ) {
     // State layouts
     struct IssuerState {
-        byte[32] template_issuer;
-        byte[32] template_ticket;
+        byte[32] __argent_template_issuer;
+        byte[32] __argent_template_ticket;
         // ----------- template fields above; source state below
         byte[32] admin;
         int next_serial;
     }
 
     // Template capability table
-    byte[32] template_issuer = init_template_issuer;
-    byte[32] template_ticket = init_template_ticket;
+    byte[32] __argent_template_issuer = __argent_init_template_issuer;
+    byte[32] __argent_template_ticket = __argent_init_template_ticket;
 
     // Ticket state fields
     byte[32] owner = init_owner;
@@ -29,26 +29,26 @@ contract Ticket(
     int redeemed = init_redeemed;
 
     // Entrypoints
-    entrypoint function redeem(sig owner_sig, pubkey owner_pk, byte[] ticket_prefix, byte[] ticket_suffix) {
-        int ticket_prefix_len = ticket_prefix.length;
-        int ticket_suffix_len = ticket_suffix.length;
+    entrypoint function redeem(sig owner_sig, pubkey owner_pk, byte[] __argent_ticket_prefix, byte[] __argent_ticket_suffix) {
+        int __argent_ticket_prefix_len = __argent_ticket_prefix.length;
+        int __argent_ticket_suffix_len = __argent_ticket_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Ticket
+        int __argent_next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Ticket
 
         require(blake2b(owner_pk) == owner);
         require(checkSig(owner_sig, owner_pk));
         require(redeemed == 0);
-        require(tx.outputs[next_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[__argent_next_output_idx].value == tx.inputs[this.activeInputIndex].value);
         State redeemed_ticket = {
-            template_issuer: template_issuer,
-            template_ticket: template_ticket,
+            __argent_template_issuer: __argent_template_issuer,
+            __argent_template_ticket: __argent_template_ticket,
             // ----------- template fields above; source state below
             owner: owner,
             serial: serial,
             redeemed: 1,
         };
-        validateOutputStateWithTemplate(next_output_idx, redeemed_ticket, ticket_prefix, ticket_suffix, template_ticket);
+        validateOutputStateWithTemplate(__argent_next_output_idx, redeemed_ticket, __argent_ticket_prefix, __argent_ticket_suffix, __argent_template_ticket);
     }
 
 }

--- a/build/tickets/sil/Ticket.sil
+++ b/build/tickets/sil/Ticket.sil
@@ -4,24 +4,24 @@ pragma silverscript ^0.1.0;
 // This is plain Silverscript: no covenant macros are used.
 
 contract Ticket(
-    byte[32] __argent_init_template_issuer,
-    byte[32] __argent_init_template_ticket,
+    byte[32] gen__init_template_issuer,
+    byte[32] gen__init_template_ticket,
     byte[32] init_owner,
     int init_serial,
     int init_redeemed
 ) {
     // State layouts
     struct IssuerState {
-        byte[32] __argent_template_issuer;
-        byte[32] __argent_template_ticket;
+        byte[32] gen__template_issuer;
+        byte[32] gen__template_ticket;
         // ----------- template fields above; source state below
         byte[32] admin;
         int next_serial;
     }
 
     // Template capability table
-    byte[32] __argent_template_issuer = __argent_init_template_issuer;
-    byte[32] __argent_template_ticket = __argent_init_template_ticket;
+    byte[32] gen__template_issuer = gen__init_template_issuer;
+    byte[32] gen__template_ticket = gen__init_template_ticket;
 
     // Ticket state fields
     byte[32] owner = init_owner;
@@ -29,26 +29,26 @@ contract Ticket(
     int redeemed = init_redeemed;
 
     // Entrypoints
-    entrypoint function redeem(sig owner_sig, pubkey owner_pk, byte[] __argent_ticket_prefix, byte[] __argent_ticket_suffix) {
-        int __argent_ticket_prefix_len = __argent_ticket_prefix.length;
-        int __argent_ticket_suffix_len = __argent_ticket_suffix.length;
+    entrypoint function redeem(sig owner_sig, pubkey owner_pk, byte[] gen__ticket_prefix, byte[] gen__ticket_suffix) {
+        int gen__ticket_prefix_len = gen__ticket_prefix.length;
+        int gen__ticket_suffix_len = gen__ticket_suffix.length;
 
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int __argent_next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Ticket
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Ticket
 
         require(blake2b(owner_pk) == owner);
         require(checkSig(owner_sig, owner_pk));
         require(redeemed == 0);
-        require(tx.outputs[__argent_next_output_idx].value == tx.inputs[this.activeInputIndex].value);
+        require(tx.outputs[gen__next_output_idx].value == tx.inputs[this.activeInputIndex].value);
         State redeemed_ticket = {
-            __argent_template_issuer: __argent_template_issuer,
-            __argent_template_ticket: __argent_template_ticket,
+            gen__template_issuer: gen__template_issuer,
+            gen__template_ticket: gen__template_ticket,
             // ----------- template fields above; source state below
             owner: owner,
             serial: serial,
             redeemed: 1,
         };
-        validateOutputStateWithTemplate(__argent_next_output_idx, redeemed_ticket, __argent_ticket_prefix, __argent_ticket_suffix, __argent_template_ticket);
+        validateOutputStateWithTemplate(gen__next_output_idx, redeemed_ticket, gen__ticket_prefix, gen__ticket_suffix, gen__template_ticket);
     }
 
 }

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use crate::ast::*;
 use crate::error::{ArgentError, Result};
-use crate::lexer::{Token, TokenKind, lex};
+use crate::lexer::{RESERVED_GENERATED_PREFIX, Token, TokenKind, lex};
 
 pub fn emit_build(program: &Program, out_dir: impl AsRef<Path>) -> Result<()> {
     let out_dir = out_dir.as_ref();
@@ -77,10 +77,68 @@ impl<'a> Model<'a> {
     }
 
     fn validate(&self) -> Result<()> {
+        self.validate_reserved_identifiers()?;
+        self.validate_generated_actor_suffixes()?;
+
         let template_actor_set = self.template_actors.iter().cloned().collect::<BTreeSet<_>>();
         for actor in &self.actors {
             for entry in &actor.entries {
                 self.validate_entry(actor, entry, &template_actor_set)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_reserved_identifiers(&self) -> Result<()> {
+        reject_reserved_identifier("app", &self.app_name)?;
+        for konst in &self.consts {
+            reject_reserved_identifier("constant", &konst.name)?;
+        }
+        for function in &self.functions {
+            reject_reserved_identifier("function", &function.name)?;
+            for param in &function.params {
+                reject_reserved_identifier(&format!("function `{}` parameter", function.name), &param.name)?;
+            }
+        }
+        for state in self.states.values() {
+            reject_reserved_identifier("state", &state.name)?;
+            for field in &state.fields {
+                reject_reserved_identifier(&format!("state `{}` field", state.name), &field.name)?;
+            }
+        }
+        for actor in self.actors_by_name.values() {
+            reject_reserved_identifier("actor", &actor.name)?;
+            for entry in &actor.entries {
+                reject_reserved_identifier(&format!("entry `{}::{}`", actor.name, entry.name), &entry.name)?;
+                for param in &entry.params {
+                    reject_reserved_identifier(&format!("entry `{}::{}` parameter", actor.name, entry.name), &param.name)?;
+                }
+                for consume in &entry.consumes {
+                    reject_reserved_identifier(&format!("entry `{}::{}` consume handle", actor.name, entry.name), &consume.name)?;
+                }
+                if let EmitSpec::Outputs(outputs) = &entry.emits {
+                    for output in outputs {
+                        reject_reserved_identifier(&format!("entry `{}::{}` output handle", actor.name, entry.name), &output.name)?;
+                    }
+                }
+                for route in &entry.routes {
+                    if let Some(output) = &route.output {
+                        reject_reserved_identifier(&format!("entry `{}::{}` route output handle", actor.name, entry.name), output)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_generated_actor_suffixes(&self) -> Result<()> {
+        let mut seen = BTreeMap::new();
+        for actor in &self.template_actors {
+            let suffix = to_snake(actor);
+            if let Some(previous) = seen.insert(suffix.clone(), actor.as_str()) {
+                return Err(ArgentError::new(format!(
+                    "template actors `{previous}` and `{actor}` both map to generated suffix `{suffix}`"
+                )));
             }
         }
         Ok(())
@@ -312,7 +370,7 @@ fn emit_actor(actor: &ActorDecl, model: &Model<'_>) -> Result<String> {
     out.push_str(&format!("contract {}(\n", actor.name));
     let mut args = Vec::new();
     for template_actor in &model.template_actors {
-        args.push(format!("    byte[32] init_template_{}", to_snake(template_actor)));
+        args.push(format!("    byte[32] {}", hidden_template_init_name(template_actor)));
     }
     for field in &state.fields {
         args.push(format!("    {} init_{}", field.ty.to_sil(), field.name));
@@ -326,8 +384,9 @@ fn emit_actor(actor: &ActorDecl, model: &Model<'_>) -> Result<String> {
 
     emit_section_header(&mut out, "Template capability table");
     for template_actor in &model.template_actors {
-        let ident = to_snake(template_actor);
-        out.push_str(&format!("    byte[32] template_{ident} = init_template_{ident};\n"));
+        let template = hidden_template_name(template_actor);
+        let init_template = hidden_template_init_name(template_actor);
+        out.push_str(&format!("    byte[32] {template} = {init_template};\n"));
     }
     out.push('\n');
 
@@ -374,7 +433,7 @@ fn emit_state_layouts(out: &mut String, current_actor: &ActorDecl, model: &Model
         let state = model.state(&actor.state)?;
         out.push_str(&format!("    struct {} {{\n", state.name));
         for template_actor in &model.template_actors {
-            out.push_str(&format!("        byte[32] template_{};\n", to_snake(template_actor)));
+            out.push_str(&format!("        byte[32] {};\n", hidden_template_name(template_actor)));
         }
         out.push_str("        // ----------- template fields above; source state below\n");
         for field in &state.fields {
@@ -408,26 +467,30 @@ fn emit_entry(out: &mut String, actor: &ActorDecl, entry: &EntryDecl, model: &Mo
     out.push_str(") {\n");
 
     for actor_name in &witness_actors {
-        let ident = to_snake(actor_name);
-        out.push_str(&format!("        int {ident}_prefix_len = {ident}_prefix.length;\n"));
-        out.push_str(&format!("        int {ident}_suffix_len = {ident}_suffix.length;\n"));
+        let prefix = hidden_witness_prefix_name(actor_name);
+        let suffix = hidden_witness_suffix_name(actor_name);
+        let prefix_len = hidden_witness_prefix_len_name(actor_name);
+        let suffix_len = hidden_witness_suffix_len_name(actor_name);
+        out.push_str(&format!("        int {prefix_len} = {prefix}.length;\n"));
+        out.push_str(&format!("        int {suffix_len} = {suffix}.length;\n"));
     }
     if !witness_actors.is_empty() {
         out.push('\n');
     }
 
     if !entry.consumes.is_empty() {
-        out.push_str("        byte[32] cov_id = OpInputCovenantId(this.activeInputIndex);\n");
+        let cov_id = hidden_cov_id_name();
+        out.push_str(&format!("        byte[32] {cov_id} = OpInputCovenantId(this.activeInputIndex);\n"));
         match entry.kind {
             EntryKind::Leader => {
                 let count = entry.consumes.len() + 1;
-                out.push_str(&format!("        require(OpCovInputCount(cov_id) == {count});\n"));
-                out.push_str("        require(OpCovInputIdx(cov_id, 0) == this.activeInputIndex);\n");
+                out.push_str(&format!("        require(OpCovInputCount({cov_id}) == {count});\n"));
+                out.push_str(&format!("        require(OpCovInputIdx({cov_id}, 0) == this.activeInputIndex);\n"));
             }
             EntryKind::Delegate => {
                 let min_count = entry.consumes.len() + 1;
-                out.push_str(&format!("        require(OpCovInputCount(cov_id) >= {min_count});\n"));
-                out.push_str("        require(OpCovInputIdx(cov_id, 0) != this.activeInputIndex);\n");
+                out.push_str(&format!("        require(OpCovInputCount({cov_id}) >= {min_count});\n"));
+                out.push_str(&format!("        require(OpCovInputIdx({cov_id}, 0) != this.activeInputIndex);\n"));
             }
         }
 
@@ -437,16 +500,19 @@ fn emit_entry(out: &mut String, actor: &ActorDecl, entry: &EntryDecl, model: &Mo
         };
         for (idx, consume) in entry.consumes.iter().enumerate() {
             let cov_index = slot_offset + idx;
-            let ident = to_snake(&consume.actor);
+            let input_idx = hidden_input_idx_name(&consume.name);
+            let prefix_len = hidden_witness_prefix_len_name(&consume.actor);
+            let suffix_len = hidden_witness_suffix_len_name(&consume.actor);
+            let template = hidden_template_name(&consume.actor);
             let state_struct = contract_state_type_for_actor(&consume.actor, actor, model)?;
             let _state = model.actor_state(&consume.actor)?;
             out.push_str(&format!(
-                "        int {}_input_idx = OpCovInputIdx(cov_id, {}); // input {} at cov[{}]\n",
-                consume.name, cov_index, consume.actor, cov_index
+                "        int {input_idx} = OpCovInputIdx({cov_id}, {cov_index}); // input {} at cov[{}]\n",
+                consume.actor, cov_index
             ));
             out.push_str(&format!(
-                "        {state_struct} {} = readInputStateWithTemplate({}_input_idx, {ident}_prefix_len, {ident}_suffix_len, template_{ident});\n",
-                consume.name, consume.name
+                "        {state_struct} {} = readInputStateWithTemplate({input_idx}, {prefix_len}, {suffix_len}, {template});\n",
+                consume.name
             ));
         }
     }
@@ -457,17 +523,18 @@ fn emit_entry(out: &mut String, actor: &ActorDecl, entry: &EntryDecl, model: &Mo
         }
         EmitSpec::One { actors } => {
             out.push_str("        require(OpAuthOutputCount(this.activeInputIndex) == 1);\n");
+            let output_idx = hidden_next_output_idx_name();
             out.push_str(&format!(
-                "        int next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one {}\n",
+                "        int {output_idx} = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one {}\n",
                 actors.join(" | ")
             ));
         }
         EmitSpec::Outputs(outputs) => {
             out.push_str(&format!("        require(OpAuthOutputCount(this.activeInputIndex) == {});\n", outputs.len()));
             for output in outputs {
+                let output_idx = hidden_output_idx_name(&output.name);
                 out.push_str(&format!(
-                    "        int {}_output_idx = OpAuthOutputIdx(this.activeInputIndex, {}); // output {}: {}\n",
-                    output.name,
+                    "        int {output_idx} = OpAuthOutputIdx(this.activeInputIndex, {}); // output {}: {}\n",
                     output.auth_index,
                     output.name,
                     output.actors.join(" | ")
@@ -624,9 +691,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
     fn lower_route(&mut self, out: &mut String, indent: usize, route: RouteCall) -> Result<()> {
         self.model.actor_state(&route.actor)?;
-        let target = to_snake(&route.actor);
-        let output_idx =
-            route.output.as_ref().map(|output| format!("{output}_output_idx")).unwrap_or_else(|| "next_output_idx".to_string());
+        let output_idx = route.output.as_ref().map_or_else(hidden_next_output_idx_name, |output| hidden_output_idx_name(output));
         let state_ty = contract_state_type_for_actor(&route.actor, self.actor, self.model)?;
         let state_expr = route.state.trim();
         let state_arg = if self.types.get(state_expr).is_some_and(|ty| ty == &state_ty) {
@@ -639,10 +704,11 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             name
         };
 
+        let prefix = hidden_witness_prefix_name(&route.actor);
+        let suffix = hidden_witness_suffix_name(&route.actor);
+        let template = hidden_template_name(&route.actor);
         push_indent(out, indent);
-        out.push_str(&format!(
-            "validateOutputStateWithTemplate({output_idx}, {state_arg}, {target}_prefix, {target}_suffix, template_{target});\n"
-        ));
+        out.push_str(&format!("validateOutputStateWithTemplate({output_idx}, {state_arg}, {prefix}, {suffix}, {template});\n"));
         Ok(())
     }
 
@@ -713,8 +779,8 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let mut out = String::new();
         out.push_str("{\n");
         for template_actor in &self.model.template_actors {
-            let ident = to_snake(template_actor);
-            out.push_str(&format!("{field_indent}template_{ident}: template_{ident},\n"));
+            let template = hidden_template_name(template_actor);
+            out.push_str(&format!("{field_indent}{template}: {template},\n"));
         }
         out.push_str(&format!("{field_indent}// ----------- template fields above; source state below\n"));
         for (name, expr) in fields {
@@ -728,10 +794,10 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     fn lower_refs(&self, expr: &str) -> String {
         let mut out = expr.replace("self.value", "tx.inputs[this.activeInputIndex].value");
         for name in &self.input_names {
-            out = out.replace(&format!("{name}.value"), &format!("tx.inputs[{name}_input_idx].value"));
+            out = out.replace(&format!("{name}.value"), &format!("tx.inputs[{}].value", hidden_input_idx_name(name)));
         }
         for name in &self.output_names {
-            out = out.replace(&format!("{name}.value"), &format!("tx.outputs[{name}_output_idx].value"));
+            out = out.replace(&format!("{name}.value"), &format!("tx.outputs[{}].value", hidden_output_idx_name(name)));
         }
         out
     }
@@ -880,7 +946,7 @@ fn push_indent(out: &mut String, indent: usize) {
 
 fn generated_state_name(route: &RouteCall, state_ty: &str) -> String {
     let base = route.output.as_deref().unwrap_or(route.actor.as_str());
-    format!("generated_{}_{}", to_snake(base), to_snake(state_ty))
+    format!("{RESERVED_GENERATED_PREFIX}generated_{}_{}", to_snake(base), to_snake(state_ty))
 }
 
 fn parse_unique_self_outpoint(expr: &str) -> Option<String> {
@@ -1049,9 +1115,8 @@ fn lower_entry_params(params: &[ParamDecl], witness_actors: &[String]) -> Vec<St
         out.push(format!("{} {}", param.ty.to_sil(), param.name));
     }
     for actor_name in witness_actors {
-        let ident = to_snake(actor_name);
-        out.push(format!("byte[] {ident}_prefix"));
-        out.push(format!("byte[] {ident}_suffix"));
+        out.push(format!("byte[] {}", hidden_witness_prefix_name(actor_name)));
+        out.push(format!("byte[] {}", hidden_witness_suffix_name(actor_name)));
     }
     out
 }
@@ -1109,9 +1174,9 @@ fn emit_manifest(program: &Program, model: &Model<'_>) -> String {
             out.push_str(",\n");
         }
         out.push_str(&format!(
-            "    {{ \"actor\": \"{}\", \"symbol\": \"template_{}\", \"hash\": null }}",
+            "    {{ \"actor\": \"{}\", \"symbol\": \"{}\", \"hash\": null }}",
             json_escape(actor),
-            to_snake(actor)
+            json_escape(&hidden_template_name(actor))
         ));
     }
     out.push_str("\n  ],\n");
@@ -1218,9 +1283,9 @@ fn emit_emit_spec_json(out: &mut String, emits: &EmitSpec) {
 
 fn to_snake(input: &str) -> String {
     let mut out = String::new();
-    for (idx, ch) in input.chars().enumerate() {
+    for ch in input.chars() {
         if ch.is_ascii_uppercase() {
-            if idx > 0 {
+            if !out.is_empty() && !out.ends_with('_') {
                 out.push('_');
             }
             out.push(ch.to_ascii_lowercase());
@@ -1229,6 +1294,59 @@ fn to_snake(input: &str) -> String {
         }
     }
     out
+}
+
+fn reject_reserved_identifier(context: &str, name: &str) -> Result<()> {
+    if name.starts_with(RESERVED_GENERATED_PREFIX) {
+        return Err(ArgentError::new(format!(
+            "{context} identifier `{name}` uses reserved generated namespace `{RESERVED_GENERATED_PREFIX}`"
+        )));
+    }
+    Ok(())
+}
+
+fn hidden_actor_suffix(actor: &str) -> String {
+    to_snake(actor)
+}
+
+fn hidden_template_init_name(actor: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}init_template_{}", hidden_actor_suffix(actor))
+}
+
+fn hidden_template_name(actor: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}template_{}", hidden_actor_suffix(actor))
+}
+
+fn hidden_witness_prefix_name(actor: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}{}_prefix", hidden_actor_suffix(actor))
+}
+
+fn hidden_witness_suffix_name(actor: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}{}_suffix", hidden_actor_suffix(actor))
+}
+
+fn hidden_witness_prefix_len_name(actor: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}{}_prefix_len", hidden_actor_suffix(actor))
+}
+
+fn hidden_witness_suffix_len_name(actor: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}{}_suffix_len", hidden_actor_suffix(actor))
+}
+
+fn hidden_cov_id_name() -> String {
+    format!("{RESERVED_GENERATED_PREFIX}cov_id")
+}
+
+fn hidden_input_idx_name(input: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}{input}_input_idx")
+}
+
+fn hidden_next_output_idx_name() -> String {
+    format!("{RESERVED_GENERATED_PREFIX}next_output_idx")
+}
+
+fn hidden_output_idx_name(output: &str) -> String {
+    format!("{RESERVED_GENERATED_PREFIX}{output}_output_idx")
 }
 
 fn state_struct_name_for_actor(actor: &str, model: &Model<'_>) -> Result<String> {
@@ -1381,6 +1499,119 @@ mod tests {
 
         let err = Model::from_program(&program).expect_err("delegate become must be rejected");
         assert!(err.to_string().contains("cannot use `become`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_reserved_state_field_from_model() {
+        let mut program = test_program();
+        program.modules[0].states[0].fields.push(FieldDecl { ty: TypeRef::new("int"), name: "__argent_template_player".to_string() });
+
+        let err = Model::from_program(&program).expect_err("reserved state field must be rejected");
+        assert!(err.to_string().contains("reserved generated namespace"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_reserved_entry_parameter_from_model() {
+        let mut program = test_program();
+        program.modules[0].actors[0].entries[0]
+            .params
+            .push(ParamDecl { name: "__argent_next_output_idx".to_string(), ty: TypeRef::new("int") });
+
+        let err = Model::from_program(&program).expect_err("reserved entry parameter must be rejected");
+        assert!(err.to_string().contains("reserved generated namespace"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_reserved_output_handle_from_model() {
+        let mut program = test_program();
+        program.modules[0].actors[0].entries[0].emits = EmitSpec::Outputs(vec![EmitOutput {
+            name: "__argent_next".to_string(),
+            actors: vec!["Player".to_string()],
+            auth_index: 0,
+        }]);
+        let route =
+            RouteCall { output: Some("__argent_next".to_string()), actor: "Player".to_string(), state: "next_player".to_string() };
+        program.modules[0].actors[0].entries[0].routes = vec![route.clone()];
+        program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![route]];
+
+        let err = Model::from_program(&program).expect_err("reserved output handle must be rejected");
+        assert!(err.to_string().contains("reserved generated namespace"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_template_actor_snake_case_collision() {
+        let mut program = test_program();
+        program.modules[0].actors[0].name = "FooBar".to_string();
+        program.modules[0].actors[1].name = "Foo_Bar".to_string();
+        program.modules[0].actors[0].entries.clear();
+        program.modules[0].apps[0].actors = vec!["FooBar".to_string(), "Foo_Bar".to_string()];
+
+        let err = Model::from_program(&program).expect_err("snake-case generated names must not collide");
+        assert!(err.to_string().contains("both map to generated suffix `foo_bar`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn allows_legacy_template_like_user_field_after_namespace_move() {
+        let module = crate::parser::parse_module(
+            PathBuf::from("test.ag"),
+            r#"
+            state FooState {
+                int template_foo;
+            }
+
+            actor Foo owns FooState {}
+
+            app Test {
+                actor Foo;
+            }
+            "#
+            .to_string(),
+        )
+        .expect("source parses");
+        let program = Program { root: PathBuf::from("test.ag"), modules: vec![module] };
+
+        Model::from_program(&program).expect("ordinary template-like names should be legal");
+    }
+
+    #[test]
+    fn emits_reserved_generated_namespace_names() {
+        let module = crate::parser::parse_module(
+            PathBuf::from("test.ag"),
+            r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry step() emits one Foo {
+                    require(next.value == self.value);
+                    become Foo(self.state);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+            "#
+            .to_string(),
+        )
+        .expect("source parses");
+        let program = Program { root: PathBuf::from("test.ag"), modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+        let actor = model.actor("Foo").expect("actor exists");
+        let sil = emit_actor(actor, &model).expect("actor emits");
+        let manifest = emit_manifest(&program, &model);
+
+        assert!(sil.contains("byte[32] __argent_init_template_foo"), "{sil}");
+        assert!(sil.contains("byte[32] __argent_template_foo = __argent_init_template_foo;"), "{sil}");
+        assert!(sil.contains("byte[] __argent_foo_prefix"), "{sil}");
+        assert!(sil.contains("int __argent_foo_prefix_len = __argent_foo_prefix.length;"), "{sil}");
+        assert!(sil.contains("int __argent_next_output_idx = OpAuthOutputIdx"), "{sil}");
+        assert!(sil.contains("tx.outputs[__argent_next_output_idx].value"), "{sil}");
+        assert!(sil.contains("validateOutputStateWithTemplate(__argent_next_output_idx,"), "{sil}");
+        assert!(sil.contains("__argent_generated_foo_state"), "{sil}");
+        assert!(manifest.contains(r#""symbol": "__argent_template_foo""#), "{manifest}");
+        assert!(!sil.contains("byte[32] init_template_foo"), "{sil}");
+        assert!(!sil.contains("int next_output_idx ="), "{sil}");
+        assert!(!sil.contains("byte[] foo_prefix"), "{sil}");
     }
 
     fn test_program() -> Program {

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1016,7 +1016,7 @@ fn push_indent(out: &mut String, indent: usize) {
 
 fn generated_state_name(route: &RouteCall, state_ty: &str) -> String {
     let base = route.output.as_deref().unwrap_or(route.actor.as_str());
-    format!("{RESERVED_GENERATED_PREFIX}generated_{}_{}", to_snake(base), to_snake(state_ty))
+    format!("{RESERVED_GENERATED_PREFIX}state_{}_{}", to_snake(base), to_snake(state_ty))
 }
 
 fn parse_unique_self_outpoint(expr: &str) -> Option<String> {
@@ -1227,14 +1227,14 @@ fn emit_manifest(program: &Program, model: &Model<'_>) -> String {
     let mut out = String::new();
     out.push_str("{\n");
     out.push_str(&format!("  \"app\": \"{}\",\n", json_escape(&model.app_name)));
-    out.push_str(&format!("  \"root\": \"{}\",\n", json_escape(&program.root.display().to_string())));
+    out.push_str(&format!("  \"root\": \"{}\",\n", json_escape(&manifest_path(&program.root))));
 
     out.push_str("  \"modules\": [\n");
     for (idx, module) in program.modules.iter().enumerate() {
         if idx > 0 {
             out.push_str(",\n");
         }
-        out.push_str(&format!("    \"{}\"", json_escape(&module.path.display().to_string())));
+        out.push_str(&format!("    \"{}\"", json_escape(&manifest_path(&module.path))));
     }
     out.push_str("\n  ],\n");
 
@@ -1349,6 +1349,19 @@ fn emit_emit_spec_json(out: &mut String, emits: &EmitSpec) {
             out.push_str("] }");
         }
     }
+}
+
+fn manifest_path(path: &Path) -> String {
+    if let Ok(cwd) = std::env::current_dir()
+        && let Ok(relative) = path.strip_prefix(&cwd)
+    {
+        return display_path(relative);
+    }
+    display_path(path)
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 fn to_snake(input: &str) -> String {
@@ -1641,7 +1654,7 @@ mod tests {
     #[test]
     fn rejects_reserved_state_field_from_model() {
         let mut program = test_program();
-        program.modules[0].states[0].fields.push(FieldDecl { ty: TypeRef::new("int"), name: "__argent_template_player".to_string() });
+        program.modules[0].states[0].fields.push(FieldDecl { ty: TypeRef::new("int"), name: "gen__template_player".to_string() });
 
         let err = Model::from_program(&program).expect_err("reserved state field must be rejected");
         assert!(err.to_string().contains("reserved generated namespace"), "unexpected error: {err}");
@@ -1652,7 +1665,7 @@ mod tests {
         let mut program = test_program();
         program.modules[0].actors[0].entries[0]
             .params
-            .push(ParamDecl { name: "__argent_next_output_idx".to_string(), ty: TypeRef::new("int") });
+            .push(ParamDecl { name: "gen__next_output_idx".to_string(), ty: TypeRef::new("int") });
 
         let err = Model::from_program(&program).expect_err("reserved entry parameter must be rejected");
         assert!(err.to_string().contains("reserved generated namespace"), "unexpected error: {err}");
@@ -1661,13 +1674,9 @@ mod tests {
     #[test]
     fn rejects_reserved_output_handle_from_model() {
         let mut program = test_program();
-        program.modules[0].actors[0].entries[0].emits = EmitSpec::Outputs(vec![EmitOutput {
-            name: "__argent_next".to_string(),
-            actors: vec!["Player".to_string()],
-            auth_index: 0,
-        }]);
-        let route =
-            RouteCall { output: Some("__argent_next".to_string()), actor: "Player".to_string(), state: "next_player".to_string() };
+        program.modules[0].actors[0].entries[0].emits =
+            EmitSpec::Outputs(vec![EmitOutput { name: "gen__next".to_string(), actors: vec!["Player".to_string()], auth_index: 0 }]);
+        let route = RouteCall { output: Some("gen__next".to_string()), actor: "Player".to_string(), state: "next_player".to_string() };
         program.modules[0].actors[0].entries[0].routes = vec![route.clone()];
         program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![route]];
 
@@ -1737,18 +1746,35 @@ mod tests {
         let sil = emit_actor(actor, &model).expect("actor emits");
         let manifest = emit_manifest(&program, &model);
 
-        assert!(sil.contains("byte[32] __argent_init_template_foo"), "{sil}");
-        assert!(sil.contains("byte[32] __argent_template_foo = __argent_init_template_foo;"), "{sil}");
-        assert!(sil.contains("byte[] __argent_foo_prefix"), "{sil}");
-        assert!(sil.contains("int __argent_foo_prefix_len = __argent_foo_prefix.length;"), "{sil}");
-        assert!(sil.contains("int __argent_next_output_idx = OpAuthOutputIdx"), "{sil}");
-        assert!(sil.contains("tx.outputs[__argent_next_output_idx].value"), "{sil}");
-        assert!(sil.contains("validateOutputStateWithTemplate(__argent_next_output_idx,"), "{sil}");
-        assert!(sil.contains("__argent_generated_foo_state"), "{sil}");
-        assert!(manifest.contains(r#""symbol": "__argent_template_foo""#), "{manifest}");
+        assert!(sil.contains("byte[32] gen__init_template_foo"), "{sil}");
+        assert!(sil.contains("byte[32] gen__template_foo = gen__init_template_foo;"), "{sil}");
+        assert!(sil.contains("byte[] gen__foo_prefix"), "{sil}");
+        assert!(sil.contains("int gen__foo_prefix_len = gen__foo_prefix.length;"), "{sil}");
+        assert!(sil.contains("int gen__next_output_idx = OpAuthOutputIdx"), "{sil}");
+        assert!(sil.contains("tx.outputs[gen__next_output_idx].value"), "{sil}");
+        assert!(sil.contains("validateOutputStateWithTemplate(gen__next_output_idx,"), "{sil}");
+        assert!(sil.contains("gen__state_foo_state"), "{sil}");
+        assert!(manifest.contains(r#""symbol": "gen__template_foo""#), "{manifest}");
         assert!(!sil.contains("byte[32] init_template_foo"), "{sil}");
         assert!(!sil.contains("int next_output_idx ="), "{sil}");
         assert!(!sil.contains("byte[] foo_prefix"), "{sil}");
+        assert!(!sil.contains("__argent_"), "{sil}");
+    }
+
+    #[test]
+    fn manifest_uses_relative_paths_when_possible() {
+        let cwd = std::env::current_dir().expect("current dir");
+        let mut program = test_program();
+        program.root = cwd.join("examples/tickets.ag");
+        program.modules[0].path = cwd.join("examples/tickets.ag");
+        program.modules[0].actors[0].entries.clear();
+        let model = Model::from_program(&program).expect("model validates");
+
+        let manifest = emit_manifest(&program, &model);
+
+        assert!(manifest.contains(r#""root": "examples/tickets.ag""#), "{manifest}");
+        assert!(manifest.contains(r#""examples/tickets.ag""#), "{manifest}");
+        assert!(!manifest.contains(&display_path(&cwd)), "{manifest}");
     }
 
     fn assert_duplicate_top_level_error(err: &ArgentError, kind: &str, name: &str) {

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -36,10 +36,11 @@ struct Model<'a> {
 
 impl<'a> Model<'a> {
     fn from_program(program: &'a Program) -> Result<Self> {
-        let consts = program.modules.iter().flat_map(|module| module.consts.iter()).collect::<Vec<_>>();
-        let functions = program.modules.iter().flat_map(|module| module.functions.iter()).collect::<Vec<_>>();
-        let states = program.states().map(|state| (state.name.clone(), state)).collect::<BTreeMap<_, _>>();
-        let all_actors = program.actors().map(|actor| (actor.name.clone(), actor)).collect::<BTreeMap<_, _>>();
+        validate_unique_apps(program)?;
+        let consts = collect_consts(program)?;
+        let functions = collect_functions(program)?;
+        let states = collect_states(program)?;
+        let all_actors = collect_actors(program)?;
 
         let app = program.apps().next();
         let (app_name, template_actors) = if let Some(app) = app {
@@ -358,6 +359,75 @@ impl<'a> Model<'a> {
         }
         Ok(())
     }
+}
+
+fn collect_consts(program: &Program) -> Result<Vec<&ConstDecl>> {
+    let mut seen = BTreeMap::new();
+    let mut consts = Vec::new();
+    for module in &program.modules {
+        for konst in &module.consts {
+            reject_duplicate_top_level("const", &konst.name, &module.path, &mut seen)?;
+            consts.push(konst);
+        }
+    }
+    Ok(consts)
+}
+
+fn collect_functions(program: &Program) -> Result<Vec<&FunctionDecl>> {
+    let mut seen = BTreeMap::new();
+    let mut functions = Vec::new();
+    for module in &program.modules {
+        for function in &module.functions {
+            reject_duplicate_top_level("fn", &function.name, &module.path, &mut seen)?;
+            functions.push(function);
+        }
+    }
+    Ok(functions)
+}
+
+fn collect_states(program: &Program) -> Result<BTreeMap<String, &StateDecl>> {
+    let mut seen = BTreeMap::new();
+    let mut states = BTreeMap::new();
+    for module in &program.modules {
+        for state in &module.states {
+            reject_duplicate_top_level("state", &state.name, &module.path, &mut seen)?;
+            states.insert(state.name.clone(), state);
+        }
+    }
+    Ok(states)
+}
+
+fn collect_actors(program: &Program) -> Result<BTreeMap<String, &ActorDecl>> {
+    let mut seen = BTreeMap::new();
+    let mut actors = BTreeMap::new();
+    for module in &program.modules {
+        for actor in &module.actors {
+            reject_duplicate_top_level("actor", &actor.name, &module.path, &mut seen)?;
+            actors.insert(actor.name.clone(), actor);
+        }
+    }
+    Ok(actors)
+}
+
+fn validate_unique_apps(program: &Program) -> Result<()> {
+    let mut seen = BTreeMap::new();
+    for module in &program.modules {
+        for app in &module.apps {
+            reject_duplicate_top_level("app", &app.name, &module.path, &mut seen)?;
+        }
+    }
+    Ok(())
+}
+
+fn reject_duplicate_top_level<'a>(kind: &str, name: &str, path: &'a Path, seen: &mut BTreeMap<String, &'a Path>) -> Result<()> {
+    if let Some(first_path) = seen.insert(name.to_string(), path) {
+        return Err(ArgentError::new(format!(
+            "duplicate top-level {kind} `{name}` in `{}`; first declared in `{}`",
+            path.display(),
+            first_path.display()
+        )));
+    }
+    Ok(())
 }
 
 fn emit_actor(actor: &ActorDecl, model: &Model<'_>) -> Result<String> {
@@ -1502,6 +1572,73 @@ mod tests {
     }
 
     #[test]
+    fn rejects_duplicate_state_declarations() {
+        let mut program = test_program();
+        let mut duplicate = empty_module("second.ag");
+        duplicate.states.push(StateDecl { name: "PlayerState".to_string(), fields: Vec::new() });
+        program.modules.push(duplicate);
+
+        let err = Model::from_program(&program).expect_err("duplicate state declaration must be rejected");
+        assert_duplicate_top_level_error(&err, "state", "PlayerState");
+    }
+
+    #[test]
+    fn rejects_duplicate_actor_declarations() {
+        let mut program = test_program();
+        let mut duplicate = empty_module("second.ag");
+        duplicate.actors.push(ActorDecl { name: "Player".to_string(), state: "PlayerState".to_string(), entries: Vec::new() });
+        program.modules.push(duplicate);
+
+        let err = Model::from_program(&program).expect_err("duplicate actor declaration must be rejected");
+        assert_duplicate_top_level_error(&err, "actor", "Player");
+    }
+
+    #[test]
+    fn rejects_duplicate_const_declarations() {
+        let mut program = test_program();
+        program.modules[0].consts.push(ConstDecl { ty: TypeRef::new("int"), name: "Limit".to_string(), value: "1".to_string() });
+        let mut duplicate = empty_module("second.ag");
+        duplicate.consts.push(ConstDecl { ty: TypeRef::new("int"), name: "Limit".to_string(), value: "2".to_string() });
+        program.modules.push(duplicate);
+
+        let err = Model::from_program(&program).expect_err("duplicate const declaration must be rejected");
+        assert_duplicate_top_level_error(&err, "const", "Limit");
+    }
+
+    #[test]
+    fn rejects_duplicate_function_declarations() {
+        let mut program = test_program();
+        program.modules[0].functions.push(FunctionDecl {
+            name: "helper".to_string(),
+            params: Vec::new(),
+            return_ty: TypeRef::new("int"),
+            body: "1".to_string(),
+        });
+        let mut duplicate = empty_module("second.ag");
+        duplicate.functions.push(FunctionDecl {
+            name: "helper".to_string(),
+            params: Vec::new(),
+            return_ty: TypeRef::new("int"),
+            body: "2".to_string(),
+        });
+        program.modules.push(duplicate);
+
+        let err = Model::from_program(&program).expect_err("duplicate function declaration must be rejected");
+        assert_duplicate_top_level_error(&err, "fn", "helper");
+    }
+
+    #[test]
+    fn rejects_duplicate_app_declarations() {
+        let mut program = test_program();
+        let mut duplicate = empty_module("second.ag");
+        duplicate.apps.push(AppDecl { name: "Test".to_string(), actors: vec!["Player".to_string()] });
+        program.modules.push(duplicate);
+
+        let err = Model::from_program(&program).expect_err("duplicate app declaration must be rejected");
+        assert_duplicate_top_level_error(&err, "app", "Test");
+    }
+
+    #[test]
     fn rejects_reserved_state_field_from_model() {
         let mut program = test_program();
         program.modules[0].states[0].fields.push(FieldDecl { ty: TypeRef::new("int"), name: "__argent_template_player".to_string() });
@@ -1612,6 +1749,25 @@ mod tests {
         assert!(!sil.contains("byte[32] init_template_foo"), "{sil}");
         assert!(!sil.contains("int next_output_idx ="), "{sil}");
         assert!(!sil.contains("byte[] foo_prefix"), "{sil}");
+    }
+
+    fn assert_duplicate_top_level_error(err: &ArgentError, kind: &str, name: &str) {
+        let message = err.to_string();
+        assert!(message.contains(&format!("duplicate top-level {kind} `{name}`")), "unexpected error: {err}");
+        assert!(message.contains("second.ag"), "expected duplicate path in error: {err}");
+        assert!(message.contains("test.ag"), "expected first declaration path in error: {err}");
+    }
+
+    fn empty_module(path: &str) -> Module {
+        Module {
+            path: PathBuf::from(path),
+            imports: Vec::new(),
+            consts: Vec::new(),
+            states: Vec::new(),
+            functions: Vec::new(),
+            actors: Vec::new(),
+            apps: Vec::new(),
+        }
     }
 
     fn test_program() -> Program {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,6 +1,6 @@
 use crate::error::{ArgentError, Result};
 
-pub const RESERVED_GENERATED_PREFIX: &str = "__argent_";
+pub const RESERVED_GENERATED_PREFIX: &str = "gen__";
 
 #[derive(Debug, Clone)]
 pub struct Token {
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn rejects_reserved_generated_namespace_identifier() {
-        let err = lex("state __argent_state {}").expect_err("reserved generated namespace must be rejected");
+        let err = lex("state gen__state {}").expect_err("reserved generated namespace must be rejected");
         assert!(err.to_string().contains("reserved generated namespace"), "unexpected error: {err}");
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,5 +1,7 @@
 use crate::error::{ArgentError, Result};
 
+pub const RESERVED_GENERATED_PREFIX: &str = "__argent_";
+
 #[derive(Debug, Clone)]
 pub struct Token {
     pub kind: TokenKind,
@@ -45,7 +47,7 @@ impl Lexer<'_> {
                 b'/' if self.peek_byte(1) == Some(b'/') => self.skip_line_comment(),
                 b'"' => self.lex_string()?,
                 b'0'..=b'9' => self.lex_number(),
-                b'a'..=b'z' | b'A'..=b'Z' | b'_' => self.lex_ident(),
+                b'a'..=b'z' | b'A'..=b'Z' | b'_' => self.lex_ident()?,
                 b'-' if self.peek_byte(1) == Some(b'>') => {
                     let start = self.pos;
                     self.pos += 2;
@@ -115,15 +117,33 @@ impl Lexer<'_> {
         self.push(TokenKind::Number(self.source[start..self.pos].to_string()), start, self.pos);
     }
 
-    fn lex_ident(&mut self) {
+    fn lex_ident(&mut self) -> Result<()> {
         let start = self.pos;
         while matches!(self.peek_byte(0), Some(b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')) {
             self.pos += 1;
         }
-        self.push(TokenKind::Ident(self.source[start..self.pos].to_string()), start, self.pos);
+        let ident = self.source[start..self.pos].to_string();
+        if ident.starts_with(RESERVED_GENERATED_PREFIX) {
+            return Err(ArgentError::new(format!(
+                "identifier `{ident}` uses reserved generated namespace `{RESERVED_GENERATED_PREFIX}` at offset {start}"
+            )));
+        }
+        self.push(TokenKind::Ident(ident), start, self.pos);
+        Ok(())
     }
 
     fn push(&mut self, kind: TokenKind, start: usize, end: usize) {
         self.tokens.push(Token { kind, span: Span { start, end } });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_reserved_generated_namespace_identifier() {
+        let err = lex("state __argent_state {}").expect_err("reserved generated namespace must be rejected");
+        assert!(err.to_string().contains("reserved generated namespace"), "unexpected error: {err}");
     }
 }


### PR DESCRIPTION
## Why

Argent generated hidden Silverscript ABI names in the same namespace as user source identifiers. That made compiler-generated names such as template fields, witness parameters, and output indices collision-prone. Top-level declarations also used map collection that could silently overwrite an earlier declaration from another module.

```mermaid
flowchart LR
    A[User source names] --> C[Shared namespace]
    B[Generated ABI names] --> C
    C --> D[Collision or silent overwrite]

    E[This change] --> F[Reserve __argent_*]
    E --> G[Reject duplicate top-level declarations]
    F --> H[Separated generated namespace]
    G --> I[Deterministic model construction]
```

## What changed

- Reserve `__argent_` for generated compiler identifiers.
- Emit hidden template, witness, index, and temporary names under `__argent_*`.
- Centralise generated-name construction in the emitter.
- Detect actor snake-case generated-name collisions before codegen.
- Reject duplicate top-level `state`, `actor`, `const`, `fn`, and `app` declarations with both source paths in the diagnostic.
- Regenerate checked-in example build output for tickets and stones.

## Verification

- `cargo +1.94.0 fmt --check`
- `cargo +1.94.0 test`
- `cargo +1.94.0 clippy --all-targets -- -D warnings`
- `cargo +1.94.0 run -- build examples/tickets.ag --out build/tickets`
- `cargo +1.94.0 run -- build examples/stones/app.ag --out build/stones`
- `git diff --check`
