### PR TITLE
Improve runtime ergonomics for playground demos

### DIFF
--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -41,6 +41,147 @@ use thiserror::Error;
 
 pub type BuilderResult<T> = std::result::Result<T, BuilderError>;
 
+pub trait IntoArtifactValue {
+    fn into_artifact_value(self) -> ArtifactValue;
+}
+
+impl IntoArtifactValue for ArtifactValue {
+    fn into_artifact_value(self) -> ArtifactValue {
+        self
+    }
+}
+
+macro_rules! impl_int_artifact_value {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl IntoArtifactValue for $ty {
+                fn into_artifact_value(self) -> ArtifactValue {
+                    ArtifactValue::Int(self as i64)
+                }
+            }
+        )*
+    };
+}
+
+impl_int_artifact_value!(i8, i16, i32, i64, isize, u16, u32);
+
+impl IntoArtifactValue for bool {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Bool(self)
+    }
+}
+
+impl IntoArtifactValue for u8 {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Byte(self)
+    }
+}
+
+impl IntoArtifactValue for Vec<u8> {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Bytes(self)
+    }
+}
+
+impl IntoArtifactValue for &[u8] {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Bytes(self.to_vec())
+    }
+}
+
+impl<const N: usize> IntoArtifactValue for [u8; N] {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Bytes(self.to_vec())
+    }
+}
+
+impl<const N: usize> IntoArtifactValue for &[u8; N] {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Bytes(self.to_vec())
+    }
+}
+
+impl IntoArtifactValue for Hash {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Bytes(self.as_bytes().to_vec())
+    }
+}
+
+impl IntoArtifactValue for &Hash {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Bytes(self.as_bytes().to_vec())
+    }
+}
+
+impl IntoArtifactValue for String {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Text(self)
+    }
+}
+
+impl IntoArtifactValue for &str {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Text(self.to_string())
+    }
+}
+
+impl IntoArtifactValue for BTreeMap<String, ArtifactValue> {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Object(self)
+    }
+}
+
+/// Build an Argent source-state object for `TxBuilder` calls.
+///
+/// Returns a `BTreeMap<String, ArtifactValue>` keyed by Argent source field
+/// name. Each value is converted through `IntoArtifactValue`.
+///
+/// ```
+/// use argent_runtime::state;
+///
+/// // Builds:
+/// // BTreeMap::from([("count".to_string(), ArtifactValue::Int(2))])
+/// let counter = state! {
+///     count: 2,
+/// };
+/// ```
+#[macro_export]
+macro_rules! state {
+    ($($field:ident : $value:expr),* $(,)?) => {{
+        let mut state = ::std::collections::BTreeMap::new();
+        $(
+            state.insert(
+                ::std::string::ToString::to_string(stringify!($field)),
+                $crate::IntoArtifactValue::into_artifact_value($value),
+            );
+        )*
+        state
+    }};
+}
+
+/// Build Argent entrypoint argument values for `TxBuilder` calls.
+///
+/// Returns a `Vec<ArtifactValue>` in entrypoint parameter order. Each value is
+/// converted through `IntoArtifactValue`.
+///
+/// ```
+/// use argent_runtime::args;
+///
+/// // Builds:
+/// // vec![ArtifactValue::Int(3), ArtifactValue::Bool(true)]
+/// let args = args![3, true];
+/// ```
+#[macro_export]
+macro_rules! args {
+    ($($value:expr),* $(,)?) => {{
+        vec![
+            $(
+                $crate::IntoArtifactValue::into_artifact_value($value),
+            )*
+        ]
+    }};
+}
+
 #[derive(Debug, Error)]
 pub enum BuilderError {
     #[error(transparent)]
@@ -1472,4 +1613,41 @@ pub fn execute_input_with_covenants(tx: &Transaction, entries: Vec<UtxoEntry>, i
 
 pub fn covenant_engine_flags() -> EngineFlags {
     EngineFlags { covenants_enabled: true, ..Default::default() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_macro_builds_artifact_value_map() {
+        let covenant_id = Hash::from_bytes([0x44; 32]);
+        let nested = state! {
+            hunger: 7,
+        };
+
+        let value = state! {
+            count: 2,
+            ready: true,
+            tag: [0xaa_u8; 2],
+            controller: covenant_id,
+            label: "counter",
+            nested: nested.clone(),
+        };
+
+        assert_eq!(value.get("count"), Some(&ArtifactValue::Int(2)));
+        assert_eq!(value.get("ready"), Some(&ArtifactValue::Bool(true)));
+        assert_eq!(value.get("tag"), Some(&ArtifactValue::Bytes(vec![0xaa; 2])));
+        assert_eq!(value.get("controller"), Some(&ArtifactValue::Bytes(vec![0x44; 32])));
+        assert_eq!(value.get("label"), Some(&ArtifactValue::Text("counter".to_string())));
+        assert_eq!(value.get("nested"), Some(&ArtifactValue::Object(nested)));
+    }
+
+    #[test]
+    fn args_macro_builds_artifact_value_list() {
+        assert_eq!(
+            args![3, true, [0xaa_u8; 2]],
+            vec![ArtifactValue::Int(3), ArtifactValue::Bool(true), ArtifactValue::Bytes(vec![0xaa; 2])]
+        );
+    }
 }

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -23,10 +23,11 @@ use argent_artifact::{
 };
 use kaspa_consensus_core::{
     Hash,
+    errors::tx::PopulateGenesisCovenantsError,
     hashing::sighash::SigHashReusedValuesUnsync,
     tx::{
-        CovenantBinding, PopulatedTransaction, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, UtxoEntry,
-        VerifiableTransaction,
+        CovenantBinding, GenesisCovenantGroup, PopulatedTransaction, Transaction, TransactionInput, TransactionOutpoint,
+        TransactionOutput, UtxoEntry, VerifiableTransaction,
     },
 };
 use kaspa_txscript::{
@@ -194,6 +195,8 @@ pub enum BuilderError {
     ScriptBuilder(#[from] ScriptBuilderError),
     #[error(transparent)]
     TxScript(#[from] TxScriptError),
+    #[error(transparent)]
+    PopulateGenesisCovenants(#[from] PopulateGenesisCovenantsError),
     #[error("unknown actor `{0}`")]
     UnknownActor(String),
     #[error("artifact bundle app alias `{0}` is already attached")]
@@ -268,6 +271,10 @@ pub enum BuilderError {
     DuplicateOutput(String),
     #[error("unsupported route without a named output")]
     UnnamedRouteOutput,
+    #[error("genesis covenant output {0} was not populated")]
+    MissingGenesisCovenantOutput(u32),
+    #[error("genesis covenant output {0} does not exist")]
+    UnknownGenesisOutput(u32),
 }
 
 #[derive(Clone, Debug)]
@@ -278,6 +285,45 @@ pub struct ArtifactBundle<'a> {
 
 pub struct TxBuilder<'a> {
     bundle: ArtifactBundle<'a>,
+}
+
+/// Result of populating genesis covenant bindings on a transaction.
+///
+/// A launch transaction may create several covenant groups, and each group may
+/// bind several outputs to the same covenant id.
+pub struct GenesisCovenants {
+    pub groups: Vec<GenesisCovenant>,
+}
+
+impl GenesisCovenants {
+    /// Return the populated genesis output by transaction output index.
+    pub fn output(&self, index: u32) -> BuilderResult<&GenesisOutput> {
+        self.groups
+            .iter()
+            .flat_map(|group| group.outputs.iter())
+            .find(|output| output.index == index)
+            .ok_or(BuilderError::UnknownGenesisOutput(index))
+    }
+}
+
+/// One populated genesis covenant group.
+///
+/// Mirrors one `GenesisCovenantGroup`: all `outputs` share `covenant_id`, which
+/// is derived from the authorizing input outpoint and the exact output list.
+pub struct GenesisCovenant {
+    pub authorizing_input: u16,
+    pub covenant_id: Hash,
+    pub outputs: Vec<GenesisOutput>,
+}
+
+/// A concrete output created by a genesis covenant transaction.
+///
+/// The `outpoint` and `utxo` are the handles needed by the first covenant spend.
+pub struct GenesisOutput {
+    pub index: u32,
+    pub covenant_id: Hash,
+    pub outpoint: TransactionOutpoint,
+    pub utxo: UtxoEntry,
 }
 
 struct ContractRef<'a> {
@@ -494,6 +540,66 @@ impl<'a> TxBuilder<'a> {
         source_state: BTreeMap<String, ArtifactValue>,
     ) -> BuilderResult<kaspa_consensus_core::tx::ScriptPublicKey> {
         Ok(pay_to_script_hash_script(&self.redeem_script_in_app(app, actor_name, source_state)?))
+    }
+
+    /// Build an actor output before it has a covenant id.
+    ///
+    /// The returned output has the correct P2SH script for `actor_name(state)`
+    /// and `covenant: None`, ready for `Transaction::populate_genesis_covenants`.
+    pub fn genesis_output(
+        &self,
+        actor_name: &str,
+        source_state: BTreeMap<String, ArtifactValue>,
+        value: u64,
+    ) -> BuilderResult<TransactionOutput> {
+        Ok(TransactionOutput::new(value, self.script_public_key(actor_name, source_state)?))
+    }
+
+    /// Build an actor output in an attached app before it has a covenant id.
+    ///
+    /// This is the multi-app variant of `genesis_output`.
+    pub fn genesis_output_in_app(
+        &self,
+        app: &str,
+        actor_name: &str,
+        source_state: BTreeMap<String, ArtifactValue>,
+        value: u64,
+    ) -> BuilderResult<TransactionOutput> {
+        Ok(TransactionOutput::new(value, self.script_public_key_in_app(app, actor_name, source_state)?))
+    }
+
+    /// Populate genesis covenant bindings and return first-spend handles.
+    ///
+    /// This wraps `Transaction::populate_genesis_covenants`, finalizes the tx
+    /// after mutation, and reports covenant ids, outpoints, and UTXO entries for
+    /// the populated outputs.
+    pub fn populate_genesis_covenants(tx: &mut Transaction, groups: &[GenesisCovenantGroup]) -> BuilderResult<GenesisCovenants> {
+        tx.populate_genesis_covenants(groups)?;
+        tx.finalize();
+
+        let tx_id = tx.id();
+        let is_coinbase = tx.is_coinbase();
+        let mut populated_groups = Vec::with_capacity(groups.len());
+        for group in groups {
+            let first_output_index = group.outputs.first().copied().ok_or(PopulateGenesisCovenantsError::EmptyOutputs)?;
+            let first_output =
+                tx.outputs.get(first_output_index as usize).ok_or(BuilderError::UnknownGenesisOutput(first_output_index))?;
+            let covenant_id = first_output.covenant.ok_or(BuilderError::MissingGenesisCovenantOutput(first_output_index))?.covenant_id;
+            let mut outputs = Vec::with_capacity(group.outputs.len());
+            for &index in &group.outputs {
+                let output = tx.outputs.get(index as usize).ok_or(BuilderError::UnknownGenesisOutput(index))?;
+                let binding = output.covenant.ok_or(BuilderError::MissingGenesisCovenantOutput(index))?;
+                outputs.push(GenesisOutput {
+                    index,
+                    covenant_id: binding.covenant_id,
+                    outpoint: TransactionOutpoint::new(tx_id, index),
+                    utxo: UtxoEntry::new(output.value, output.script_public_key.clone(), 0, is_coinbase, Some(binding.covenant_id)),
+                });
+            }
+            populated_groups.push(GenesisCovenant { authorizing_input: group.authorizing_input, covenant_id, outputs });
+        }
+
+        Ok(GenesisCovenants { groups: populated_groups })
     }
 
     pub fn p2sh_signature_script(
@@ -1649,5 +1755,47 @@ mod tests {
             args![3, true, [0xaa_u8; 2]],
             vec![ArtifactValue::Int(3), ArtifactValue::Bool(true), ArtifactValue::Bytes(vec![0xaa; 2])]
         );
+    }
+
+    #[test]
+    fn populate_genesis_covenants_reports_multiple_groups() {
+        let funding_outpoint = TransactionOutpoint::new(Hash::from_bytes([0x91; 32]), 0);
+        let mut tx = TxBuilder::transaction(
+            vec![TxBuilder::transaction_input(funding_outpoint, Vec::new())],
+            vec![
+                TransactionOutput::new(1_000, Default::default()),
+                TransactionOutput::new(2_000, Default::default()),
+                TransactionOutput::new(3_000, Default::default()),
+                TransactionOutput::new(4_000, Default::default()),
+            ],
+        );
+
+        let genesis = TxBuilder::populate_genesis_covenants(
+            &mut tx,
+            &[GenesisCovenantGroup::new(0, vec![0, 2]), GenesisCovenantGroup::new(0, vec![1, 3])],
+        )
+        .expect("genesis covenant population succeeds");
+
+        assert_eq!(genesis.groups.len(), 2);
+        assert_eq!(genesis.groups[0].outputs.len(), 2);
+        assert_eq!(genesis.groups[1].outputs.len(), 2);
+        assert_ne!(genesis.groups[0].covenant_id, genesis.groups[1].covenant_id);
+
+        let output_0 = genesis.output(0).expect("output 0 handle exists");
+        let output_2 = genesis.output(2).expect("output 2 handle exists");
+        assert_eq!(output_0.covenant_id, genesis.groups[0].covenant_id);
+        assert_eq!(output_2.covenant_id, genesis.groups[0].covenant_id);
+        assert_eq!(output_0.outpoint, TransactionOutpoint::new(tx.id(), 0));
+        assert_eq!(output_2.outpoint, TransactionOutpoint::new(tx.id(), 2));
+        assert_eq!(output_0.utxo.amount, tx.outputs[0].value);
+        assert_eq!(output_0.utxo.script_public_key, tx.outputs[0].script_public_key);
+        assert_eq!(output_0.utxo.covenant_id, Some(output_0.covenant_id));
+
+        let output_1 = genesis.output(1).expect("output 1 handle exists");
+        let output_3 = genesis.output(3).expect("output 3 handle exists");
+        assert_eq!(output_1.covenant_id, genesis.groups[1].covenant_id);
+        assert_eq!(output_3.covenant_id, genesis.groups[1].covenant_id);
+        assert_eq!(tx.outputs[1].covenant.expect("output 1 covenant").covenant_id, output_1.covenant_id);
+        assert!(matches!(genesis.output(99), Err(BuilderError::UnknownGenesisOutput(99))));
     }
 }

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1,0 +1,57 @@
+# Argent follow-ups
+
+Small design and compiler notes that are worth keeping, but not yet ready for
+their own branch or design doc.
+
+## Expanded capsules and route templates
+
+Check what happens when a capsule state is extended by another app, and that
+extending app has multiple actors whose route graph requires generated template
+fields.
+
+The core invariant to preserve:
+
+- the base capsule ABI observed by another app remains stable
+- expanded states can satisfy `actor<BaseCapsule>` handles
+- hidden route/template fields needed by the extending app do not leak into the
+  observed capsule ABI
+- generated state-layout/cut validation rejects mismatched compiled layouts
+
+Useful fixture:
+
+```rust
+state AgentCapsule {
+    covid controller_id;
+    virtual strategy;
+}
+
+state ForagerState expands AgentCapsule {
+    strategy: ForagerStrategy;
+}
+
+state TraderState expands AgentCapsule {
+    strategy: TraderStrategy;
+}
+
+actor Forager owns ForagerState {
+    entry become_trader() emits one Trader {
+        become Trader(next_trader);
+    }
+}
+```
+
+## Leader and delegate entrypoint relations
+
+Clarify how paired transaction inputs relate when one entrypoint leads a
+transition and another entrypoint authorizes or mirrors it.
+
+Things to make explicit in docs/tests:
+
+- co-spend presence proves only that a covenant id appears in the transaction
+- peer covenant ids in state bind which counterparty is authorized
+- shared output validation is what makes two inputs agree on the same transition
+- runtime builder pairing is convenience, not covenant security
+
+Open question: should Argent eventually have source syntax for declaring a
+paired entry relation, or should this remain expressed through `observes`,
+`authorized()`, consumed inputs, and output checks?

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -55,3 +55,43 @@ Things to make explicit in docs/tests:
 Open question: should Argent eventually have source syntax for declaring a
 paired entry relation, or should this remain expressed through `observes`,
 `authorized()`, consumed inputs, and output checks?
+
+## Genesis launch roots
+
+Expose artifact/runtime guidance for actors that look genesis-created: actors
+with no incoming non-self creation route in the app graph.
+
+This should probably feed a future launch-plan API or warning, not the low-level
+`populate_genesis_covenants` helper. The low-level helper should keep doing
+exactly what the caller asked for: bind the provided transaction output groups.
+
+The useful invariant is advisory: if an actor has no way to be created by
+another actor in the same covenant, a launcher likely needs to create at least
+one genesis output for it, unless the app intentionally leaves that actor
+unlaunched.
+
+## Launch proofs
+
+Support producing and verifying a launch proof for one genesis covenant group.
+Each group launches one covenant; a transaction that launches multiple covenants
+can carry multiple launch proofs.
+
+The proof should include:
+
+- the authorizing funding outpoint
+- the covenant id derived from that outpoint and the ordered launch outputs
+- each initial actor state
+- each output's redeem-script preimage: template prefix, encoded state, template
+  suffix
+- each corresponding P2SH script public key
+
+Verification should show:
+
+- the actor state encodes to the claimed redeem script
+- the redeem script hashes to the launch output script public key
+- the ordered outputs and authorizing outpoint recompute the covenant id
+
+The goal is to explain a covenant id already seen in a live UTXO: given the
+funding outpoint and initial actor states, show exactly how that id was
+launched, so auditing the contracts and initial states gives confidence in the
+live covenant.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 pub mod artifact;
 pub mod ast;
 pub mod builder;
@@ -10,3 +12,90 @@ pub mod parser;
 pub mod routes;
 
 pub use error::{ArgentError, Result};
+
+/// Compile an inline Argent source string and return its artifact.
+///
+/// `source_label` is used for diagnostics and module identity; it does not
+/// need to exist on disk.
+pub fn compile_inline(source_label: impl AsRef<Path>, source: impl Into<String>) -> Result<artifact::Artifact> {
+    let nonce =
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|duration| duration.as_nanos()).unwrap_or_default();
+    let out_dir = std::env::temp_dir().join(format!("argent-inline-{}-{nonce}", std::process::id()));
+    let artifact = build_inline(source_label, source, &out_dir);
+    if artifact.is_ok() {
+        let _ = std::fs::remove_dir_all(&out_dir);
+    }
+    artifact
+}
+
+/// Build an inline Argent source string into `out_dir` and return its artifact.
+///
+/// This writes the same generated files as `argentc build`, including
+/// `artifact.json`, `manifest.json`, and generated Silverscript contracts.
+pub fn build_inline(
+    source_label: impl AsRef<Path>,
+    source: impl Into<String>,
+    out_dir: impl AsRef<Path>,
+) -> Result<artifact::Artifact> {
+    let source_label = source_label.as_ref().to_path_buf();
+    let program = inline_program(source_label, source.into())?;
+    emit::emit_build(&program, out_dir.as_ref())?;
+    read_artifact(out_dir.as_ref())
+}
+
+fn inline_program(source_label: PathBuf, source: String) -> Result<ast::Program> {
+    let module = parser::parse_module(source_label.clone(), source)?;
+    Ok(ast::Program { root: source_label, modules: vec![module] })
+}
+
+fn read_artifact(out_dir: &Path) -> Result<artifact::Artifact> {
+    let path = out_dir.join("artifact.json");
+    let json = std::fs::read_to_string(&path)?;
+    serde_json::from_str(&json).map_err(|err| ArgentError::at(path, err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const COUNTER_APP: &str = r#"
+state CounterState {
+    int count;
+}
+
+actor Counter owns CounterState {
+    entry bump(delta: int) emits one Counter {
+        CounterState next = {
+            count: count + delta,
+        };
+
+        become Counter(next);
+    }
+}
+
+app CounterApp {
+    actor Counter;
+}
+"#;
+
+    #[test]
+    fn compile_inline_returns_artifact_without_a_user_output_dir() {
+        let artifact = compile_inline("counter.ag", COUNTER_APP).expect("inline app compiles");
+        assert_eq!(artifact.app, "CounterApp");
+        assert!(artifact.sil_abi.contract("Counter").is_some());
+    }
+
+    #[test]
+    fn build_inline_writes_outputs_and_returns_artifact() {
+        let out_dir = std::env::temp_dir().join(format!("argent-build-inline-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&out_dir);
+
+        let artifact = build_inline("counter.ag", COUNTER_APP, &out_dir).expect("inline app builds");
+
+        assert_eq!(artifact.app, "CounterApp");
+        assert!(out_dir.join("artifact.json").exists());
+        assert!(out_dir.join("sil").join("Counter.sil").exists());
+
+        let _ = std::fs::remove_dir_all(out_dir);
+    }
+}


### PR DESCRIPTION
This PR adds small runtime/DX helpers used by [the Argent playground repo](https://github.com/michaelsutton/argent-playground).

Changes:

- adds inline compile/build helpers for embedding `.ag` source in Rust demos
- adds `state!` and `args!` macros for concise runtime values
- adds genesis covenant helpers:
  - `TxBuilder::genesis_output`
  - `TxBuilder::genesis_output_in_app`
  - `TxBuilder::populate_genesis_covenants`
- returns first-spend handles for populated genesis outputs: covenant id, outpoint, and UTXO
- adds runtime coverage for multiple genesis covenant groups
- records follow-up notes for launch roots, launch proofs, expanded capsules, and paired entry relations