### PR TITLE
Artifact bundles for ICC runtime composition

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -542,30 +542,30 @@ The bundle is builder knowledge, not consensus truth. Scripts still verify
 template hashes, covenant ids, script public keys, state bytes, and signatures.
 The builder should reject inconsistent bundles before constructing a transaction.
 
-Bundle support milestone:
+Bundle support milestone completed:
 
-- [ ] Add `ArtifactBundle` as the explicit runtime composition object.
-- [ ] Add stable artifact ids derived from canonical artifact content.
-- [ ] Add interface fingerprints for exported/imported state and actor views.
-- [ ] Keep `TxBuilder::new(&artifact)` as the single-artifact convenience path,
-  but make it internally use the bundle resolver.
-- [ ] Add `TxBuilder::from_bundle(&bundle)` for multi-artifact construction.
-- [ ] Attach observed apps through a stable app alias such as
+- Added `ArtifactBundle` as the explicit runtime composition object.
+- Added stable artifact ids derived from canonical artifact content.
+- Added interface fingerprints for exported/imported state and actor views.
+- Kept `TxBuilder::new(&artifact)` as the single-artifact convenience path,
+  but made it internally use the bundle resolver.
+- Added `TxBuilder::from_bundle(&bundle)` for multi-artifact construction.
+- Attached observed apps through a stable app alias such as
   `bundle.with_app("asset", asset_artifact)`.
-- [ ] Reject duplicate app aliases.
-- [ ] Resolve observed actor refs through app aliases and interface
+- Rejected duplicate app aliases.
+- Resolved observed actor refs through app aliases and interface
   fingerprints, not temporary global actor-name uniqueness rules.
-- [ ] Reject bundles where the observing artifact's imported state/actor view
+- Rejected bundles where the observing artifact's imported state/actor view
   fingerprint does not match the attached app's exported view.
-- [ ] Move observed contract/actor lookup, route table/proof lookup, and runtime
+- Moved observed contract/actor lookup, route table/proof lookup, and runtime
   state filling through the bundle resolver.
-- [ ] Add fluent `ObservedCovenantContext` helpers for semantic observed inputs
+- Added fluent `ObservedCovenantContext` helpers for semantic observed inputs
   and outputs.
-- [ ] Add an `observed_outputs` convenience method that builds observed covenant
+- Added an `observed_outputs` convenience method that builds observed covenant
   outputs by observe alias and declaration order.
-- [ ] Update the ICC minter runtime test to use the bundle API and keep the
+- Updated the ICC minter runtime test to use the bundle API and keep the
   existing rejection coverage.
-- [ ] Add a negative test where the attached observed app has the right actor
+- Added a negative test where the attached observed app has the right actor
   names but an incompatible state/interface fingerprint.
 
 Later source-language dependency work:

--- a/TASKS.md
+++ b/TASKS.md
@@ -542,6 +542,39 @@ The bundle is builder knowledge, not consensus truth. Scripts still verify
 template hashes, covenant ids, script public keys, state bytes, and signatures.
 The builder should reject inconsistent bundles before constructing a transaction.
 
+Bundle support milestone:
+
+- [ ] Add `ArtifactBundle` as the explicit runtime composition object.
+- [ ] Add stable artifact ids derived from canonical artifact content.
+- [ ] Add interface fingerprints for exported/imported state and actor views.
+- [ ] Keep `TxBuilder::new(&artifact)` as the single-artifact convenience path,
+  but make it internally use the bundle resolver.
+- [ ] Add `TxBuilder::from_bundle(&bundle)` for multi-artifact construction.
+- [ ] Attach observed apps through a stable app alias such as
+  `bundle.with_app("asset", asset_artifact)`.
+- [ ] Reject duplicate app aliases.
+- [ ] Resolve observed actor refs through app aliases and interface
+  fingerprints, not temporary global actor-name uniqueness rules.
+- [ ] Reject bundles where the observing artifact's imported state/actor view
+  fingerprint does not match the attached app's exported view.
+- [ ] Move observed contract/actor lookup, route table/proof lookup, and runtime
+  state filling through the bundle resolver.
+- [ ] Add fluent `ObservedCovenantContext` helpers for semantic observed inputs
+  and outputs.
+- [ ] Add an `observed_outputs` convenience method that builds observed covenant
+  outputs by observe alias and declaration order.
+- [ ] Update the ICC minter runtime test to use the bundle API and keep the
+  existing rejection coverage.
+- [ ] Add a negative test where the attached observed app has the right actor
+  names but an incompatible state/interface fingerprint.
+
+Later source-language dependency work:
+
+- Add source-level dependency declarations and exported interface syntax.
+- Support qualified actor refs in Argent source.
+- Embed declared dependency ids/fingerprints at compile time once source syntax
+  exists.
+
 End-to-end test:
 
 - Compile a core game artifact exposing `Cell` and `AgentCapsule`.

--- a/build/icc_kcc20_asset/artifact.json
+++ b/build/icc_kcc20_asset/artifact.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "id": "e2addc33e626eb0782d4979e166316866883a53286c035126dd83538d583d97e",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -96,6 +97,23 @@
           }
         }
       ]
+    },
+    "interfaces": {
+      "exports": [
+        {
+          "id": "interface/actor/KCC20",
+          "actor": "KCC20",
+          "state": "KCC20State",
+          "fingerprint_hex": "910cfa7d51e95f5ffa44a6e342e7ff585d5328302dd32126071acc8e836138c8"
+        },
+        {
+          "id": "interface/actor/MinterProxy",
+          "actor": "MinterProxy",
+          "state": "MinterProxyState",
+          "fingerprint_hex": "6e4a918db5a03bebaeebbb6f4b9fba6a8626d7098a34d61272e6216f02c1d7f1"
+        }
+      ],
+      "imports": []
     },
     "states": [
       {

--- a/build/icc_minter/artifact.json
+++ b/build/icc_minter/artifact.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "id": "3ba8550baa1c6d6aa5484125e60cddaa6ac8e2f29cf6c3079bb78588a3e52345",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -115,6 +116,30 @@
           "purpose": {
             "kind": "template_suffix_bytes"
           }
+        }
+      ]
+    },
+    "interfaces": {
+      "exports": [
+        {
+          "id": "interface/actor/Minter",
+          "actor": "Minter",
+          "state": "MinterState",
+          "fingerprint_hex": "5108a0d4506d0fa6a1a3449ceca91a156f27bbe7a1c602d769415490dbab2273"
+        }
+      ],
+      "imports": [
+        {
+          "id": "interface/actor/KCC20",
+          "actor": "KCC20",
+          "state": "KCC20State",
+          "fingerprint_hex": "910cfa7d51e95f5ffa44a6e342e7ff585d5328302dd32126071acc8e836138c8"
+        },
+        {
+          "id": "interface/actor/MinterProxy",
+          "actor": "MinterProxy",
+          "state": "MinterProxyState",
+          "fingerprint_hex": "6e4a918db5a03bebaeebbb6f4b9fba6a8626d7098a34d61272e6216f02c1d7f1"
         }
       ]
     },

--- a/build/stones/artifact.json
+++ b/build/stones/artifact.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "id": "f99f62e02423187ed660fc43908cb9d964a5340485a65d0485256765415e4b96",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -303,6 +304,35 @@
           }
         }
       ]
