### PR TITLE
fix: exclude root/modules paths from artifact id computation

### DIFF
--- a/crates/argent-artifact/src/lib.rs
+++ b/crates/argent-artifact/src/lib.rs
@@ -67,6 +67,17 @@ impl Artifact {
     pub fn computed_id_hex(&self) -> std::result::Result<String, ArtifactIdentityError> {
         let mut artifact = self.clone();
         artifact.id.clear();
+        // `root` and `modules` are filesystem paths recorded for informational/
+        // debugging purposes only. They must NOT participate in artifact
+        // identity: two builds of byte-identical source should produce the
+        // same id regardless of which absolute path the source happened to
+        // live at when it was built (e.g. a different clone directory, a
+        // different machine, or - on Windows specifically - a `\\?\` UNC-
+        // extended-length canonical path that a naive `strip_prefix` against
+        // `current_dir()` fails to match, silently leaking the full absolute
+        // path into what's supposed to be a portable, content-addressed id).
+        artifact.root.clear();
+        artifact.modules.clear();
         hash_json("argent/artifact/v1", &artifact)
     }
 
@@ -1493,6 +1504,118 @@ mod tests {
         assert_eq!(artifact.argent.actors[0].abi.actor, "Foo");
         assert_eq!(artifact.argent.template_plan.runtime_states[0].field_roles[0].name, "gen__foo_template");
         assert_eq!(artifact.sil_abi.contracts[0].compiled.script_hex, "");
+    }
+
+    #[test]
+    fn artifact_id_is_independent_of_root_and_module_paths() {
+        // The `root` and `modules` fields record where the source lived on
+        // disk at build time. They are informational only and must NOT
+        // affect the content-addressed artifact id: the same source built
+        // from two different directories (a different clone location, a
+        // different machine, or a Windows `\\?\` UNC-extended canonical
+        // path that a naive `strip_prefix(current_dir())` fails to strip)
+        // must yield the same id. Otherwise "portable artifact" and
+        // "verifiable bundle id" claims don't hold.
+        fn artifact_with_paths(root: &str, modules: &[&str]) -> Artifact {
+            let root_json = serde_json::to_string(root).expect("root serializes");
+            let modules_json = serde_json::to_string(modules).expect("modules serialize");
+            let json = format!(
+                r#"{{
+                  "schema_version": 1,
+                  "generator": {{ "name": "argentc", "version": "0.1.0" }},
+                  "app": "Tiny",
+                  "root": {root_json},
+                  "modules": {modules_json},
+                  "argent": {{
+                    "templates": [{{ "id": "template/foo", "actor": "Foo", "symbol": "gen__foo_template" }}],
+                    "template_plan": {{
+                      "templates": [],
+                      "runtime_states": [
+                        {{
+                          "contract": "Foo",
+                          "source": "FooState",
+                          "field_roles": [
+                            {{
+                              "name": "gen__foo_template",
+                              "role": {{ "kind": "template", "contract": "Foo" }}
+                            }}
+                          ]
+                        }}
+                      ],
+                      "witness_recipes": []
+                    }},
+                    "states": [
+                      {{
+                        "name": "FooState",
+                        "fields": [{{ "name": "owner", "type": {{ "kind": "fixed_bytes", "len": 32 }} }}]
+                      }}
+                    ],
+                    "actors": [
+                      {{
+                        "name": "Foo",
+                        "state": "FooState",
+                        "abi": {{ "actor": "Foo" }},
+                        "entries": []
+                      }}
+                    ]
+                  }},
+                  "sil_abi": {{
+                    "schema_version": 1,
+                    "states": [
+                      {{
+                        "name": "FooState",
+                        "fields": [{{ "name": "owner", "type": {{ "kind": "fixed_bytes", "len": 32 }} }}]
+                      }}
+                    ],
+                    "contracts": [
+                      {{
+                        "name": "Foo",
+                        "source_path": "sil/Foo.sil",
+                        "runtime_state": {{
+                          "source": "FooState",
+                          "fields": [
+                            {{
+                              "name": "gen__foo_template",
+                              "type": {{ "kind": "fixed_bytes", "len": 32 }}
+                            }},
+                            {{
+                              "name": "owner",
+                              "type": {{ "kind": "fixed_bytes", "len": 32 }}
+                            }}
+                          ]
+                        }},
+                        "entries": [],
+                        "compiled": {{
+                          "script_hex": "",
+                          "template": {{ "prefix_hex": "", "suffix_hex": "", "hash_hex": "" }},
+                          "state_span": {{ "offset": 0, "len": 0 }}
+                        }}
+                      }}
+                    ]
+                  }}
+                }}"#,
+            );
+            serde_json::from_str(&json).expect("artifact should deserialize")
+        }
+
+        let built_at_repo_root = artifact_with_paths("examples/tiny.ag", &["examples/tiny.ag"]);
+        let built_at_different_absolute_path = artifact_with_paths(
+            r"\\?\C:\Users\wolfie\projects\kaspanet\argent\examples\tiny.ag",
+            &[r"\\?\C:\Users\wolfie\projects\kaspanet\argent\examples\tiny.ag"],
+        );
+        let built_from_a_third_location =
+            artifact_with_paths("/home/ci-runner/build-42/examples/tiny.ag", &["/home/ci-runner/build-42/examples/tiny.ag"]);
+
+        let id_a = built_at_repo_root.computed_id_hex().expect("id computes");
+        let id_b = built_at_different_absolute_path.computed_id_hex().expect("id computes");
+        let id_c = built_from_a_third_location.computed_id_hex().expect("id computes");
+
+        assert_eq!(id_a, id_b, "artifact id must not depend on the build's source root path");
+        assert_eq!(id_a, id_c, "artifact id must not depend on the build's source root path");
+
+        // Sanity check the fields themselves genuinely differ, so this test
+        // isn't accidentally comparing two identical inputs.
+        assert_ne!(built_at_repo_root.root, built_at_different_absolute_path.root);
     }
 
     #[test]


### PR DESCRIPTION
`Artifact::computed_id_hex()` hashes the entire `Artifact` struct (after blanking `.id`), which includes `root` and `modules` — filesystem paths recorded at build time. The same source built from two different directories (different clone location, different machine, CI) produces two different artifact ids for byte-identical program logic.

On Windows this is worse than "different machine, different id": `fs::canonicalize` returns a `\\?\` UNC-extended-length path that `manifest_path`'s relativization (`strip_prefix` against `current_dir()`) silently fails to match, so the full absolute UNC path gets baked into `root`/`modules` and hashed into the id — even for a single-machine, single-clone build.

`root`/`modules` are informational metadata for humans/tooling; they carry no semantic content about the compiled program and shouldn't participate in the identity a downstream client uses to verify a portable, content-addressed artifact bundle.

Fix: clear `root` and `modules` on the cloned `Artifact` before hashing in `computed_id_hex()`, same pattern already used for `id` itself. Real values are preserved on the artifact written to disk — only the hash input is affected.

Adds `artifact_id_is_independent_of_root_and_module_paths`, a regression test that builds the same minimal artifact fixture with three different root/modules path sets (repo-relative, a synthetic Windows UNC path, a synthetic CI absolute path) and asserts `computed_id_hex()` is identical across all three. Confirmed this test fails against the pre-fix code and passes after.

Verified: full `check.sh` (fmt + clippy + tests + doctests) passes.