### PR TITLE
fix: normalize CRLF before indenting helper function bodies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,12 @@
 *.sil linguist-language=JavaScript
 *.ag linguist-language=Rust
+
+# Force LF endings for source and generated files regardless of platform
+# checkout settings (e.g. Windows core.autocrlf=true). The compiler is
+# content-hashed and byte-reproducibility across platforms depends on
+# consistent line endings in .ag sources and generated .sil output.
+*.ag text eol=lf
+*.sil text eol=lf
+*.rs text eol=lf
+*.md text eol=lf
+*.json text eol=lf

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -5543,7 +5543,13 @@ fn compact_expr(input: &str) -> String {
 
 fn indent_block_body(body: &str, spaces: usize) -> String {
     let indent = " ".repeat(spaces);
-    let trimmed = body.trim_matches('\n');
+    // Normalize CRLF to LF first. `body` may originate from a CRLF-checked-out
+    // source file (e.g. on Windows with core.autocrlf=true); without this,
+    // trim_matches('\n') only strips bare '\n' from the very edges, leaving a
+    // stray '\r' attached to the first/last line and producing output that
+    // differs byte-for-byte from the same source checked out with LF endings.
+    let normalized = body.replace("\r\n", "\n");
+    let trimmed = normalized.trim_matches('\n');
     if trimmed.trim().is_empty() {
         return String::new();
     }


### PR DESCRIPTION
`indent_block_body()` only trimmed bare `\n` at the string edges via `trim_matches('\n')`. When the source `.ag` file is checked out with CRLF line endings (e.g. Windows with the default `core.autocrlf=true`), the body string ends `...\r\n` — trimming the trailing `\n` leaves a dangling `\r` attached to what `str::lines()` then treats as the final line's content, producing an extra blank/stray line in every emitted helper function body.

Proven with a standalone repro: building the same source with LF vs CRLF line endings produced byte-different `indent_block_body()` output before this fix, byte-identical after.

Fix: normalize CRLF to LF before trimming/indenting. Also adds `.gitattributes` EOL rules (checked-in `.ag`/`.rs`/`.md`/`.json`/`.sil` forced to LF regardless of platform checkout settings) as defense in depth — a contributor on Windows would otherwise silently break the compiler's determinism/reproducibility guarantee.

Verified: all 7 tracked examples still rebuild byte-identical to the checked-in `examples/build/` output; full `check.sh` (fmt + clippy + tests + doctests) passes.