+    },
+    "interfaces": {
+      "exports": [
+        {
+          "id": "interface/actor/League",
+          "actor": "League",
+          "state": "LeagueState",
+          "fingerprint_hex": "0e3682d0996058618689250b06fe0354d74d293525fe0d4b9141c7bcea667d51"
+        },
+        {
+          "id": "interface/actor/Player",
+          "actor": "Player",
+          "state": "PlayerState",
+          "fingerprint_hex": "f0b108f7697ffc92ca201f096aa8deb0958a48cc33225f1f5d111a4ef82e23b1"
+        },
+        {
+          "id": "interface/actor/StonesGame",
+          "actor": "StonesGame",
+          "state": "GameState",
+          "fingerprint_hex": "d73c831c1bca319b1abc4be58249114b0c2f75b0134ac632d31cc294b60b9779"
+        },
+        {
+          "id": "interface/actor/StonesSettle",
+          "actor": "StonesSettle",
+          "state": "SettleState",
+          "fingerprint_hex": "c28af1c426c81a710eb7a709278e19fc92fcd49528db68053320223cfc273bba"
+        }
+      ],
+      "imports": []
     },
     "states": [
       {

--- a/build/tickets/artifact.json
+++ b/build/tickets/artifact.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "id": "5c0f119a765058d8be648465a47742d1cb1424311703062e10235eac8e80bf9d",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -96,6 +97,23 @@
           }
         }
       ]
+    },
+    "interfaces": {
+      "exports": [
+        {
+          "id": "interface/actor/Issuer",
+          "actor": "Issuer",
+          "state": "IssuerState",
+          "fingerprint_hex": "05f8522be84d6ca43bb946115abd2a347ae4a21372a41183d395e4e6276d27f9"
+        },
+        {
+          "id": "interface/actor/Ticket",
+          "actor": "Ticket",
+          "state": "TicketState",
+          "fingerprint_hex": "4a281ab4e9e3bc73f742c2727758448beec4685306bd188b3ae7eb57294b42ea"
+        }
+      ],
+      "imports": []
     },
     "states": [
       {

--- a/build/toy_chess/artifact.json
+++ b/build/toy_chess/artifact.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "id": "62dacc038dd129b9591ca97ff88dc2abc37296bcb285569537f2258e4c66ca98",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -408,6 +409,41 @@
           }
         }
       ]
+    },
+    "interfaces": {
+      "exports": [
+        {
+          "id": "interface/actor/League",
+          "actor": "League",
+          "state": "LeagueState",
+          "fingerprint_hex": "4bfe363a756d049221626b23263b38b2b14b01585627d8cf1b5b036e05afbd58"
+        },
+        {
+          "id": "interface/actor/Player",
+          "actor": "Player",
+          "state": "PlayerState",
+          "fingerprint_hex": "c58590d647b7cbcd81ea57d8f4e3196c04900bf4ca9c038d824de10085f3859e"
+        },
+        {
+          "id": "interface/actor/Mux",
+          "actor": "Mux",
+          "state": "BoardState",
+          "fingerprint_hex": "bdc2dcd8395bb3a464209616ef41506c44e870754ed280aa95cec5f3ab947c06"
+        },
+        {
+          "id": "interface/actor/Pawn",
+          "actor": "Pawn",
+          "state": "BoardState",
+          "fingerprint_hex": "2358ea2891e8afc80f702fe1b65985958e048292bb16c0d7c51f3a630948d4d7"
+        },
+        {
+          "id": "interface/actor/Knight",
+          "actor": "Knight",
+          "state": "BoardState",
+          "fingerprint_hex": "2d7a372a64bf008bc34a01751aa4c0d7ddb68f1895ebdf04a644498e0a9e4dc8"
+        }
+      ],
+      "imports": []
     },
     "states": [
       {

--- a/crates/argent-artifact/Cargo.toml
+++ b/crates/argent-artifact/Cargo.toml
@@ -8,8 +8,6 @@ rust-version = "1.94.0"
 blake2b_simd = { workspace = true }
 faster-hex = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 silverscript-abi = { workspace = true }
 thiserror = { workspace = true }
-
-[dev-dependencies]
-serde_json = { workspace = true }

--- a/crates/argent-artifact/src/lib.rs
+++ b/crates/argent-artifact/src/lib.rs
@@ -23,6 +23,8 @@ pub const ARTIFACT_SCHEMA_VERSION: u32 = 1;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Artifact {
     pub schema_version: u32,
+    #[serde(default)]
+    pub id: String,
     pub generator: GeneratorArtifact,
     pub app: String,
     pub root: String,
@@ -36,6 +38,8 @@ pub struct ArgentArtifact {
     pub templates: Vec<TemplateRefArtifact>,
     #[serde(default)]
     pub template_plan: TemplatePlanArtifact,
+    #[serde(default)]
+    pub interfaces: InterfaceSetArtifact,
     pub states: Vec<StateArtifact>,
     #[serde(default)]
     pub actor_enums: Vec<ActorEnumArtifact>,
@@ -57,6 +61,23 @@ impl Artifact {
     pub fn verify_template_plan(&self) -> std::result::Result<(), TemplatePlanError> {
         self.argent.template_plan.verify(self)
     }
+
+    pub fn computed_id_hex(&self) -> std::result::Result<String, ArtifactIdentityError> {
+        let mut artifact = self.clone();
+        artifact.id.clear();
+        hash_json("argent/artifact/v1", &artifact)
+    }
+
+    pub fn verify_id(&self) -> std::result::Result<(), ArtifactIdentityError> {
+        if self.id.is_empty() {
+            return Err(ArtifactIdentityError::MissingArtifactId { app: self.app.clone() });
+        }
+        let expected = self.computed_id_hex()?;
+        if self.id != expected {
+            return Err(ArtifactIdentityError::ArtifactIdMismatch { app: self.app.clone(), expected, found: self.id.clone() });
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -77,6 +98,22 @@ pub struct ActorEnumArtifact {
     pub name: String,
     pub state: String,
     pub variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InterfaceSetArtifact {
+    #[serde(default)]
+    pub exports: Vec<ActorInterfaceArtifact>,
+    #[serde(default)]
+    pub imports: Vec<ActorInterfaceArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActorInterfaceArtifact {
+    pub id: String,
+    pub actor: String,
+    pub state: String,
+    pub fingerprint_hex: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -513,6 +550,16 @@ pub enum TemplatePlanError {
     RoutePlanRecipeNotExposed { entry: String, recipe_id: String },
     #[error("route plan for `{entry}` points at missing witness recipe `{recipe_id}`")]
     MissingRoutePlanRecipe { entry: String, recipe_id: String },
+}
+
+#[derive(Debug, Error)]
+pub enum ArtifactIdentityError {
+    #[error("artifact `{app}` is missing an artifact id")]
+    MissingArtifactId { app: String },
+    #[error("artifact `{app}` id mismatch: expected {expected}, found {found}")]
+    ArtifactIdMismatch { app: String, expected: String, found: String },
+    #[error("failed to serialize {subject} for hashing: {source}")]
+    Serialize { subject: &'static str, source: serde_json::Error },
 }
 
 impl TemplatePlanArtifact {
@@ -1046,6 +1093,32 @@ fn template_hash_hex(id: &str, prefix_hex: &str, suffix_hex: &str) -> std::resul
     Ok(encode_hex(hash.as_bytes()))
 }
 
+pub fn actor_interface_id(actor: &str) -> String {
+    format!("interface/actor/{actor}")
+}
+
+pub fn actor_interface_fingerprint_hex(
+    actor: &str,
+    state: &str,
+    runtime_fields: &[RuntimeFieldArtifact],
+) -> std::result::Result<String, ArtifactIdentityError> {
+    #[derive(Serialize)]
+    struct ActorInterfaceFingerprint<'a> {
+        kind: &'static str,
+        actor: &'a str,
+        state: &'a str,
+        runtime_fields: &'a [RuntimeFieldArtifact],
+    }
+
+    hash_json("argent/interface/actor/v1", &ActorInterfaceFingerprint { kind: "actor", actor, state, runtime_fields })
+}
+
+fn hash_json<T: Serialize>(domain: &'static str, value: &T) -> std::result::Result<String, ArtifactIdentityError> {
+    let json = serde_json::to_vec(value).map_err(|source| ArtifactIdentityError::Serialize { subject: domain, source })?;
+    let hash = blake2b_simd::Params::new().hash_length(32).to_state().update(domain.as_bytes()).update(&json).finalize();
+    Ok(encode_hex(hash.as_bytes()))
+}
+
 pub fn route_template_table_receipt_id(state: &str, field: &str) -> String {
     format!("route_table/{state}/{field}")
 }
@@ -1403,6 +1476,7 @@ mod tests {
     fn rejects_unknown_argent_schema_version() {
         let artifact = Artifact {
             schema_version: ARTIFACT_SCHEMA_VERSION + 1,
+            id: String::new(),
             generator: GeneratorArtifact { name: "argentc".to_string(), version: "0.1.0".to_string() },
             app: "Tiny".to_string(),
             root: "tiny.ag".to_string(),
@@ -1410,6 +1484,7 @@ mod tests {
             argent: ArgentArtifact {
                 templates: Vec::new(),
                 template_plan: TemplatePlanArtifact::default(),
+                interfaces: InterfaceSetArtifact::default(),
                 states: Vec::new(),
                 actor_enums: Vec::new(),
                 actors: Vec::new(),
@@ -1426,6 +1501,7 @@ mod tests {
     fn rejects_unknown_sil_abi_schema_version() {
         let artifact = Artifact {
             schema_version: ARTIFACT_SCHEMA_VERSION,
+            id: String::new(),
             generator: GeneratorArtifact { name: "argentc".to_string(), version: "0.1.0".to_string() },
             app: "Tiny".to_string(),
             root: "tiny.ag".to_string(),
@@ -1433,6 +1509,7 @@ mod tests {
             argent: ArgentArtifact {
                 templates: Vec::new(),
                 template_plan: TemplatePlanArtifact::default(),
+                interfaces: InterfaceSetArtifact::default(),
                 states: Vec::new(),
                 actor_enums: Vec::new(),
                 actors: Vec::new(),
@@ -1449,6 +1526,7 @@ mod tests {
     fn accepts_sil_contract_without_runtime_state_plan() {
         let artifact = Artifact {
             schema_version: ARTIFACT_SCHEMA_VERSION,
+            id: String::new(),
             generator: GeneratorArtifact { name: "argentc".to_string(), version: "0.1.0".to_string() },
             app: "Tiny".to_string(),
             root: "tiny.ag".to_string(),
@@ -1456,6 +1534,7 @@ mod tests {
             argent: ArgentArtifact {
                 templates: Vec::new(),
                 template_plan: TemplatePlanArtifact::default(),
+                interfaces: InterfaceSetArtifact::default(),
                 states: Vec::new(),
                 actor_enums: Vec::new(),
                 actors: Vec::new(),
@@ -1586,6 +1665,7 @@ mod tests {
 
         let artifact = Artifact {
             schema_version: ARTIFACT_SCHEMA_VERSION,
+            id: String::new(),
             generator: GeneratorArtifact { name: "argentc".to_string(), version: "0.1.0".to_string() },
             app: "NestedFamily".to_string(),
             root: "nested.ag".to_string(),
@@ -1599,6 +1679,7 @@ mod tests {
                         symbol: template.symbol.clone(),
                     })
                     .collect(),
+                interfaces: InterfaceSetArtifact::default(),
                 template_plan: TemplatePlanArtifact {
                     templates,
                     runtime_states: vec![
@@ -1697,6 +1778,7 @@ mod tests {
     fn artifact_with_route_families(route_families: Vec<RouteTemplateFamilyArtifact>) -> Artifact {
         Artifact {
             schema_version: ARTIFACT_SCHEMA_VERSION,
+            id: String::new(),
             generator: GeneratorArtifact { name: "argentc".to_string(), version: "0.1.0".to_string() },
             app: "Tiny".to_string(),
             root: "tiny.ag".to_string(),
@@ -1704,6 +1786,7 @@ mod tests {
             argent: ArgentArtifact {
                 templates: Vec::new(),
                 template_plan: TemplatePlanArtifact { route_families, ..TemplatePlanArtifact::default() },
+                interfaces: InterfaceSetArtifact::default(),
                 states: Vec::new(),
                 actor_enums: Vec::new(),
                 actors: vec![

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -16,10 +16,10 @@ pub use argent_artifact::Artifact;
 pub use silverscript_abi::ArtifactValue;
 
 use argent_artifact::{
-    ActorArtifact, ArtifactVersionError, EntryArtifact, HiddenParamArtifact, HiddenParamPurposeArtifact, HiddenParamSubjectArtifact,
-    ObserveArtifact, ObservedActorArtifact, ObservedActorSideArtifact, RouteTemplateLeafArtifact, RouteTemplateProofArtifact,
-    RuntimeFieldRoleArtifact, RuntimeStatePlanArtifact, SilContractArtifact, SilEntryArtifact, TemplatePlanError,
-    route_template_proof_receipt_id,
+    ActorArtifact, ActorInterfaceArtifact, ArtifactIdentityError, ArtifactVersionError, EntryArtifact, HiddenParamArtifact,
+    HiddenParamPurposeArtifact, HiddenParamSubjectArtifact, ObserveArtifact, ObservedActorArtifact, ObservedActorSideArtifact,
+    RouteTemplateLeafArtifact, RouteTemplateProofArtifact, RuntimeFieldRoleArtifact, RuntimeStatePlanArtifact, SilContractArtifact,
+    SilEntryArtifact, TemplatePlanError, route_template_proof_receipt_id,
 };
 use kaspa_consensus_core::{
     Hash,
@@ -53,6 +53,24 @@ pub enum BuilderError {
     TxScript(#[from] TxScriptError),
     #[error("unknown actor `{0}`")]
     UnknownActor(String),
+    #[error("artifact bundle app alias `{0}` is already attached")]
+    DuplicateAppAlias(String),
+    #[error("artifact bundle has no app alias `{0}`")]
+    UnknownAppAlias(String),
+    #[error("primary artifact does not declare observed app alias `{0}`")]
+    UnknownObservedAppAlias(String),
+    #[error("observed artifact `{app}` does not match any observed app alias")]
+    NoMatchingObservedApp { app: String },
+    #[error("observed artifact `{app}` matches multiple observed app aliases: {aliases:?}")]
+    AmbiguousObservedArtifact { app: String, aliases: Vec<String> },
+    #[error("artifact bundle app `{app}` has invalid artifact id: {source}")]
+    ArtifactIdentity { app: String, source: ArtifactIdentityError },
+    #[error("artifact bundle app `{app}` is missing {direction} interface for actor `{actor}`")]
+    MissingInterface { app: String, direction: &'static str, actor: String },
+    #[error(
+        "artifact bundle app `{app}` actor `{actor}` interface mismatch: expected {expected_fingerprint}, found {found_fingerprint}"
+    )]
+    InterfaceMismatch { app: String, actor: String, expected_fingerprint: String, found_fingerprint: String },
     #[error("runtime state plan for contract `{contract}` is invalid: {message}")]
     RuntimeStatePlanMismatch { contract: String, message: String },
     #[error("runtime state field `{field}` for contract `{contract}` is generated and must be filled by the runtime")]
@@ -103,9 +121,14 @@ pub enum BuilderError {
     UnnamedRouteOutput,
 }
 
+#[derive(Clone, Debug)]
+pub struct ArtifactBundle<'a> {
+    primary: &'a Artifact,
+    apps: BTreeMap<String, &'a Artifact>,
+}
+
 pub struct TxBuilder<'a> {
-    artifact: &'a Artifact,
-    observed_artifacts: Vec<&'a Artifact>,
+    bundle: ArtifactBundle<'a>,
 }
 
 struct ContractRef<'a> {
@@ -160,6 +183,28 @@ pub struct ObservedCovenantContext {
     pub outputs: BTreeMap<String, ObservedOutput>,
 }
 
+impl ObservedCovenantContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn input(
+        mut self,
+        handle: impl Into<String>,
+        actor: impl Into<String>,
+        utxo: UtxoEntry,
+        state: BTreeMap<String, ArtifactValue>,
+    ) -> Self {
+        self.inputs.insert(handle.into(), ObservedInput { actor: actor.into(), state, utxo });
+        self
+    }
+
+    pub fn output(mut self, handle: impl Into<String>, actor: impl Into<String>, state: BTreeMap<String, ArtifactValue>) -> Self {
+        self.outputs.insert(handle.into(), ObservedOutput { actor: actor.into(), state });
+        self
+    }
+}
+
 pub struct ObservedCovenantOutputRequest<'a> {
     pub actor_name: &'a str,
     pub entry_name: &'a str,
@@ -170,11 +215,126 @@ pub struct ObservedCovenantOutputRequest<'a> {
     pub covenant_id: Hash,
 }
 
+impl<'a> ArtifactBundle<'a> {
+    pub fn new(primary: &'a Artifact) -> BuilderResult<Self> {
+        validate_artifact("primary", primary)?;
+        Ok(Self { primary, apps: BTreeMap::new() })
+    }
+
+    pub fn with_app(mut self, alias: impl Into<String>, artifact: &'a Artifact) -> BuilderResult<Self> {
+        let alias = alias.into();
+        if self.apps.contains_key(&alias) {
+            return Err(BuilderError::DuplicateAppAlias(alias));
+        }
+        validate_artifact(&alias, artifact)?;
+        self.validate_app_interfaces(&alias, artifact)?;
+        self.apps.insert(alias, artifact);
+        Ok(self)
+    }
+
+    fn validate_app_interfaces(&self, alias: &str, artifact: &Artifact) -> BuilderResult<()> {
+        let observed_actors = self.observed_actors_for_alias(alias);
+        if observed_actors.is_empty() {
+            return Err(BuilderError::UnknownObservedAppAlias(alias.to_string()));
+        }
+        self.validate_actor_interfaces(alias, artifact, &observed_actors)
+    }
+
+    fn validate_actor_interfaces(&self, alias: &str, artifact: &Artifact, observed_actors: &[String]) -> BuilderResult<()> {
+        for actor in observed_actors {
+            let expected = find_interface(&self.primary.argent.interfaces.imports, actor).ok_or_else(|| {
+                BuilderError::MissingInterface { app: "primary".to_string(), direction: "import", actor: actor.clone() }
+            })?;
+            let found = find_interface(&artifact.argent.interfaces.exports, actor).ok_or_else(|| BuilderError::MissingInterface {
+                app: alias.to_string(),
+                direction: "export",
+                actor: actor.clone(),
+            })?;
+            if expected.fingerprint_hex != found.fingerprint_hex {
+                return Err(BuilderError::InterfaceMismatch {
+                    app: alias.to_string(),
+                    actor: actor.clone(),
+                    expected_fingerprint: expected.fingerprint_hex.clone(),
+                    found_fingerprint: found.fingerprint_hex.clone(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn observed_actors_for_alias(&self, alias: &str) -> Vec<String> {
+        let mut observed_actors = BTreeMap::new();
+        for actor in &self.primary.argent.actors {
+            for entry in &actor.entries {
+                for observe in &entry.observes {
+                    if observe.name != alias {
+                        continue;
+                    }
+                    for observed in observe.inputs.iter().chain(observe.outputs.iter()) {
+                        observed_actors.insert(observed.actor.as_str(), observed.actor.as_str());
+                    }
+                }
+            }
+        }
+        observed_actors.into_keys().map(str::to_string).collect()
+    }
+
+    fn observed_aliases(&self) -> Vec<String> {
+        let mut aliases = BTreeMap::new();
+        for actor in &self.primary.argent.actors {
+            for entry in &actor.entries {
+                for observe in &entry.observes {
+                    aliases.insert(observe.name.as_str(), observe.name.as_str());
+                }
+            }
+        }
+        aliases.into_keys().map(str::to_string).collect()
+    }
+
+    fn infer_observed_alias(&self, artifact: &Artifact) -> BuilderResult<String> {
+        let matches = self
+            .observed_aliases()
+            .into_iter()
+            .filter(|alias| {
+                let observed_actors = self.observed_actors_for_alias(alias);
+                !observed_actors.is_empty() && self.validate_actor_interfaces(alias, artifact, &observed_actors).is_ok()
+            })
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [alias] => Ok(alias.clone()),
+            [] => Err(BuilderError::NoMatchingObservedApp { app: artifact.app.clone() }),
+            _ => Err(BuilderError::AmbiguousObservedArtifact { app: artifact.app.clone(), aliases: matches }),
+        }
+    }
+
+    fn attach_observed_artifact(mut self, artifact: &'a Artifact) -> BuilderResult<Self> {
+        let alias = self.infer_observed_alias(artifact)?;
+        if self.apps.contains_key(&alias) {
+            return Err(BuilderError::DuplicateAppAlias(alias));
+        }
+        validate_artifact(&alias, artifact)?;
+        self.validate_app_interfaces(&alias, artifact)?;
+        self.apps.insert(alias, artifact);
+        Ok(self)
+    }
+
+    fn app(&self, alias: &str) -> BuilderResult<&'a Artifact> {
+        self.apps.get(alias).copied().ok_or_else(|| BuilderError::UnknownAppAlias(alias.to_string()))
+    }
+
+    fn artifacts(&self) -> impl Iterator<Item = &'a Artifact> + '_ {
+        std::iter::once(self.primary).chain(self.apps.values().copied())
+    }
+}
+
 impl<'a> TxBuilder<'a> {
     pub fn new(artifact: &'a Artifact) -> BuilderResult<Self> {
-        artifact.check_schema_version()?;
-        artifact.verify_template_plan()?;
-        Ok(Self { artifact, observed_artifacts: Vec::new() })
+        Ok(Self { bundle: ArtifactBundle::new(artifact)? })
+    }
+
+    pub fn from_bundle(bundle: &ArtifactBundle<'a>) -> BuilderResult<Self> {
+        Ok(Self { bundle: bundle.clone() })
     }
 
     /// Attach another covenant app artifact that this artifact observes.
@@ -183,17 +343,59 @@ impl<'a> TxBuilder<'a> {
     /// supply foreign actor templates and state layouts for observed inputs and
     /// outputs, preserving the `app == covenant` boundary.
     pub fn with_observed_artifact(mut self, artifact: &'a Artifact) -> BuilderResult<Self> {
-        artifact.check_schema_version()?;
-        artifact.verify_template_plan()?;
-        self.observed_artifacts.push(artifact);
+        self.bundle = self.bundle.clone().attach_observed_artifact(artifact)?;
         Ok(self)
+    }
+
+    pub fn with_app(mut self, alias: impl Into<String>, artifact: &'a Artifact) -> BuilderResult<Self> {
+        self.bundle = self.bundle.clone().with_app(alias, artifact)?;
+        Ok(self)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn observed_outputs(
+        &self,
+        actor_name: &str,
+        entry_name: &str,
+        observe: &str,
+        context: &ObservedCovenantContext,
+        output_values: BTreeMap<String, u64>,
+        authorizing_input: u16,
+        covenant_id: Hash,
+    ) -> BuilderResult<Vec<TransactionOutput>> {
+        self.observed_covenant_outputs(ObservedCovenantOutputRequest {
+            actor_name,
+            entry_name,
+            observe,
+            context,
+            output_values,
+            authorizing_input,
+            covenant_id,
+        })
     }
 
     pub fn redeem_script(&self, actor_name: &str, source_state: BTreeMap<String, ArtifactValue>) -> BuilderResult<Vec<u8>> {
         let contract_ref = self.contract_ref(actor_name)?;
+        self.redeem_script_for_contract(contract_ref, source_state)
+    }
+
+    pub fn redeem_script_in_app(
+        &self,
+        app: &str,
+        actor_name: &str,
+        source_state: BTreeMap<String, ArtifactValue>,
+    ) -> BuilderResult<Vec<u8>> {
+        let contract_ref = self.contract_ref_in_app(app, actor_name)?;
+        self.redeem_script_for_contract(contract_ref, source_state)
+    }
+
+    fn redeem_script_for_contract(
+        &self,
+        contract_ref: ContractRef<'a>,
+        source_state: BTreeMap<String, ArtifactValue>,
+    ) -> BuilderResult<Vec<u8>> {
         let state = self.runtime_state_values(contract_ref.artifact, contract_ref.contract, source_state)?;
         let state_script = encode_runtime_state_script(&contract_ref.contract.runtime_state, &state)?;
-
         let mut script = decode_hex(&contract_ref.contract.compiled.template.prefix_hex)?;
         script.extend_from_slice(&state_script);
         script.extend_from_slice(&decode_hex(&contract_ref.contract.compiled.template.suffix_hex)?);
@@ -208,6 +410,15 @@ impl<'a> TxBuilder<'a> {
         Ok(pay_to_script_hash_script(&self.redeem_script(actor_name, source_state)?))
     }
 
+    pub fn script_public_key_in_app(
+        &self,
+        app: &str,
+        actor_name: &str,
+        source_state: BTreeMap<String, ArtifactValue>,
+    ) -> BuilderResult<kaspa_consensus_core::tx::ScriptPublicKey> {
+        Ok(pay_to_script_hash_script(&self.redeem_script_in_app(app, actor_name, source_state)?))
+    }
+
     pub fn p2sh_signature_script(
         &self,
         actor_name: &str,
@@ -216,6 +427,25 @@ impl<'a> TxBuilder<'a> {
         user_args: Vec<ArtifactValue>,
     ) -> BuilderResult<Vec<u8>> {
         self.p2sh_signature_script_with_context(actor_name, entry_name, input_source_state, user_args, &BTreeMap::new(), None)
+    }
+
+    pub fn p2sh_signature_script_in_app(
+        &self,
+        app: &str,
+        actor_name: &str,
+        entry_name: &str,
+        input_source_state: BTreeMap<String, ArtifactValue>,
+        user_args: Vec<ArtifactValue>,
+    ) -> BuilderResult<Vec<u8>> {
+        self.p2sh_signature_script_with_context_in_artifact(
+            self.bundle.app(app)?,
+            actor_name,
+            entry_name,
+            input_source_state,
+            user_args,
+            &BTreeMap::new(),
+            None,
+        )
     }
 
     pub fn p2sh_signature_script_with_template_selector(
@@ -266,11 +496,34 @@ impl<'a> TxBuilder<'a> {
         observed: Option<&BTreeMap<String, ObservedCovenantContext>>,
     ) -> BuilderResult<Vec<u8>> {
         let contract_ref = self.contract_ref(actor_name)?;
+        self.p2sh_signature_script_with_context_in_artifact(
+            contract_ref.artifact,
+            actor_name,
+            entry_name,
+            input_source_state,
+            user_args,
+            template_selectors,
+            observed,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn p2sh_signature_script_with_context_in_artifact(
+        &self,
+        artifact: &'a Artifact,
+        actor_name: &str,
+        entry_name: &str,
+        input_source_state: BTreeMap<String, ArtifactValue>,
+        user_args: Vec<ArtifactValue>,
+        template_selectors: &BTreeMap<String, String>,
+        observed: Option<&BTreeMap<String, ObservedCovenantContext>>,
+    ) -> BuilderResult<Vec<u8>> {
+        let contract_ref = self.contract_ref_in_artifact(artifact, actor_name)?;
         let contract = contract_ref.contract;
         let sil_entry = contract
             .entry(entry_name)
             .ok_or_else(|| BuilderError::UnknownEntry { actor: actor_name.to_string(), entry: entry_name.to_string() })?;
-        let entry_ref = self.entry_ref(actor_name, entry_name)?;
+        let entry_ref = self.entry_ref_in_artifact(artifact, actor_name, entry_name)?;
         let argent_entry = entry_ref.entry;
         for selector in template_selectors.keys() {
             if argent_entry.template_selectors.iter().all(|candidate| &candidate.name != selector) {
@@ -288,24 +541,30 @@ impl<'a> TxBuilder<'a> {
         for hidden in &argent_entry.hidden_params {
             args.push(match &hidden.purpose {
                 HiddenParamPurposeArtifact::TemplatePrefixBytes => {
-                    let actor = hidden_template_actor(hidden, argent_entry, template_selectors)?;
-                    ArtifactValue::Bytes(decode_hex(&self.contract(&actor)?.compiled.template.prefix_hex)?)
+                    let contract_ref =
+                        self.hidden_template_contract_ref(entry_ref.artifact, hidden, argent_entry, template_selectors)?;
+                    ArtifactValue::Bytes(decode_hex(&contract_ref.contract.compiled.template.prefix_hex)?)
                 }
                 HiddenParamPurposeArtifact::TemplateSuffixBytes => {
-                    let actor = hidden_template_actor(hidden, argent_entry, template_selectors)?;
-                    ArtifactValue::Bytes(decode_hex(&self.contract(&actor)?.compiled.template.suffix_hex)?)
+                    let contract_ref =
+                        self.hidden_template_contract_ref(entry_ref.artifact, hidden, argent_entry, template_selectors)?;
+                    ArtifactValue::Bytes(decode_hex(&contract_ref.contract.compiled.template.suffix_hex)?)
                 }
                 HiddenParamPurposeArtifact::TemplatePrefixLen => {
-                    let actor = hidden_actor_subject(hidden)?;
-                    ArtifactValue::Int(decode_hex(&self.contract(actor)?.compiled.template.prefix_hex)?.len() as i64)
+                    let contract_ref =
+                        self.hidden_template_contract_ref(entry_ref.artifact, hidden, argent_entry, template_selectors)?;
+                    ArtifactValue::Int(decode_hex(&contract_ref.contract.compiled.template.prefix_hex)?.len() as i64)
                 }
                 HiddenParamPurposeArtifact::TemplateSuffixLen => {
-                    let actor = hidden_actor_subject(hidden)?;
-                    ArtifactValue::Int(decode_hex(&self.contract(actor)?.compiled.template.suffix_hex)?.len() as i64)
+                    let contract_ref =
+                        self.hidden_template_contract_ref(entry_ref.artifact, hidden, argent_entry, template_selectors)?;
+                    ArtifactValue::Int(decode_hex(&contract_ref.contract.compiled.template.suffix_hex)?.len() as i64)
                 }
                 HiddenParamPurposeArtifact::RouteTemplateLeaf => {
                     let actor = hidden_actor_subject(hidden)?;
-                    ArtifactValue::Bytes(decode_hex(&self.contract(actor)?.compiled.template.hash_hex)?)
+                    ArtifactValue::Bytes(decode_hex(
+                        &self.contract_ref_in_artifact(entry_ref.artifact, actor)?.contract.compiled.template.hash_hex,
+                    )?)
                 }
                 HiddenParamPurposeArtifact::RouteTemplateProof => {
                     let actor = hidden_actor_subject(hidden)?;
@@ -339,7 +598,7 @@ impl<'a> TxBuilder<'a> {
 
         let sigscript = encode_entry_sig_script(&contract_ref.artifact.sil_abi, contract, sil_entry, &args)?;
         Ok(pay_to_script_hash_signature_script_with_flags(
-            self.redeem_script(actor_name, input_source_state)?,
+            self.redeem_script_for_contract(contract_ref, input_source_state)?,
             sigscript,
             covenant_engine_flags(),
         )?)
@@ -382,6 +641,22 @@ impl<'a> TxBuilder<'a> {
         })
     }
 
+    pub fn covenant_output_in_app(
+        &self,
+        app: &str,
+        actor_name: &str,
+        source_state: BTreeMap<String, ArtifactValue>,
+        value: u64,
+        authorizing_input: u16,
+        covenant_id: Hash,
+    ) -> BuilderResult<TransactionOutput> {
+        Ok(TransactionOutput {
+            value,
+            script_public_key: self.script_public_key_in_app(app, actor_name, source_state)?,
+            covenant: Some(CovenantBinding { authorizing_input, covenant_id }),
+        })
+    }
+
     pub fn covenant_utxo(
         &self,
         actor_name: &str,
@@ -392,6 +667,26 @@ impl<'a> TxBuilder<'a> {
         covenant_id: Option<Hash>,
     ) -> BuilderResult<UtxoEntry> {
         Ok(UtxoEntry::new(value, self.script_public_key(actor_name, source_state)?, block_daa_score, is_coinbase, covenant_id))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn covenant_utxo_in_app(
+        &self,
+        app: &str,
+        actor_name: &str,
+        source_state: BTreeMap<String, ArtifactValue>,
+        value: u64,
+        block_daa_score: u64,
+        is_coinbase: bool,
+        covenant_id: Option<Hash>,
+    ) -> BuilderResult<UtxoEntry> {
+        Ok(UtxoEntry::new(
+            value,
+            self.script_public_key_in_app(app, actor_name, source_state)?,
+            block_daa_score,
+            is_coinbase,
+            covenant_id,
+        ))
     }
 
     pub fn terminal_path_outputs(&self, request: TerminalPathOutputRequest<'_>) -> BuilderResult<Vec<TransactionOutput>> {
@@ -455,7 +750,8 @@ impl<'a> TxBuilder<'a> {
                 .output_values
                 .get(&observed_output.name)
                 .ok_or_else(|| BuilderError::MissingOutput(observed_output.name.clone()))?;
-            outputs.push(self.covenant_output(
+            outputs.push(self.covenant_output_in_app(
+                request.observe,
                 &output.actor,
                 output.state.clone(),
                 value,
@@ -482,6 +778,10 @@ impl<'a> TxBuilder<'a> {
         Ok(self.contract_ref(name)?.contract)
     }
 
+    pub fn contract_in_app(&self, app: &str, name: &str) -> BuilderResult<&'a SilContractArtifact> {
+        Ok(self.contract_ref_in_app(app, name)?.contract)
+    }
+
     fn contract_ref(&self, name: &str) -> BuilderResult<ContractRef<'a>> {
         for artifact in self.artifacts() {
             if let Some(contract) = artifact.sil_abi.contract(name) {
@@ -496,7 +796,36 @@ impl<'a> TxBuilder<'a> {
     }
 
     fn artifacts(&self) -> impl Iterator<Item = &'a Artifact> + '_ {
-        std::iter::once(self.artifact).chain(self.observed_artifacts.iter().copied())
+        self.bundle.artifacts()
+    }
+
+    fn contract_ref_in_artifact(&self, artifact: &'a Artifact, name: &str) -> BuilderResult<ContractRef<'a>> {
+        let contract = self.contract_in_artifact(artifact, name)?;
+        Ok(ContractRef { artifact, contract })
+    }
+
+    fn contract_ref_in_app(&self, app: &str, name: &str) -> BuilderResult<ContractRef<'a>> {
+        self.contract_ref_in_artifact(self.bundle.app(app)?, name)
+    }
+
+    fn hidden_template_contract_ref(
+        &self,
+        primary_artifact: &'a Artifact,
+        hidden: &HiddenParamArtifact,
+        entry: &EntryArtifact,
+        template_selectors: &BTreeMap<String, String>,
+    ) -> BuilderResult<ContractRef<'a>> {
+        match &hidden.subject {
+            HiddenParamSubjectArtifact::Actor { actor } => self.contract_ref_in_artifact(primary_artifact, actor),
+            HiddenParamSubjectArtifact::ObservedActor { observe, actor, .. } => self.contract_ref_in_app(observe, actor),
+            HiddenParamSubjectArtifact::TemplateSelector { .. } => {
+                let actor = hidden_template_actor(hidden, entry, template_selectors)?;
+                self.contract_ref_in_artifact(primary_artifact, &actor)
+            }
+            HiddenParamSubjectArtifact::RouteFamily { .. } => {
+                Err(BuilderError::UnexpectedHiddenSubject { param: hidden.name.clone(), expected: "actor or template selector" })
+            }
+        }
     }
 
     fn runtime_state_plan(&self, artifact: &'a Artifact, contract_name: &str) -> Option<&'a RuntimeStatePlanArtifact> {
@@ -512,12 +841,31 @@ impl<'a> TxBuilder<'a> {
         Err(BuilderError::UnknownActor(name.to_string()))
     }
 
+    fn argent_actor_ref_in_artifact(&self, artifact: &'a Artifact, name: &str) -> BuilderResult<ActorRef<'a>> {
+        artifact
+            .argent
+            .actors
+            .iter()
+            .find(|actor| actor.name == name)
+            .map(|actor| ActorRef { artifact, actor })
+            .ok_or_else(|| BuilderError::UnknownActor(name.to_string()))
+    }
+
     pub fn entry(&self, actor_name: &str, entry_name: &str) -> BuilderResult<&'a EntryArtifact> {
         Ok(self.entry_ref(actor_name, entry_name)?.entry)
     }
 
     fn entry_ref(&self, actor_name: &str, entry_name: &str) -> BuilderResult<EntryRef<'a>> {
         let actor_ref = self.argent_actor_ref(actor_name)?;
+        self.entry_ref_for_actor(actor_ref, actor_name, entry_name)
+    }
+
+    fn entry_ref_in_artifact(&self, artifact: &'a Artifact, actor_name: &str, entry_name: &str) -> BuilderResult<EntryRef<'a>> {
+        let actor_ref = self.argent_actor_ref_in_artifact(artifact, actor_name)?;
+        self.entry_ref_for_actor(actor_ref, actor_name, entry_name)
+    }
+
+    fn entry_ref_for_actor(&self, actor_ref: ActorRef<'a>, actor_name: &str, entry_name: &str) -> BuilderResult<EntryRef<'a>> {
         let entry = actor_ref
             .actor
             .entries
@@ -591,7 +939,7 @@ impl<'a> TxBuilder<'a> {
                 handle: input.name.clone(),
             })?;
             self.validate_observed_actor(observe_name, ObservedActorSideArtifact::Input, input, &observed.actor)?;
-            let expected_script_public_key = self.script_public_key(&observed.actor, observed.state.clone())?;
+            let expected_script_public_key = self.script_public_key_in_app(observe_name, &observed.actor, observed.state.clone())?;
             if observed.utxo.script_public_key != expected_script_public_key {
                 return Err(BuilderError::ObservedUtxoScriptMismatch {
                     observe: observe_name.to_string(),
@@ -625,7 +973,7 @@ impl<'a> TxBuilder<'a> {
                 handle: output.name.clone(),
             })?;
             self.validate_observed_actor(observe_name, ObservedActorSideArtifact::Output, output, &observed.actor)?;
-            self.redeem_script(&observed.actor, observed.state.clone())?;
+            self.redeem_script_in_app(observe_name, &observed.actor, observed.state.clone())?;
         }
         Ok(())
     }
@@ -699,11 +1047,20 @@ impl<'a> TxBuilder<'a> {
                         });
                     }
                     match role {
-                        RuntimeFieldRoleArtifact::Template { contract }
-                        | RuntimeFieldRoleArtifact::ObservedTemplate { contract, .. } => {
+                        RuntimeFieldRoleArtifact::Template { contract } => {
                             values.insert(
                                 field.name.clone(),
-                                ArtifactValue::Bytes(decode_hex(&self.contract(contract)?.compiled.template.hash_hex)?),
+                                ArtifactValue::Bytes(decode_hex(
+                                    &self.contract_in_artifact(artifact, contract)?.compiled.template.hash_hex,
+                                )?),
+                            );
+                        }
+                        RuntimeFieldRoleArtifact::ObservedTemplate { observe, contract, .. } => {
+                            values.insert(
+                                field.name.clone(),
+                                ArtifactValue::Bytes(decode_hex(
+                                    &self.contract_ref_in_app(observe, contract)?.contract.compiled.template.hash_hex,
+                                )?),
                             );
                         }
                         RuntimeFieldRoleArtifact::TemplateTable { contracts } => {
@@ -788,7 +1145,7 @@ impl<'a> TxBuilder<'a> {
     }
 
     pub fn route_family_table_bytes(&self, family_id: &str) -> BuilderResult<Vec<u8>> {
-        self.route_family_table_bytes_in_artifact(self.artifact, family_id)
+        self.route_family_table_bytes_in_artifact(self.bundle.primary, family_id)
     }
 
     fn route_family_table_bytes_in_artifact(&self, artifact: &'a Artifact, family_id: &str) -> BuilderResult<Vec<u8>> {
@@ -822,6 +1179,17 @@ impl<'a> TxBuilder<'a> {
         }
         Ok(table)
     }
+}
+
+fn validate_artifact(app: &str, artifact: &Artifact) -> BuilderResult<()> {
+    artifact.check_schema_version()?;
+    artifact.verify_template_plan()?;
+    artifact.verify_id().map_err(|source| BuilderError::ArtifactIdentity { app: app.to_string(), source })?;
+    Ok(())
+}
+
+fn find_interface<'a>(interfaces: &'a [ActorInterfaceArtifact], actor: &str) -> Option<&'a ActorInterfaceArtifact> {
+    interfaces.iter().find(|interface| interface.actor == actor)
 }
 
 fn hidden_actor_subject(hidden: &HiddenParamArtifact) -> BuilderResult<&str> {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -839,10 +839,11 @@ mod tests {
     fn observed_covenant_runtime_builds_icc_mint_and_rejects_mismatches() {
         let controller_artifact = icc_controller_artifact();
         let asset_artifact = icc_asset_artifact();
-        let builder = TxBuilder::new(&controller_artifact)
-            .expect("builder accepts controller artifact")
-            .with_observed_artifact(&asset_artifact)
-            .expect("builder accepts observed asset artifact");
+        let bundle = ArtifactBundle::new(&controller_artifact)
+            .expect("bundle accepts controller artifact")
+            .with_app("asset", &asset_artifact)
+            .expect("bundle accepts observed asset artifact");
+        let builder = TxBuilder::from_bundle(&bundle).expect("builder accepts artifact bundle");
         let owner = keypair_from_byte(9);
         let owner_pk = owner.x_only_public_key().0.serialize().to_vec();
         let recipient_owner = [0x55; 32].to_vec();
@@ -875,7 +876,7 @@ mod tests {
             "MinterProxy",
             proxy_state.clone(),
             builder
-                .covenant_utxo("MinterProxy", proxy_state.clone(), proxy_value, 0, false, Some(asset_covenant_id))
+                .covenant_utxo_in_app("asset", "MinterProxy", proxy_state.clone(), proxy_value, 0, false, Some(asset_covenant_id))
                 .expect("proxy utxo builds"),
             "KCC20",
             recipient_state.clone(),
@@ -896,7 +897,8 @@ mod tests {
         let proxy_utxo = observed.get("asset").unwrap().inputs.get("proxy").unwrap().utxo.clone();
         let entries = vec![minter_utxo.clone(), proxy_utxo.clone()];
         let proxy_sigscript = builder
-            .p2sh_signature_script(
+            .p2sh_signature_script_in_app(
+                "asset",
                 "MinterProxy",
                 "mint",
                 proxy_state.clone(),
@@ -935,8 +937,8 @@ mod tests {
 
         let minter_contract = builder.contract("Minter").expect("Minter contract exists");
         let minter_entry = minter_contract.entry("mint").expect("mint entry exists");
-        let mut bad_proxy_suffix =
-            decode_hex(&builder.contract("MinterProxy").unwrap().compiled.template.suffix_hex).expect("proxy suffix decodes");
+        let mut bad_proxy_suffix = decode_hex(&builder.contract_in_app("asset", "MinterProxy").unwrap().compiled.template.suffix_hex)
+            .expect("proxy suffix decodes");
         bad_proxy_suffix.push(0);
         let corrupt_hidden_sigscript = encode_entry_sig_script(
             &controller_artifact.sil_abi,
@@ -947,14 +949,17 @@ mod tests {
                 ArtifactValue::Bytes(recipient_owner.clone()),
                 ArtifactValue::Int(minted_amount),
                 ArtifactValue::Bytes(
-                    decode_hex(&builder.contract("MinterProxy").unwrap().compiled.template.prefix_hex).expect("proxy prefix decodes"),
+                    decode_hex(&builder.contract_in_app("asset", "MinterProxy").unwrap().compiled.template.prefix_hex)
+                        .expect("proxy prefix decodes"),
                 ),
                 ArtifactValue::Bytes(bad_proxy_suffix),
                 ArtifactValue::Bytes(
-                    decode_hex(&builder.contract("KCC20").unwrap().compiled.template.prefix_hex).expect("KCC20 prefix decodes"),
+                    decode_hex(&builder.contract_in_app("asset", "KCC20").unwrap().compiled.template.prefix_hex)
+                        .expect("KCC20 prefix decodes"),
                 ),
                 ArtifactValue::Bytes(
-                    decode_hex(&builder.contract("KCC20").unwrap().compiled.template.suffix_hex).expect("KCC20 suffix decodes"),
+                    decode_hex(&builder.contract_in_app("asset", "KCC20").unwrap().compiled.template.suffix_hex)
+                        .expect("KCC20 suffix decodes"),
                 ),
             ],
         )
@@ -1102,6 +1107,59 @@ mod tests {
         assert!(execute_input_with_covenants(&wrong_asset_tx, wrong_asset_entries, 0).is_err());
     }
 
+    #[test]
+    fn artifact_bundle_rejects_bad_ids_and_interface_mismatches() {
+        let controller_artifact = icc_controller_artifact();
+        let asset_artifact = icc_asset_artifact();
+
+        controller_artifact.verify_id().expect("controller artifact id is stable");
+        asset_artifact.verify_id().expect("asset artifact id is stable");
+        let bundle = ArtifactBundle::new(&controller_artifact)
+            .expect("bundle accepts controller artifact")
+            .with_app("asset", &asset_artifact)
+            .expect("matching observed artifact attaches");
+        TxBuilder::from_bundle(&bundle).expect("builder accepts valid bundle");
+        TxBuilder::new(&controller_artifact)
+            .expect("builder accepts controller artifact")
+            .with_observed_artifact(&asset_artifact)
+            .expect("legacy observed artifact attach infers the observed alias")
+            .contract_in_app("asset", "MinterProxy")
+            .expect("inferred alias exposes the observed asset app");
+
+        let wrong_alias_err = ArtifactBundle::new(&controller_artifact)
+            .expect("controller artifact remains valid")
+            .with_app("wrong", &asset_artifact)
+            .expect_err("unknown observed app alias is rejected");
+        assert!(matches!(wrong_alias_err, BuilderError::UnknownObservedAppAlias(alias) if alias == "wrong"));
+
+        let mut bad_id_asset = asset_artifact.clone();
+        bad_id_asset.id = "00".repeat(32);
+        let bad_id_err = ArtifactBundle::new(&controller_artifact)
+            .expect("controller artifact remains valid")
+            .with_app("asset", &bad_id_asset)
+            .expect_err("bad observed artifact id is rejected");
+        assert!(matches!(bad_id_err, BuilderError::ArtifactIdentity { app, .. } if app == "asset"));
+
+        let mut bad_interface_asset = asset_artifact.clone();
+        let proxy_export = bad_interface_asset
+            .argent
+            .interfaces
+            .exports
+            .iter_mut()
+            .find(|interface| interface.actor == "MinterProxy")
+            .expect("asset exports MinterProxy");
+        proxy_export.fingerprint_hex = "11".repeat(32);
+        bad_interface_asset.id = bad_interface_asset.computed_id_hex().expect("mutated artifact id computes");
+        let mismatch_err = ArtifactBundle::new(&controller_artifact)
+            .expect("controller artifact remains valid")
+            .with_app("asset", &bad_interface_asset)
+            .expect_err("interface fingerprint mismatch is rejected");
+        assert!(
+            matches!(&mismatch_err, BuilderError::InterfaceMismatch { app, actor, .. } if app == "asset" && actor == "MinterProxy"),
+            "unexpected error: {mismatch_err}"
+        );
+    }
+
     fn tickets_artifact() -> Artifact {
         example_artifact("examples/tickets.ag", "tickets")
     }
@@ -1247,16 +1305,10 @@ mod tests {
     ) -> BTreeMap<String, ObservedCovenantContext> {
         BTreeMap::from([(
             "asset".to_string(),
-            ObservedCovenantContext {
-                inputs: BTreeMap::from([(
-                    "proxy".to_string(),
-                    ObservedInput { actor: proxy_actor.to_string(), state: proxy_state.clone(), utxo: proxy_utxo },
-                )]),
-                outputs: BTreeMap::from([
-                    ("proxy".to_string(), ObservedOutput { actor: proxy_actor.to_string(), state: proxy_state }),
-                    ("recipient".to_string(), ObservedOutput { actor: recipient_actor.to_string(), state: recipient_state }),
-                ]),
-            },
+            ObservedCovenantContext::new()
+                .input("proxy", proxy_actor, proxy_utxo, proxy_state.clone())
+                .output("proxy", proxy_actor, proxy_state)
+                .output("recipient", recipient_actor, recipient_state),
         )])
     }
 
@@ -1278,15 +1330,15 @@ mod tests {
         ];
         outputs.extend(
             builder
-                .observed_covenant_outputs(ObservedCovenantOutputRequest {
-                    actor_name: "Minter",
-                    entry_name: "mint",
-                    observe: "asset",
-                    context: observed.get("asset").expect("asset observed context exists"),
-                    output_values: BTreeMap::from([("proxy".to_string(), proxy_value), ("recipient".to_string(), recipient_value)]),
-                    authorizing_input: 1,
-                    covenant_id: asset_covenant_id,
-                })
+                .observed_outputs(
+                    "Minter",
+                    "mint",
+                    "asset",
+                    observed.get("asset").expect("asset observed context exists"),
+                    BTreeMap::from([("proxy".to_string(), proxy_value), ("recipient".to_string(), recipient_value)]),
+                    1,
+                    asset_covenant_id,
+                )
                 .expect("observed asset outputs build"),
         );
         outputs

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -3094,18 +3094,56 @@ fn emit_artifact(program: &Program, model: &Model<'_>, actor_sil: &BTreeMap<Stri
         .collect::<Vec<_>>();
     let argent_actors = model.actors.iter().map(|actor| actor_artifact(actor, model)).collect::<Result<Vec<_>>>()?;
     let template_plan = template_plan_artifact(model, &templates, &argent_actors, &sil_contracts)?;
+    let interfaces = interface_set_artifact(model)?;
 
-    let artifact = Artifact {
+    let mut artifact = Artifact {
         schema_version: ARTIFACT_SCHEMA_VERSION,
+        id: String::new(),
         generator: GeneratorArtifact { name: "argentc".to_string(), version: env!("CARGO_PKG_VERSION").to_string() },
         app: model.app_name.clone(),
         root: manifest_path(&program.root),
         modules: program.modules.iter().map(|module| manifest_path(&module.path)).collect(),
-        argent: ArgentArtifact { templates, template_plan, states: states.clone(), actor_enums, actors: argent_actors },
+        argent: ArgentArtifact { templates, template_plan, interfaces, states: states.clone(), actor_enums, actors: argent_actors },
         sil_abi: SilAbiArtifact { schema_version: SIL_ABI_SCHEMA_VERSION, states, contracts: sil_contracts },
     };
     artifact.verify_template_plan().map_err(|err| ArgentError::new(format!("invalid template plan receipt: {err}")))?;
+    artifact.id = artifact.computed_id_hex().map_err(|err| ArgentError::new(format!("failed to compute artifact id: {err}")))?;
     Ok(artifact)
+}
+
+fn interface_set_artifact(model: &Model<'_>) -> Result<InterfaceSetArtifact> {
+    let exports = model.template_actors.iter().map(|actor| actor_interface_artifact(actor, model)).collect::<Result<Vec<_>>>()?;
+
+    let mut imported_actors = BTreeSet::new();
+    let template_actor_set = model.template_actors.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    for actor in &model.actors {
+        for entry in &actor.entries {
+            for observe in &entry.observes {
+                for observed in observe.inputs.iter().chain(observe.outputs.iter()) {
+                    if !template_actor_set.contains(observed.actor.as_str()) {
+                        imported_actors.insert(observed.actor.clone());
+                    }
+                }
+            }
+        }
+    }
+    let imports = imported_actors.iter().map(|actor| actor_interface_artifact(actor, model)).collect::<Result<Vec<_>>>()?;
+
+    Ok(InterfaceSetArtifact { exports, imports })
+}
+
+fn actor_interface_artifact(actor_name: &str, model: &Model<'_>) -> Result<ActorInterfaceArtifact> {
+    let actor = model.actor(actor_name)?;
+    let state = model.state(&actor.state)?;
+    let runtime_fields = runtime_state_fields(state, model);
+    let fingerprint_hex = actor_interface_fingerprint_hex(&actor.name, &actor.state, &runtime_fields)
+        .map_err(|err| ArgentError::new(format!("failed to compute actor interface fingerprint for `{}`: {err}", actor.name)))?;
+    Ok(ActorInterfaceArtifact {
+        id: actor_interface_id(&actor.name),
+        actor: actor.name.clone(),
+        state: actor.state.clone(),
+        fingerprint_hex,
+    })
 }
 
 fn template_ref_artifact(actor: &str) -> TemplateRefArtifact {


### PR DESCRIPTION
This PR adds proper artifact bundle support for multi-app runtime construction.

The main use case is ICC / observed-covenant composition: a controller app can observe another covenant app by alias, and `argent-runtime` now verifies that the attached artifact really exports the actor interfaces the controller compiled against.

Argent source stays semantic:

```js
observes asset by self.kcc20_covid {
    inputs {
        proxy: MinterProxy;
    }

    outputs {
        proxy: MinterProxy;
        recipient: KCC20;
    }
}
```

Runtime construction now has an explicit bundle boundary:

```rust
let bundle = ArtifactBundle::new(&controller_artifact)?
    .with_app("asset", &asset_artifact)?;

let builder = TxBuilder::from_bundle(&bundle)?;

let observed = ObservedCovenantContext::new()
    .input("proxy", "MinterProxy", proxy_utxo, proxy_state)
    .output("proxy", "MinterProxy", next_proxy_state)
    .output("recipient", "KCC20", recipient_state);

let outputs = builder.observed_outputs(
    "Minter",
    "mint",
    "asset",
    &observed,
    output_values,
    1,
    asset_covenant_id,
)?;
```

Changes:

- adds stable artifact ids derived from artifact content
- adds exported/imported actor interface fingerprints
- adds `ArtifactBundle` as the explicit runtime composition object
- keeps `TxBuilder::new(&artifact)` for single-artifact usage
- adds `TxBuilder::from_bundle(&bundle)` for multi-artifact usage
- resolves observed actors through app aliases instead of global actor-name lookup
- rejects bad artifact ids, duplicate aliases, unknown aliases, and interface mismatches
- adds fluent `ObservedCovenantContext` helpers
- adds alias-aware runtime helpers for observed app outputs, UTXOs, sigscripts, and contracts
- updates ICC runtime tests to use the bundle API
- regenerates checked-in build artifacts with ids and interface metadata

Verification:

```text
./check.sh --full
```