### PR TITLE
Harden artifact validation and extend transaction context APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,10 +2956,12 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 name = "silverscript-abi"
 version = "0.1.0"
 dependencies = [
+ "blake2b_simd",
  "faster-hex 0.10.0",
  "kaspa-txscript",
  "serde",
  "serde_json",
+ "silverscript-lang",
  "thiserror 2.0.18",
 ]
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ let context = TxContext::new()
         EntryCall::new("bump").args(args![3]),
         outpoint,
         input_utxo,
+        0, // sequence
     )
     .argent_output(
         "Counter",
@@ -182,6 +183,9 @@ let context = TxContext::new()
 
 let tx = builder.build(&context)?;
 ```
+
+Each input declares its sequence. Lock time, lane and gas, and payload can be
+set fluently on `TxContext`; their defaults produce a native transaction.
 
 The runtime API is Argent-specific while the language settles. The lower-level
 Silverscript ABI and artifact boundaries are split into small crates so they can

--- a/crates/argent-artifact/src/lib.rs
+++ b/crates/argent-artifact/src/lib.rs
@@ -1160,12 +1160,20 @@ fn verify_actor_type_handle(
     let canonical_suffix = decode_hex_for_template(&template.id, &contract.compiled.template.suffix_hex)?;
     let handle_prefix = decode_hex_for_template(&template.id, &handle.template.prefix_hex)?;
     let handle_suffix = decode_hex_for_template(&template.id, &handle.template.suffix_hex)?;
-    decode_hash_hex(&template.id, &handle.template.hash_hex)?;
+    let handle_hash = decode_hash_hex(&template.id, &handle.template.hash_hex)?;
     if !handle_prefix.starts_with(&canonical_prefix) {
         return Err(mismatch("prefix does not extend the canonical template prefix".to_string()));
     }
     if handle_suffix != canonical_suffix {
         return Err(mismatch("suffix differs from the canonical template suffix".to_string()));
+    }
+    let expected_handle_hash = silverscript_abi::template_hash(&handle_prefix, &handle_suffix);
+    if handle_hash != expected_handle_hash {
+        return Err(mismatch(format!(
+            "template hash does not match its prefix and suffix: expected `{}`, found `{}`",
+            encode_hex(&expected_handle_hash),
+            handle.template.hash_hex
+        )));
     }
 
     let context_state =

--- a/crates/argent-runtime/src/context.rs
+++ b/crates/argent-runtime/src/context.rs
@@ -1,6 +1,9 @@
-use std::{collections::BTreeMap, fmt};
+use std::{collections::BTreeMap, error::Error, fmt};
 
-use kaspa_consensus_core::tx::{CovenantBinding, MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry};
+use kaspa_consensus_core::{
+    subnets::SubnetworkId,
+    tx::{CovenantBinding, MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
+};
 
 use crate::{ArgValue, ArtifactValue};
 
@@ -48,7 +51,8 @@ impl fmt::Display for ActorPath {
     }
 }
 
-type EntryArgsCallback<'a> = dyn Fn(&MutableTransaction<Transaction>, usize) -> Vec<ArgValue> + 'a;
+type CallbackError = Box<dyn Error + Send + Sync + 'static>;
+type EntryArgsCallback<'a> = dyn Fn(&MutableTransaction<Transaction>, usize) -> Result<Vec<ArgValue>, CallbackError> + 'a;
 
 /// User arguments for an Argent entry call.
 pub enum EntryArgs<'a> {
@@ -88,7 +92,18 @@ impl<'a> EntryCall<'a> {
 
     /// Build arguments from the unsigned transaction and this input's index.
     pub fn args_with(mut self, build: impl Fn(&MutableTransaction<Transaction>, usize) -> Vec<ArgValue> + 'a) -> Self {
-        self.args = EntryArgs::WithTransaction(Box::new(build));
+        self.args = EntryArgs::WithTransaction(Box::new(move |tx, input_index| Ok(build(tx, input_index))));
+        self
+    }
+
+    /// Fallibly build arguments from the unsigned transaction and this input's index.
+    pub fn try_args_with<E>(mut self, build: impl Fn(&MutableTransaction<Transaction>, usize) -> Result<Vec<ArgValue>, E> + 'a) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        self.args = EntryArgs::WithTransaction(Box::new(move |tx, input_index| {
+            build(tx, input_index).map_err(|error| Box::new(error) as CallbackError)
+        }));
         self
     }
 }
@@ -105,7 +120,7 @@ impl<'a> From<String> for EntryCall<'a> {
     }
 }
 
-type InputSigScriptCallback<'a> = dyn Fn(&MutableTransaction<Transaction>, usize) -> Vec<u8> + 'a;
+type InputSigScriptCallback<'a> = dyn Fn(&MutableTransaction<Transaction>, usize) -> Result<Vec<u8>, CallbackError> + 'a;
 
 /// Signature script supplied for a non-Argent input.
 pub enum InputSigScript<'a> {
@@ -118,7 +133,17 @@ pub enum InputSigScript<'a> {
 impl<'a> InputSigScript<'a> {
     /// Build a signature script from the unsigned transaction and input index.
     pub fn with_transaction(build: impl Fn(&MutableTransaction<Transaction>, usize) -> Vec<u8> + 'a) -> Self {
-        Self::WithTransaction(Box::new(build))
+        Self::WithTransaction(Box::new(move |tx, input_index| Ok(build(tx, input_index))))
+    }
+
+    /// Fallibly build a signature script from the unsigned transaction and input index.
+    pub fn try_with_transaction<E>(build: impl Fn(&MutableTransaction<Transaction>, usize) -> Result<Vec<u8>, E> + 'a) -> Self
+    where
+        E: Error + Send + Sync + 'static,
+    {
+        Self::WithTransaction(Box::new(move |tx, input_index| {
+            build(tx, input_index).map_err(|error| Box::new(error) as CallbackError)
+        }))
     }
 }
 
@@ -145,6 +170,7 @@ pub struct ArgentInput<'a> {
     pub entry: EntryCall<'a>,
     pub outpoint: TransactionOutpoint,
     pub utxo: UtxoEntry,
+    pub sequence: u64,
 }
 
 /// One non-Argent input in a transaction context.
@@ -153,6 +179,7 @@ pub struct OrdinaryInput<'a> {
     pub outpoint: TransactionOutpoint,
     pub utxo: UtxoEntry,
     pub signature_script: InputSigScript<'a>,
+    pub sequence: u64,
 }
 
 /// An ordered input in a transaction context.
@@ -194,15 +221,41 @@ pub enum ContextOutput {
 /// Callers provide only user-visible entry arguments and signature callbacks;
 /// the builder derives compiler-generated witness material from the context
 /// and artifact bundle.
+///
+/// Transaction-wide metadata defaults to lock time zero, the native lane with
+/// zero gas, and an empty payload. Each input sequence is explicit.
 #[derive(Debug, Default)]
 pub struct TxContext<'a> {
     pub inputs: Vec<ContextInput<'a>>,
     pub outputs: Vec<ContextOutput>,
+    pub lock_time: u64,
+    pub subnetwork_id: SubnetworkId,
+    pub gas: u64,
+    pub payload: Vec<u8>,
 }
 
 impl<'a> TxContext<'a> {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Set the transaction lock time.
+    pub fn lock_time(mut self, lock_time: u64) -> Self {
+        self.lock_time = lock_time;
+        self
+    }
+
+    /// Set the transaction lane and its gas value together.
+    pub fn lane(mut self, id: SubnetworkId, gas: u64) -> Self {
+        self.subnetwork_id = id;
+        self.gas = gas;
+        self
+    }
+
+    /// Set the transaction payload.
+    pub fn payload(mut self, payload: impl Into<Vec<u8>>) -> Self {
+        self.payload = payload.into();
+        self
     }
 
     /// Append an Argent covenant input.
@@ -213,14 +266,33 @@ impl<'a> TxContext<'a> {
         entry: impl Into<EntryCall<'a>>,
         outpoint: TransactionOutpoint,
         utxo: UtxoEntry,
+        sequence: u64,
     ) -> Self {
-        self.inputs.push(ContextInput::Argent(ArgentInput { actor: actor.into(), state, entry: entry.into(), outpoint, utxo }));
+        self.inputs.push(ContextInput::Argent(ArgentInput {
+            actor: actor.into(),
+            state,
+            entry: entry.into(),
+            outpoint,
+            utxo,
+            sequence,
+        }));
         self
     }
 
     /// Append a non-Argent input.
-    pub fn input(mut self, outpoint: TransactionOutpoint, utxo: UtxoEntry, signature_script: impl Into<InputSigScript<'a>>) -> Self {
-        self.inputs.push(ContextInput::Ordinary(OrdinaryInput { outpoint, utxo, signature_script: signature_script.into() }));
+    pub fn input(
+        mut self,
+        outpoint: TransactionOutpoint,
+        utxo: UtxoEntry,
+        signature_script: impl Into<InputSigScript<'a>>,
+        sequence: u64,
+    ) -> Self {
+        self.inputs.push(ContextInput::Ordinary(OrdinaryInput {
+            outpoint,
+            utxo,
+            signature_script: signature_script.into(),
+            sequence,
+        }));
         self
     }
 
@@ -275,17 +347,27 @@ mod tests {
                 EntryCall::new("bump").args(vec![ArgValue::Value(ArtifactValue::Int(3))]),
                 outpoint(1),
                 utxo(Some(covenant_id)),
+                3,
             )
-            .input(outpoint(2), utxo(None), vec![0xaa])
+            .input(outpoint(2), utxo(None), vec![0xaa], 4)
             .argent_output("Counter", BTreeMap::from([("count".to_string(), ArtifactValue::Int(5))]), binding, 900)
-            .output(ScriptPublicKey::default(), None, 100);
+            .output(ScriptPublicKey::default(), None, 100)
+            .lock_time(5)
+            .lane(SubnetworkId::from_namespace([1, 2, 3, 4]), 6)
+            .payload([0xaa, 0xbb]);
 
-        assert!(matches!(&context.inputs[0], ContextInput::Argent(input) if input.actor == ActorPath::primary("Counter")));
         assert!(
-            matches!(&context.inputs[1], ContextInput::Ordinary(input) if matches!(input.signature_script, InputSigScript::Static(ref script) if script == &[0xaa]))
+            matches!(&context.inputs[0], ContextInput::Argent(input) if input.actor == ActorPath::primary("Counter") && input.sequence == 3)
+        );
+        assert!(
+            matches!(&context.inputs[1], ContextInput::Ordinary(input) if input.sequence == 4 && matches!(input.signature_script, InputSigScript::Static(ref script) if script == &[0xaa]))
         );
         assert!(matches!(&context.outputs[0], ContextOutput::Argent(output) if output.covenant == binding));
         assert!(matches!(&context.outputs[1], ContextOutput::Ordinary(output) if output.value == 100));
+        assert_eq!(context.lock_time, 5);
+        assert_eq!(context.subnetwork_id, SubnetworkId::from_namespace([1, 2, 3, 4]));
+        assert_eq!(context.gas, 6);
+        assert_eq!(context.payload, [0xaa, 0xbb]);
     }
 
     #[test]

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -13,7 +13,7 @@
 mod context;
 mod resolve;
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, error::Error};
 
 pub use argent_artifact::Artifact;
 pub use context::{
@@ -320,10 +320,30 @@ pub enum BuilderError {
     MissingArgentInputCovenantId { input_index: usize, actor: String },
     #[error("Argent input {input_index} `{actor}` UTXO script does not match its declared state")]
     ArgentInputScriptMismatch { input_index: usize, actor: String },
+    #[error("failed to build arguments for Argent input {input_index} `{actor}::{entry}`: {source}")]
+    EntryArgsCallback {
+        input_index: usize,
+        actor: String,
+        entry: String,
+        #[source]
+        source: Box<dyn Error + Send + Sync + 'static>,
+    },
+    #[error("failed to build signature script for input {input_index}: {source}")]
+    InputSigScriptCallback {
+        input_index: usize,
+        #[source]
+        source: Box<dyn Error + Send + Sync + 'static>,
+    },
     #[error("cannot build transition `{actor}::{entry}`: {message}")]
     InvalidTransition { actor: String, entry: String, message: String },
     #[error("input {input_index} requires {script_units} script units, which do not fit a compute budget")]
     ComputeBudgetOverflow { input_index: usize, script_units: u64 },
+    #[error("input {input_index} script failed: {source}")]
+    InputScript {
+        input_index: usize,
+        #[source]
+        source: TxScriptError,
+    },
     #[error("transaction has {input_count} inputs but {entry_count} UTXO entries")]
     InputEntryCountMismatch { input_count: usize, entry_count: usize },
     #[error("transaction version {found} is not supported; expected {expected}")]
@@ -1641,9 +1661,14 @@ pub fn execute_transaction_with_covenants(tx: &mut Transaction, entries: Vec<Utx
         let sig_cache = Cache::new(100);
         let populated = PopulatedTransaction::new(tx, entries);
         let cov_ctx = CovenantsContext::from_tx(&populated).map_err(TxScriptError::from)?;
-        (0..tx.inputs.len())
-            .map(|input_idx| measure_input_script_units_with_covenants(&populated, input_idx, &sig_cache, &reused_values, &cov_ctx))
-            .collect::<Result<Vec<_>, _>>()?
+        let mut used_script_units = Vec::with_capacity(tx.inputs.len());
+        for input_index in 0..tx.inputs.len() {
+            let script_units =
+                measure_input_script_units_with_covenants(&populated, input_index, &sig_cache, &reused_values, &cov_ctx)
+                    .map_err(|source| BuilderError::InputScript { input_index, source })?;
+            used_script_units.push(script_units);
+        }
+        used_script_units
     };
 
     for (input_idx, script_units) in used_script_units.into_iter().enumerate() {
@@ -1693,6 +1718,9 @@ pub fn covenant_engine_flags() -> EngineFlags {
 
 #[cfg(test)]
 mod tests {
+    use kaspa_consensus_core::tx::{ScriptPublicKey, TransactionId};
+    use kaspa_txscript::opcodes::codes::OpFalse;
+
     use super::*;
 
     #[test]
@@ -1730,6 +1758,17 @@ mod tests {
                 ArgValue::Actor("Alpha".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn transaction_execution_reports_the_failing_input_index() {
+        let outpoint = TransactionOutpoint::new(TransactionId::from_bytes([0x33; 32]), 0);
+        let input = TransactionInput::new_with_compute_budget(outpoint, Vec::new(), 0, 0);
+        let mut transaction = Transaction::new(TX_VERSION_TOCCATA, vec![input], Vec::new(), 0, Default::default(), 0, Vec::new());
+        let utxo = UtxoEntry::new(1_000, ScriptPublicKey::new(0, vec![OpFalse].into()), 0, false, None);
+
+        let error = execute_transaction_with_covenants(&mut transaction, vec![utxo]).expect_err("false script fails");
+        assert!(matches!(error, BuilderError::InputScript { input_index: 0, .. }));
     }
 
     #[test]

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -13,7 +13,7 @@
 mod context;
 mod resolve;
 
-use std::{collections::BTreeMap, error::Error};
+use std::{collections::BTreeMap, error::Error, fmt};
 
 pub use argent_artifact::Artifact;
 pub use context::{
@@ -226,6 +226,33 @@ macro_rules! args {
     }};
 }
 
+/// The input or output side of an observed covenant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    /// Observed inputs.
+    In,
+    /// Observed outputs.
+    Out,
+}
+
+impl fmt::Display for Side {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::In => "input",
+            Self::Out => "output",
+        })
+    }
+}
+
+impl From<ObservedActorSideArtifact> for Side {
+    fn from(side: ObservedActorSideArtifact) -> Self {
+        match side {
+            ObservedActorSideArtifact::Input => Self::In,
+            ObservedActorSideArtifact::Output => Self::Out,
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum BuilderError {
     #[error(transparent)]
@@ -293,13 +320,13 @@ pub enum BuilderError {
     #[error("missing observed covenant context `{observe}`")]
     MissingObservedCovenant { observe: String },
     #[error("missing observed {side} `{observe}.{handle}`")]
-    MissingObservedActor { observe: String, side: &'static str, handle: String },
+    MissingObservedActor { observe: String, side: Side, handle: String },
     #[error("unknown observed {side} `{observe}.{handle}`")]
-    UnknownObservedActor { observe: String, side: &'static str, handle: String },
+    UnknownObservedActor { observe: String, side: Side, handle: String },
     #[error("observed {side} `{observe}.{handle}` expected actor `{expected}`, got `{found}`")]
-    ObservedActorMismatch { observe: String, side: &'static str, handle: String, expected: String, found: String },
+    ObservedActorMismatch { observe: String, side: Side, handle: String, expected: String, found: String },
     #[error("observed {side} `{observe}.{handle}` state `{state}` layout does not match attached actor `{actor}`")]
-    ObservedStateLayoutMismatch { observe: String, side: &'static str, handle: String, state: String, actor: String },
+    ObservedStateLayoutMismatch { observe: String, side: Side, handle: String, state: String, actor: String },
     #[error("attached actor `{actor}` does not expose actor_type<{state}>")]
     MissingActorTypeHandle { actor: String, state: String },
     #[error("artifact `{app}` has no state `{state}`")]
@@ -309,9 +336,9 @@ pub enum BuilderError {
     #[error("observe `{observe}` covenant id source must resolve to exactly 32 bytes")]
     InvalidObservedCovenantId { observe: String },
     #[error("observe `{observe}` expects {expected} {side}s for its covenant id, found {found}")]
-    ObservedCountMismatch { observe: String, side: &'static str, expected: usize, found: usize },
+    ObservedCountMismatch { observe: String, side: Side, expected: usize, found: usize },
     #[error("observed {side} `{observe}.{handle}` at transaction index {index} has no Argent actor metadata")]
-    MissingObservedActorMetadata { observe: String, side: &'static str, handle: String, index: usize },
+    MissingObservedActorMetadata { observe: String, side: Side, handle: String, index: usize },
     #[error("observe `{observe}` spans apps `{expected}` and `{found}`")]
     ObservedAppMismatch { observe: String, expected: String, found: String },
     #[error("unknown entry `{actor}::{entry}`")]
@@ -1066,7 +1093,7 @@ impl<'a> TxBuilder<'a> {
         };
         actors.iter().find(|actor| actor.name == handle).ok_or_else(|| BuilderError::MissingObservedActor {
             observe: observe_name.to_string(),
-            side: observed_side_label(side),
+            side: side.into(),
             handle: handle.to_string(),
         })
     }
@@ -1113,7 +1140,7 @@ impl<'a> TxBuilder<'a> {
             if expected.iter().all(|input| &input.name != handle) {
                 return Err(BuilderError::UnknownObservedActor {
                     observe: observe_name.to_string(),
-                    side: observed_side_label(ObservedActorSideArtifact::Input),
+                    side: Side::In,
                     handle: handle.clone(),
                 });
             }
@@ -1121,7 +1148,7 @@ impl<'a> TxBuilder<'a> {
         for input in expected {
             let observed = context.inputs.get(&input.name).ok_or_else(|| BuilderError::MissingObservedActor {
                 observe: observe_name.to_string(),
-                side: observed_side_label(ObservedActorSideArtifact::Input),
+                side: Side::In,
                 handle: input.name.clone(),
             })?;
             self.validate_observed_actor(
@@ -1157,7 +1184,7 @@ impl<'a> TxBuilder<'a> {
             if expected.iter().all(|output| &output.name != handle) {
                 return Err(BuilderError::UnknownObservedActor {
                     observe: observe_name.to_string(),
-                    side: observed_side_label(ObservedActorSideArtifact::Output),
+                    side: Side::Out,
                     handle: handle.clone(),
                 });
             }
@@ -1165,7 +1192,7 @@ impl<'a> TxBuilder<'a> {
         for output in expected {
             let observed = context.outputs.get(&output.name).ok_or_else(|| BuilderError::MissingObservedActor {
                 observe: observe_name.to_string(),
-                side: observed_side_label(ObservedActorSideArtifact::Output),
+                side: Side::Out,
                 handle: output.name.clone(),
             })?;
             self.validate_observed_actor(
@@ -1196,7 +1223,7 @@ impl<'a> TxBuilder<'a> {
             if !state_satisfies(found.artifact, &found.actor.state, expected_state) {
                 return Err(BuilderError::ObservedStateLayoutMismatch {
                     observe: observe_name.to_string(),
-                    side: observed_side_label(side),
+                    side: side.into(),
                     handle: expected.name.clone(),
                     actor: found_actor.to_string(),
                     state: expected_state.to_string(),
@@ -1207,7 +1234,7 @@ impl<'a> TxBuilder<'a> {
             if expected_layout.fields != found_layout.fields {
                 return Err(BuilderError::ObservedStateLayoutMismatch {
                     observe: observe_name.to_string(),
-                    side: observed_side_label(side),
+                    side: side.into(),
                     handle: expected.name.clone(),
                     state: expected_state.to_string(),
                     actor: found_actor.to_string(),
@@ -1218,7 +1245,7 @@ impl<'a> TxBuilder<'a> {
         if expected.actor != found_actor {
             return Err(BuilderError::ObservedActorMismatch {
                 observe: observe_name.to_string(),
-                side: observed_side_label(side),
+                side: side.into(),
                 handle: expected.name.clone(),
                 expected: expected.actor.clone(),
                 found: found_actor.to_string(),
@@ -1353,14 +1380,14 @@ impl<'a> TxBuilder<'a> {
             .ok_or_else(|| BuilderError::MissingObservedCovenant { observe: observe.clone() })?;
         let output = context.outputs.get(handle).ok_or_else(|| BuilderError::MissingObservedActor {
             observe: observe.clone(),
-            side: observed_side_label(ObservedActorSideArtifact::Output),
+            side: Side::Out,
             handle: handle.clone(),
         })?;
         let contract_ref = self.contract_ref_in_app(&context.app, &output.actor)?;
         if !state_satisfies(contract_ref.artifact, &contract_ref.contract.runtime_state.source, state) {
             return Err(BuilderError::ObservedStateLayoutMismatch {
                 observe: observe.clone(),
-                side: observed_side_label(ObservedActorSideArtifact::Output),
+                side: Side::Out,
                 handle: handle.clone(),
                 state: state.clone(),
                 actor: output.actor.clone(),
@@ -1568,13 +1595,6 @@ fn route_leaf_label(leaf: &RouteTemplateLeafArtifact) -> String {
     match leaf {
         RouteTemplateLeafArtifact::Template { actor, .. } => actor.clone(),
         RouteTemplateLeafArtifact::RouteFamily { family_id, .. } => family_id.clone(),
-    }
-}
-
-fn observed_side_label(side: ObservedActorSideArtifact) -> &'static str {
-    match side {
-        ObservedActorSideArtifact::Input => "input",
-        ObservedActorSideArtifact::Output => "output",
     }
 }
 

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -14,7 +14,7 @@ use kaspa_txscript::{pay_to_script_hash_script, pay_to_script_hash_signature_scr
 use crate::{
     ActorPath, ArgentInput, ArgentOutput, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput,
     ContractRef, EntryArgs, InputSigScript, ObservedCovenantContext, ObservedInput, ObservedOutput, OrdinaryInput, OrdinaryOutput,
-    TxBuilder, TxContext, covenant_engine_flags, execute_transaction_with_covenants,
+    Side, TxBuilder, TxContext, covenant_engine_flags, execute_transaction_with_covenants,
 };
 
 type ResolvedObservations = BTreeMap<String, ObservedCovenantContext>;
@@ -412,9 +412,9 @@ fn resolve_observation(
     covenant_id: Hash,
 ) -> BuilderResult<ObservedCovenantContext> {
     let matching_inputs = matching_observed_inputs(context, covenant_id);
-    require_observed_count(&observe.name, "input", observe.inputs.len(), matching_inputs.len())?;
+    require_observed_count(&observe.name, Side::In, observe.inputs.len(), matching_inputs.len())?;
     let matching_outputs = matching_observed_outputs(context, covenant_id);
-    require_observed_count(&observe.name, "output", observe.outputs.len(), matching_outputs.len())?;
+    require_observed_count(&observe.name, Side::Out, observe.outputs.len(), matching_outputs.len())?;
 
     // Pair both sides positionally: covenant members are indexed by transaction
     // order, while emitted observe checks assign indexes in declaration order.
@@ -466,7 +466,7 @@ fn matching_observed_outputs(context: &ResolveContext<'_, '_, '_>, covenant_id: 
         .collect()
 }
 
-fn require_observed_count(observe: &str, side: &'static str, expected: usize, found: usize) -> BuilderResult<()> {
+fn require_observed_count(observe: &str, side: Side, expected: usize, found: usize) -> BuilderResult<()> {
     if found != expected {
         return Err(BuilderError::ObservedCountMismatch { observe: observe.to_string(), side, expected, found });
     }
@@ -483,7 +483,7 @@ fn resolve_observed_input(
     let ResolveInput::Argent(candidate) = candidate else {
         return Err(BuilderError::MissingObservedActorMetadata {
             observe: observe.to_string(),
-            side: "input",
+            side: Side::In,
             handle: declaration.name.clone(),
             index,
         });
@@ -509,7 +509,7 @@ fn resolve_observed_output(
     let ResolveOutput::Argent(candidate) = candidate else {
         return Err(BuilderError::MissingObservedActorMetadata {
             observe: observe.to_string(),
-            side: "output",
+            side: Side::Out,
             handle: declaration.name.clone(),
             index,
         });

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -6,6 +6,7 @@ use argent_artifact::{
 use kaspa_consensus_core::{
     Hash,
     constants::TX_VERSION_TOCCATA,
+    subnets::SubnetworkId,
     tx::{MutableTransaction, Transaction, TransactionInput, TransactionOutput},
 };
 use kaspa_txscript::{pay_to_script_hash_script, pay_to_script_hash_signature_script_with_flags};
@@ -24,9 +25,19 @@ struct ResolvedEntryArgs {
     template_selectors: BTreeMap<String, String>,
 }
 
+/// Artifact-bound working representation of a [`TxContext`].
+///
+/// Actor paths are resolved once into concrete app, contract, and entry
+/// metadata while transaction ordering and transaction-wide fields are
+/// preserved. Subsequent passes populate entry arguments, observations, and
+/// hidden witnesses before the final signature scripts are assembled.
 struct ResolveContext<'artifact, 'context, 'args> {
     inputs: Vec<ResolveInput<'artifact, 'context, 'args>>,
     outputs: Vec<ResolveOutput<'artifact, 'context>>,
+    lock_time: u64,
+    subnetwork_id: SubnetworkId,
+    gas: u64,
+    payload: &'context [u8],
 }
 
 enum ResolveInput<'artifact, 'context, 'args> {
@@ -124,7 +135,14 @@ impl<'artifact> TxBuilder<'artifact> {
             }
         }
 
-        Ok(ResolveContext { inputs, outputs })
+        Ok(ResolveContext {
+            inputs,
+            outputs,
+            lock_time: context.lock_time,
+            subnetwork_id: context.subnetwork_id,
+            gas: context.gas,
+            payload: &context.payload,
+        })
     }
 
     /// Materialize the unsigned transaction described by `context`.
@@ -147,11 +165,16 @@ impl<'artifact> TxBuilder<'artifact> {
                     if input.source.utxo.script_public_key != expected_script {
                         return Err(BuilderError::ArgentInputScriptMismatch { input_index, actor: input.source.actor.to_string() });
                     }
-                    inputs.push(TransactionInput::new_with_compute_budget(input.source.outpoint, Vec::new(), 0, 0));
+                    inputs.push(TransactionInput::new_with_compute_budget(
+                        input.source.outpoint,
+                        Vec::new(),
+                        input.source.sequence,
+                        0,
+                    ));
                     entries.push(input.source.utxo.clone());
                 }
                 ResolveInput::Ordinary(input) => {
-                    inputs.push(TransactionInput::new_with_compute_budget(input.outpoint, Vec::new(), 0, 0));
+                    inputs.push(TransactionInput::new_with_compute_budget(input.outpoint, Vec::new(), input.sequence, 0));
                     entries.push(input.utxo.clone());
                 }
             }
@@ -176,7 +199,15 @@ impl<'artifact> TxBuilder<'artifact> {
             }
         }
 
-        let transaction = Transaction::new(TX_VERSION_TOCCATA, inputs, outputs, 0, Default::default(), 0, Vec::new());
+        let transaction = Transaction::new(
+            TX_VERSION_TOCCATA,
+            inputs,
+            outputs,
+            context.lock_time,
+            context.subnetwork_id,
+            context.gas,
+            context.payload.to_vec(),
+        );
         Ok(MutableTransaction::with_entries(transaction, entries))
     }
 
@@ -208,7 +239,14 @@ impl<'artifact> TxBuilder<'artifact> {
                 })?;
             let source_args = match &input.source.entry.args {
                 EntryArgs::Static(args) => args.clone(),
-                EntryArgs::WithTransaction(build) => build(unsigned, input_index),
+                EntryArgs::WithTransaction(build) => {
+                    build(unsigned, input_index).map_err(|source| BuilderError::EntryArgsCallback {
+                        input_index,
+                        actor: input.source.actor.to_string(),
+                        entry: input.source.entry.name.clone(),
+                        source,
+                    })?
+                }
             };
             if source_args.len() != expected_arg_count {
                 return Err(silverscript_abi::CodecError::WrongArgumentCount {
@@ -325,7 +363,9 @@ impl<'artifact> TxBuilder<'artifact> {
                 }
                 ResolveInput::Ordinary(input) => match &input.signature_script {
                     InputSigScript::Static(script) => script.clone(),
-                    InputSigScript::WithTransaction(build) => build(&unsigned, input_index),
+                    InputSigScript::WithTransaction(build) => {
+                        build(&unsigned, input_index).map_err(|source| BuilderError::InputSigScriptCallback { input_index, source })?
+                    }
                 },
             };
             signature_scripts.push(signature_script);
@@ -508,6 +548,7 @@ mod tests {
     };
     use kaspa_consensus_core::{
         Hash,
+        subnets::SubnetworkId,
         tx::{CovenantBinding, ScriptPublicKey, TransactionId, TransactionOutpoint, UtxoEntry},
     };
 
@@ -627,6 +668,7 @@ mod tests {
                 }),
                 outpoint(1),
                 counter_utxo.clone(),
+                11,
             )
             .input(
                 outpoint(2),
@@ -635,11 +677,15 @@ mod tests {
                     script_called.set(true);
                     vec![0xaa]
                 }),
+                12,
             )
-            .argent_input("asset::Reserve", state(7), "move", outpoint(3), reserve_utxo.clone())
+            .argent_input("asset::Reserve", state(7), "move", outpoint(3), reserve_utxo.clone(), 13)
             .argent_output("Counter", state(3), CovenantBinding::new(0, counter_id), 900)
             .output(ScriptPublicKey::default(), Some(CovenantBinding::new(0, counter_id)), 100)
-            .argent_output("asset::Reserve", state(8), CovenantBinding::new(2, reserve_id), 2_000);
+            .argent_output("asset::Reserve", state(8), CovenantBinding::new(2, reserve_id), 2_000)
+            .lock_time(14)
+            .lane(SubnetworkId::from_namespace([1, 2, 3, 4]), 15)
+            .payload([0xaa, 0xbb]);
 
         let resolved = builder.bind_context(&context).expect("context binds");
         assert!(matches!(&resolved.inputs[0], ResolveInput::Argent(input) if input.app == "primary"));
@@ -655,6 +701,11 @@ mod tests {
         assert_eq!(unsigned.tx.inputs[0].previous_outpoint, outpoint(1));
         assert_eq!(unsigned.tx.inputs[1].previous_outpoint, outpoint(2));
         assert_eq!(unsigned.tx.inputs[2].previous_outpoint, outpoint(3));
+        assert_eq!(unsigned.tx.inputs.iter().map(|input| input.sequence).collect::<Vec<_>>(), vec![11, 12, 13]);
+        assert_eq!(unsigned.tx.lock_time, 14);
+        assert_eq!(unsigned.tx.subnetwork_id, SubnetworkId::from_namespace([1, 2, 3, 4]));
+        assert_eq!(unsigned.tx.gas, 15);
+        assert_eq!(unsigned.tx.payload, [0xaa, 0xbb]);
         assert_eq!(unsigned.entries, vec![Some(counter_utxo), Some(ordinary_utxo), Some(reserve_utxo)]);
         assert_eq!(
             unsigned.tx.outputs[0].script_public_key,
@@ -687,14 +738,14 @@ mod tests {
         let mut unbound_utxo = matching_utxo.clone();
         unbound_utxo.covenant_id = None;
 
-        let missing_id = TxContext::new().argent_input("Counter", state(2), "bump", outpoint(1), unbound_utxo);
+        let missing_id = TxContext::new().argent_input("Counter", state(2), "bump", outpoint(1), unbound_utxo, 0);
         let missing_id = builder.bind_context(&missing_id).expect("context binds");
         assert!(matches!(
             builder.unsigned_transaction(&missing_id),
             Err(BuilderError::MissingArgentInputCovenantId { input_index: 0, actor }) if actor == "Counter"
         ));
 
-        let wrong_state = TxContext::new().argent_input("Counter", state(3), "bump", outpoint(1), matching_utxo);
+        let wrong_state = TxContext::new().argent_input("Counter", state(3), "bump", outpoint(1), matching_utxo, 0);
         let wrong_state = builder.bind_context(&wrong_state).expect("context binds");
         assert!(matches!(
             builder.unsigned_transaction(&wrong_state),
@@ -709,13 +760,13 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x44; 32]);
         let utxo = builder.covenant_utxo("Counter", state(2), 1_000, 0, false, Some(covenant_id)).expect("counter UTXO builds");
 
-        let unknown_app = TxContext::new().argent_input("missing::Counter", state(2), "bump", outpoint(1), utxo.clone());
+        let unknown_app = TxContext::new().argent_input("missing::Counter", state(2), "bump", outpoint(1), utxo.clone(), 0);
         assert!(matches!(builder.bind_context(&unknown_app), Err(BuilderError::UnknownAppAlias(app)) if app == "missing"));
 
-        let unknown_actor = TxContext::new().argent_input("Missing", state(2), "bump", outpoint(1), utxo.clone());
+        let unknown_actor = TxContext::new().argent_input("Missing", state(2), "bump", outpoint(1), utxo.clone(), 0);
         assert!(matches!(builder.bind_context(&unknown_actor), Err(BuilderError::UnknownActor(actor)) if actor == "Missing"));
 
-        let unknown_entry = TxContext::new().argent_input("Counter", state(2), "missing", outpoint(1), utxo);
+        let unknown_entry = TxContext::new().argent_input("Counter", state(2), "missing", outpoint(1), utxo, 0);
         assert!(matches!(
             builder.bind_context(&unknown_entry),
             Err(BuilderError::UnknownEntry { actor, entry }) if actor == "Counter" && entry == "missing"
@@ -745,6 +796,7 @@ mod tests {
                 EntryCall::new("bump").args(vec![ArgValue::Value(ArtifactValue::Int(3))]),
                 outpoint(1),
                 counter_utxo.clone(),
+                0,
             )
             .input(
                 outpoint(2),
@@ -753,6 +805,7 @@ mod tests {
                     ordinary_callback_called.set(true);
                     vec![0xaa]
                 }),
+                0,
             )
             .argent_input(
                 "Counter",
@@ -768,6 +821,7 @@ mod tests {
                 }),
                 outpoint(3),
                 counter_utxo,
+                0,
             )
             .argent_output("Counter", state(3), CovenantBinding::new(0, covenant_id), 900);
         let mut resolved = builder.bind_context(&context).expect("context binds");
@@ -806,6 +860,7 @@ mod tests {
             EntryCall::new("choose").args(vec![actor("Beta")]),
             outpoint(1),
             router_utxo,
+            0,
         );
         let mut resolved = builder.bind_context(&context).expect("context binds");
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
@@ -836,6 +891,7 @@ mod tests {
             EntryCall::new("replace").args(vec![ArgValue::Value(ArtifactValue::Object(state(9)))]),
             outpoint(1),
             counter_utxo,
+            0,
         );
         let mut resolved = builder.bind_context(&context).expect("context binds");
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
@@ -858,13 +914,52 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x77; 32]);
         let counter_utxo =
             builder.covenant_utxo("Counter", state(2), 1_000, 0, false, Some(covenant_id)).expect("counter UTXO builds");
-        let context = TxContext::new().argent_input("Counter", state(2), "bump", outpoint(1), counter_utxo);
+        let context = TxContext::new().argent_input("Counter", state(2), "bump", outpoint(1), counter_utxo, 0);
         let mut resolved = builder.bind_context(&context).expect("context binds");
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
 
         assert!(matches!(
             builder.resolve_context_args(&mut resolved, &unsigned),
             Err(BuilderError::Codec(silverscript_abi::CodecError::WrongArgumentCount { expected: 1, actual: 0, .. }))
+        ));
+    }
+
+    #[test]
+    fn context_reports_fallible_callback_errors_with_input_identity() {
+        let artifact = artifact("primary", "Counter", "bump");
+        let builder = TxBuilder::new(&artifact).expect("artifact builds");
+        let covenant_id = Hash::from_bytes([0x78; 32]);
+        let counter_utxo =
+            builder.covenant_utxo("Counter", state(2), 1_000, 0, false, Some(covenant_id)).expect("counter UTXO builds");
+        let context = TxContext::new().argent_input(
+            "Counter",
+            state(2),
+            EntryCall::new("bump").try_args_with(|_, _| Err::<Vec<ArgValue>, _>(std::io::Error::other("signer unavailable"))),
+            outpoint(1),
+            counter_utxo,
+            0,
+        );
+
+        let error = builder.build(&context).expect_err("argument callback fails");
+        assert!(matches!(
+            error,
+            BuilderError::EntryArgsCallback { input_index: 0, actor, entry, source }
+                if actor == "Counter" && entry == "bump" && source.to_string() == "signer unavailable"
+        ));
+
+        let ordinary_utxo = UtxoEntry::new(100, ScriptPublicKey::default(), 0, false, None);
+        let context = TxContext::new().input(
+            outpoint(2),
+            ordinary_utxo,
+            InputSigScript::try_with_transaction(|_, _| Err::<Vec<u8>, _>(std::io::Error::other("script signer unavailable"))),
+            0,
+        );
+
+        let error = builder.build(&context).expect_err("sigscript callback fails");
+        assert!(matches!(
+            error,
+            BuilderError::InputSigScriptCallback { input_index: 0, source }
+                if source.to_string() == "script signer unavailable"
         ));
     }
 }

--- a/crates/silverscript-abi/Cargo.toml
+++ b/crates/silverscript-abi/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 rust-version = "1.94.0"
 
 [dependencies]
+blake2b_simd = { workspace = true }
 faster-hex = { workspace = true }
 kaspa-txscript = { workspace = true }
 serde = { workspace = true }
@@ -12,3 +13,5 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+# Keep the Sil compiler test-only; production ABI code must not depend on it.
+silverscript-lang = { workspace = true }

--- a/crates/silverscript-abi/src/lib.rs
+++ b/crates/silverscript-abi/src/lib.rs
@@ -12,6 +12,7 @@
 
 use std::collections::BTreeMap;
 
+use blake2b_simd::Params as Blake2bParams;
 use kaspa_txscript::{
     EngineFlags, deserialize_i64 as deserialize_script_i64,
     opcodes::codes::{
@@ -25,6 +26,27 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub const SIL_ABI_SCHEMA_VERSION: u32 = 1;
+const TEMPLATE_PART_LENGTH_BYTES: usize = 8;
+
+/// Calculate the canonical hash of a state-bearing Silverscript template.
+pub fn template_hash(prefix: &[u8], suffix: &[u8]) -> [u8; 32] {
+    let prefix_len = i64::try_from(prefix.len()).unwrap();
+    let suffix_len = i64::try_from(suffix.len()).unwrap();
+    let encoded_prefix_len = serialize_script_i64(prefix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
+    let encoded_suffix_len = serialize_script_i64(suffix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
+
+    Blake2bParams::new()
+        .hash_length(32)
+        .to_state()
+        .update(encoded_prefix_len.as_ref())
+        .update(prefix)
+        .update(encoded_suffix_len.as_ref())
+        .update(suffix)
+        .finalize()
+        .as_bytes()
+        .try_into()
+        .unwrap()
+}
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[error("unsupported {artifact} schema version {found}; expected {supported}")]
@@ -778,6 +800,17 @@ fn type_name(ty: &TypeArtifact) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Locks the ABI copy to Sil's canonical implementation. Ideally, Sil will
+    // expose this from a small shared core crate instead of requiring a copy.
+    #[test]
+    fn template_hash_matches_silverscript() {
+        let cases: &[(&[u8], &[u8])] = &[(b"", b""), (b"a", b"bc"), (b"ab", b"c"), (&[0, 1, 2, 3], &[0xff, 0x80, 0x40])];
+
+        for (prefix, suffix) in cases {
+            assert_eq!(template_hash(prefix, suffix), silverscript_lang::template::template_hash(prefix, suffix));
+        }
+    }
 
     #[test]
     fn encodes_pushes_like_silverscript_builder() {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -106,6 +106,7 @@ mod tests {
                 EntryCall::new("redeem").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), owner_pk.clone()]),
                 outpoint,
                 input_utxo.clone(),
+                0,
             )
             .argent_output("Ticket", redeemed_state, CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&context).expect("valid redeem tx passes");
@@ -118,6 +119,7 @@ mod tests {
                 EntryCall::new("redeem").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), wrong_pk.clone()]),
                 outpoint,
                 input_utxo.clone(),
+                0,
             )
             .argent_output("Ticket", ticket_state(owner_hash.clone(), 7, 1), CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&bad_args).is_err());
@@ -129,6 +131,7 @@ mod tests {
                 EntryCall::new("redeem").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), owner_pk.clone()]),
                 outpoint,
                 input_utxo,
+                0,
             )
             .argent_output("Ticket", initial_state, CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&stale_output).is_err());
@@ -152,6 +155,7 @@ mod tests {
                 EntryCall::new("redeem").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), owner_pk.clone()]),
                 TransactionOutpoint::new(TransactionId::from_bytes([0x22; 32]), 0),
                 input_utxo,
+                0,
             )
             .argent_output("Ticket", ticket_state(blake2b32(&owner_pk), 11, 1), CovenantBinding::new(0, covenant_id), 1_000);
         let transaction = builder.build(&context).expect("ticket transaction builds");
@@ -205,13 +209,14 @@ mod tests {
             .covenant_utxo("ReserveAsset", state.clone(), 1_000, 0, false, Some(asset_covenant_id))
             .expect("ReserveAsset UTXO builds");
         let context = TxContext::new()
-            .input(TransactionOutpoint::new(TransactionId::from_bytes([0x33; 32]), 0), owner_utxo, Vec::new())
+            .input(TransactionOutpoint::new(TransactionId::from_bytes([0x33; 32]), 0), owner_utxo, Vec::new(), 0)
             .argent_input(
                 "ReserveAsset",
                 state,
                 EntryCall::new("settle").args(args![100]),
                 TransactionOutpoint::new(TransactionId::from_bytes([0x34; 32]), 0),
                 asset_utxo,
+                0,
             )
             .argent_output("ReserveAsset", next_state, CovenantBinding::new(1, asset_covenant_id), 1_000);
         let transaction = builder.build(&context).expect("expanded actor transaction builds");
@@ -258,6 +263,7 @@ mod tests {
             EntryCall::new("redeem").args(args![vec![1; 65], owner_pk, vec![2; 32], vec![3; 32]]),
             TransactionOutpoint::new(TransactionId::from_bytes([0x42; 32]), 0),
             input_utxo,
+            0,
         );
         let err = builder.build(&context).expect_err("user must not provide hidden prefix/suffix witnesses");
 
@@ -310,6 +316,7 @@ mod tests {
                 EntryCall::new("bump").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), 3]),
                 outpoint,
                 input_utxo.clone(),
+                0,
             )
             .argent_output("Counter", next, CovenantBinding::new(0, covenant_id), input_value);
         let transaction = builder.build(&context).expect("context builds");
@@ -328,10 +335,11 @@ mod tests {
                 EntryCall::new("bump").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), 3]),
                 outpoint,
                 input_utxo,
+                0,
             )
             .argent_output("Counter", initial, CovenantBinding::new(0, covenant_id), input_value);
         let err = builder.build(&wrong_state).expect_err("incorrect expected state must fail contract execution");
-        assert!(matches!(err, BuilderError::TxScript(_)), "unexpected error: {err}");
+        assert!(matches!(err, BuilderError::InputScript { input_index: 0, .. }), "unexpected error: {err}");
     }
 
     #[test]
@@ -389,6 +397,7 @@ mod tests {
                 EntryCall::new("shift").args(args![3]),
                 TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x61; 32]), index: 0 },
                 left_utxo,
+                0,
             )
             .argent_input(
                 "Right",
@@ -396,6 +405,7 @@ mod tests {
                 "accept_shift",
                 TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x62; 32]), index: 0 },
                 right_utxo,
+                0,
             )
             .argent_output("Left", state! { units: 7 }, CovenantBinding::new(0, covenant_id), 3_000)
             .argent_output("Right", state! { units: 4 }, CovenantBinding::new(0, covenant_id), 2_000);
@@ -456,6 +466,7 @@ mod tests {
                 EntryCall::new("mint").args(args![asset_covenant_id, 7]),
                 controller_outpoint,
                 controller_utxo.clone(),
+                0,
             )
             .argent_input(
                 "badge_asset::Badge",
@@ -463,6 +474,7 @@ mod tests {
                 EntryCall::new("apply").args_with(|tx, input_idx| args![17, sign_mutable_input(tx, input_idx, &badge_owner)]),
                 badge_outpoint,
                 badge_utxo.clone(),
+                0,
             )
             .argent_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
             .argent_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
@@ -480,6 +492,7 @@ mod tests {
                 EntryCall::new("mint").args(args![asset_covenant_id, 7]),
                 controller_outpoint,
                 controller_utxo.clone(),
+                0,
             )
             .argent_input(
                 "badge_asset::Badge",
@@ -487,6 +500,7 @@ mod tests {
                 EntryCall::new("apply").args(args![17, vec![0; 65]]),
                 badge_outpoint,
                 badge_utxo.clone(),
+                0,
             )
             .argent_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
             .argent_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000)
@@ -512,6 +526,7 @@ mod tests {
                 EntryCall::new("mint").args(args![asset_covenant_id, 7]),
                 controller_outpoint,
                 controller_utxo,
+                0,
             )
             .argent_input(
                 "badge_asset::Badge",
@@ -519,6 +534,7 @@ mod tests {
                 EntryCall::new("apply").args(args![17, vec![0; 65]]),
                 badge_outpoint,
                 badge_utxo,
+                0,
             )
             .argent_output("Controller", controller_next, CovenantBinding::new(0, controller_covenant_id), 4_000)
             .output(ordinary_badge_script, Some(CovenantBinding::new(1, asset_covenant_id)), 2_000);
@@ -574,6 +590,7 @@ mod tests {
                 EntryCall::new("swap").args(args![asset_covenant_id, next_owner_pk.clone()]),
                 controller_outpoint,
                 controller_utxo.clone(),
+                0,
             )
             .argent_input(
                 "asset_app::Asset",
@@ -582,6 +599,7 @@ mod tests {
                     .args_with(|tx, input_idx| args![next_owner_pk.clone(), sign_mutable_input(tx, input_idx, &owner)]),
                 asset_outpoint,
                 asset_utxo.clone(),
+                0,
             )
             .argent_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
             .argent_output("asset_app::Asset", asset_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
@@ -598,6 +616,7 @@ mod tests {
                 EntryCall::new("swap").args(args![asset_covenant_id, next_owner_pk.clone()]),
                 controller_outpoint,
                 controller_utxo,
+                0,
             )
             .argent_input(
                 "asset_app::Asset",
@@ -605,11 +624,12 @@ mod tests {
                 EntryCall::new("transfer").args(args![next_owner_pk.clone(), vec![0; 65]]),
                 asset_outpoint,
                 asset_utxo,
+                0,
             )
             .argent_output("Controller", controller_next, CovenantBinding::new(0, controller_covenant_id), 4_000)
             .argent_output("asset_app::Asset", asset_next, CovenantBinding::new(1, asset_covenant_id), 2_000);
         let err = builder.build(&invalid_signature).expect_err("invalid observed co-spend signature must fail");
-        assert!(matches!(err, BuilderError::TxScript(_)), "unexpected error: {err}");
+        assert!(matches!(err, BuilderError::InputScript { input_index: 1, .. }), "unexpected error: {err}");
     }
 
     #[test]
@@ -695,6 +715,7 @@ mod tests {
                     .args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner_a), owner_a_pk.clone(), 0, 7, 3]),
                 outpoint_a,
                 player_a_utxo.clone(),
+                0,
             )
             .argent_input(
                 "Player",
@@ -703,6 +724,7 @@ mod tests {
                     .args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner_b), owner_b_pk.clone()]),
                 outpoint_b,
                 player_b_utxo.clone(),
+                0,
             )
             .argent_output("Player", next_a.clone(), CovenantBinding::new(0, covenant_id), input_a_value)
             .argent_output("Player", next_b.clone(), CovenantBinding::new(0, covenant_id), input_b_value)
@@ -751,6 +773,7 @@ mod tests {
                     .args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner_a), owner_a_pk.clone(), 0, 7, 3]),
                 outpoint_a,
                 player_a_utxo.clone(),
+                0,
             )
             .argent_input(
                 "Player",
@@ -759,6 +782,7 @@ mod tests {
                     .args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner_b), owner_b_pk.clone()]),
                 outpoint_b,
                 player_b_utxo,
+                0,
             )
             .argent_output("Player", next_b, CovenantBinding::new(0, covenant_id), input_b_value)
             .argent_output("Player", next_a, CovenantBinding::new(0, covenant_id), input_a_value)
@@ -776,8 +800,9 @@ mod tests {
                     .args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner_a), owner_a_pk.clone(), 0, 7, 3]),
                 outpoint_a,
                 player_a_utxo,
+                0,
             )
-            .input(outpoint_b, wrong_peer, Vec::new())
+            .input(outpoint_b, wrong_peer, Vec::new(), 0)
             .argent_output(
                 "Player",
                 player_state(owner_a_hash, player_a_id, 1, 0, 0, 0),
@@ -808,7 +833,7 @@ mod tests {
             .covenant_utxo("Player", player_initial.clone(), input_value, 0, false, Some(covenant_id))
             .expect("Player utxo builds");
         let enter_mux = TxContext::new()
-            .argent_input("Player", player_initial.clone(), "enter_mux", player_outpoint, player_utxo.clone())
+            .argent_input("Player", player_initial.clone(), "enter_mux", player_outpoint, player_utxo.clone(), 0)
             .argent_output("Mux", mux_initial.clone(), CovenantBinding::new(0, covenant_id), input_value);
         let enter_mux_tx = builder.build(&enter_mux).expect("Player can enter the mux family");
 
@@ -846,7 +871,7 @@ mod tests {
         let mux_utxo =
             builder.covenant_utxo("Mux", mux_initial.clone(), input_value, 0, false, Some(covenant_id)).expect("Mux utxo builds");
         let choose_pawn = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), "choose_pawn", mux_outpoint, mux_utxo.clone())
+            .argent_input("Mux", mux_initial.clone(), "choose_pawn", mux_outpoint, mux_utxo.clone(), 0)
             .argent_output("Pawn", pawn_next.clone(), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&choose_pawn).expect("Mux can route to Pawn by table slice");
 
@@ -858,6 +883,7 @@ mod tests {
                 EntryCall::new("choose").args(args![actor("Pawn")]),
                 mux_outpoint,
                 mux_utxo.clone(),
+                0,
             )
             .argent_output("Pawn", dynamic_pawn_next.clone(), CovenantBinding::new(0, covenant_id), input_value);
         let context_tx = builder.build(&context).expect("context builder resolves the dynamic route witnesses");
@@ -870,12 +896,13 @@ mod tests {
                 EntryCall::new("choose").args(args![actor("Knight")]),
                 mux_outpoint,
                 mux_utxo.clone(),
+                0,
             )
             .argent_output("Knight", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&dynamic_knight).expect("Mux selector can choose the second table entry");
 
         let missing_selector = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), EntryCall::new("choose").args(args![0]), mux_outpoint, mux_utxo.clone())
+            .argent_input("Mux", mux_initial.clone(), EntryCall::new("choose").args(args![0]), mux_outpoint, mux_utxo.clone(), 0)
             .argent_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         let missing_selector = builder.build(&missing_selector).expect_err("selector entries require an explicit template choice");
         assert!(
@@ -890,6 +917,7 @@ mod tests {
                 EntryCall::new("choose").args(args![actor("League")]),
                 mux_outpoint,
                 mux_utxo.clone(),
+                0,
             )
             .argent_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         let invalid_selector = builder.build(&invalid_selector).expect_err("selector must choose one of the actor enum variants");
@@ -909,21 +937,22 @@ mod tests {
                 EntryCall::new("choose").args(args![actor("Knight")]),
                 mux_outpoint,
                 mux_utxo.clone(),
+                0,
             )
             .argent_output("Pawn", dynamic_pawn_next, CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&wrong_selector).is_err(), "selector witness must match the actor selected by table index");
 
         let const_knight = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone())
+            .argent_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone(), 0)
             .argent_output("Knight", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&const_knight).expect("fixed actor enum selector can route to Knight without caller selector metadata");
 
         let const_wrong_output = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone())
+            .argent_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone(), 0)
             .argent_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&const_wrong_output).is_err(), "fixed actor enum selector must reject a non-Knight output");
 
-        let wrong_worker = TxContext::new().argent_input("Mux", mux_initial, "choose_pawn", mux_outpoint, mux_utxo).argent_output(
+        let wrong_worker = TxContext::new().argent_input("Mux", mux_initial, "choose_pawn", mux_outpoint, mux_utxo, 0).argent_output(
             "Knight",
             pawn_next,
             CovenantBinding::new(0, covenant_id),
@@ -1059,12 +1088,12 @@ mod tests {
         let input_utxo =
             builder.covenant_utxo("Foo", initial.clone(), input_value, 0, false, Some(covenant_id)).expect("foo utxo builds");
         let context = TxContext::new()
-            .argent_input("Foo", initial.clone(), EntryCall::new("bump").args(args![5]), outpoint, input_utxo.clone())
+            .argent_input("Foo", initial.clone(), EntryCall::new("bump").args(args![5]), outpoint, input_utxo.clone(), 0)
             .argent_output("Foo", next.clone(), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&context).expect("same-template transition passes");
 
         let wrong_template = TxContext::new()
-            .argent_input("Foo", initial, EntryCall::new("bump").args(args![5]), outpoint, input_utxo)
+            .argent_input("Foo", initial, EntryCall::new("bump").args(args![5]), outpoint, input_utxo, 0)
             .argent_output("Bar", next, CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&wrong_template).is_err(), "same-template validation must reject a different actor template");
     }
@@ -1102,6 +1131,7 @@ mod tests {
                     .args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), owner_pk.clone()]),
                 outpoint,
                 league_utxo.clone(),
+                0,
             )
             .argent_output("League", league_initial.clone(), CovenantBinding::new(0, covenant_id), input_value)
             .argent_output("Player", player_next.clone(), CovenantBinding::new(0, covenant_id), player_value);
@@ -1150,6 +1180,7 @@ mod tests {
                     .args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), owner_pk.clone()]),
                 outpoint,
                 league_utxo,
+                0,
             )
             .argent_output("League", changed_league_state, CovenantBinding::new(0, covenant_id), input_value)
             .argent_output("Player", player_next, CovenantBinding::new(0, covenant_id), player_value);
@@ -1214,6 +1245,7 @@ mod tests {
                 }),
                 minter_outpoint,
                 minter_utxo.clone(),
+                0,
             )
             .argent_input(
                 "kcc20_asset::MinterProxy",
@@ -1221,6 +1253,7 @@ mod tests {
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
                 proxy_outpoint,
                 proxy_utxo.clone(),
+                0,
             )
             .argent_output("Minter", minter_next.clone(), CovenantBinding::new(0, controller_covenant_id), minter_value)
             .argent_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
@@ -1270,6 +1303,7 @@ mod tests {
                 EntryCall::new("mint").args(args![vec![0; 65], recipient_owner.clone(), minted_amount]),
                 minter_outpoint,
                 minter_utxo.clone(),
+                0,
             )
             .argent_output("Minter", minter_next.clone(), CovenantBinding::new(0, controller_covenant_id), minter_value)
             .argent_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
@@ -1285,6 +1319,7 @@ mod tests {
                 EntryCall::new("mint").args(args![vec![0; 65], recipient_owner.clone(), minted_amount]),
                 minter_outpoint,
                 minter_utxo.clone(),
+                0,
             )
             .argent_input(
                 "kcc20_asset::MinterProxy",
@@ -1292,6 +1327,7 @@ mod tests {
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
                 proxy_outpoint,
                 proxy_utxo.clone(),
+                0,
             );
         let wrong_proxy_err = builder.build(&wrong_proxy).expect_err("observed input state must match its UTXO script");
         assert!(matches!(wrong_proxy_err, BuilderError::ArgentInputScriptMismatch { input_index: 1, .. }));
@@ -1305,6 +1341,7 @@ mod tests {
                 }),
                 minter_outpoint,
                 minter_utxo.clone(),
+                0,
             )
             .argent_input(
                 "kcc20_asset::MinterProxy",
@@ -1312,6 +1349,7 @@ mod tests {
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
                 proxy_outpoint,
                 proxy_utxo.clone(),
+                0,
             )
             .argent_output("Minter", minter_next, CovenantBinding::new(0, controller_covenant_id), minter_value)
             .argent_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
@@ -1335,6 +1373,7 @@ mod tests {
                 EntryCall::new("mint").args(args![vec![0; 65], recipient_owner.clone(), minted_amount]),
                 minter_outpoint,
                 wrong_asset_minter_utxo,
+                0,
             )
             .argent_input(
                 "kcc20_asset::MinterProxy",
@@ -1342,6 +1381,7 @@ mod tests {
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
                 proxy_outpoint,
                 proxy_utxo,
+                0,
             )
             .argent_output("Minter", wrong_asset_minter_next, CovenantBinding::new(0, controller_covenant_id), minter_value)
             .argent_output("kcc20_asset::MinterProxy", proxy_state, CovenantBinding::new(1, asset_covenant_id), proxy_value)
@@ -1475,13 +1515,14 @@ mod tests {
             .expect("cell UTXO builds");
 
         let context = TxContext::new()
-            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo.clone())
+            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo.clone(), 0)
             .argent_input(
                 "open_agent::Agent",
                 agent_initial.clone(),
                 EntryCall::new("step").args(args![agent_next.clone()]),
                 agent_outpoint,
                 agent_utxo.clone(),
+                0,
             )
             .argent_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value)
             .argent_output("open_agent::Agent", agent_next.clone(), CovenantBinding::new(1, agent_covenant_id), agent_value);
@@ -1493,7 +1534,7 @@ mod tests {
         assert!(transaction.inputs.iter().all(|input| input.compute_commit.compute_budget().is_some()));
 
         let missing_observed = TxContext::new()
-            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo)
+            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo, 0)
             .argent_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value);
         let missing_observed_err = builder.build(&missing_observed).expect_err("the declared observed input/output pair is required");
         assert!(
@@ -1524,13 +1565,14 @@ mod tests {
             .covenant_utxo("open_agent::Agent", agent_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("bad-layout bundle still builds the Agent UTXO");
         let bad_layout_context = TxContext::new()
-            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, bad_layout_cell_utxo)
+            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, bad_layout_cell_utxo, 0)
             .argent_input(
                 "open_agent::Agent",
                 agent_initial.clone(),
                 EntryCall::new("step").args(args![agent_next.clone()]),
                 agent_outpoint,
                 bad_layout_agent_utxo,
+                0,
             )
             .argent_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value)
             .argent_output("open_agent::Agent", agent_next.clone(), CovenantBinding::new(1, agent_covenant_id), agent_value);
@@ -1565,8 +1607,15 @@ mod tests {
             .covenant_utxo("open_agent::Forager", expanded_agent_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("expanded agent utxo builds");
         let expanded_context = TxContext::new()
-            .argent_input("Cell", expanded_cell_initial, "advance", cell_outpoint, expanded_cell_utxo)
-            .argent_input("open_agent::Forager", expanded_agent_initial.clone(), "step", agent_outpoint, expanded_agent_utxo.clone())
+            .argent_input("Cell", expanded_cell_initial, "advance", cell_outpoint, expanded_cell_utxo, 0)
+            .argent_input(
+                "open_agent::Forager",
+                expanded_agent_initial.clone(),
+                "step",
+                agent_outpoint,
+                expanded_agent_utxo.clone(),
+                0,
+            )
             .argent_output("Cell", expanded_cell_next, CovenantBinding::new(0, controller_covenant_id), cell_value)
             .argent_output("open_agent::Forager", expanded_agent_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
         expanded_builder.build(&expanded_context).expect("open ICC accepts an actor state that expands the observed capsule");
@@ -1576,8 +1625,14 @@ mod tests {
         flattened_forager_state.insert("hunger".to_string(), ArtifactValue::Int(2));
         flattened_forager_state.insert("mood".to_string(), ArtifactValue::Int(1));
         flattened_forager_state.insert("target_agent_id".to_string(), ArtifactValue::Bytes(vec![0x55; 32]));
-        let flattened_context =
-            TxContext::new().argent_input("open_agent::Forager", flattened_forager_state, "step", agent_outpoint, expanded_agent_utxo);
+        let flattened_context = TxContext::new().argent_input(
+            "open_agent::Forager",
+            flattened_forager_state,
+            "step",
+            agent_outpoint,
+            expanded_agent_utxo,
+            0,
+        );
         let flattened_err =
             expanded_builder.build(&flattened_context).expect_err("expanded agent state must provide slot-qualified source fields");
         assert!(
@@ -1599,13 +1654,14 @@ mod tests {
             .covenant_utxo("open_agent::Forager", forager_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("Forager utxo builds");
         let forager_context = TxContext::new()
-            .argent_input("Cell", forager_cell_initial.clone(), "advance", cell_outpoint, forager_cell_utxo)
+            .argent_input("Cell", forager_cell_initial.clone(), "advance", cell_outpoint, forager_cell_utxo, 0)
             .argent_input(
                 "open_agent::Forager",
                 forager_initial,
                 EntryCall::new("step").args(args![0, 0, 4]),
                 forager_outpoint,
                 forager_utxo,
+                0,
             )
             .argent_output("Cell", forager_cell_initial, CovenantBinding::new(0, controller_covenant_id), cell_value)
             .argent_output("open_agent::Forager", forager_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
@@ -1619,13 +1675,14 @@ mod tests {
             .covenant_utxo("open_agent::Agent", agent_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("wrong-output Agent UTXO builds");
         let wrong_context = TxContext::new()
-            .argent_input("Cell", cell_initial, "advance", cell_outpoint, wrong_cell_utxo)
+            .argent_input("Cell", cell_initial, "advance", cell_outpoint, wrong_cell_utxo, 0)
             .argent_input(
                 "open_agent::Agent",
                 agent_initial,
                 EntryCall::new("step").args(args![wrong_agent_next.clone()]),
                 agent_outpoint,
                 wrong_agent_utxo,
+                0,
             )
             .argent_output("Cell", cell_next, CovenantBinding::new(0, controller_covenant_id), cell_value)
             .argent_output("open_agent::Agent", wrong_agent_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
@@ -1699,6 +1756,7 @@ mod tests {
                 "advance",
                 TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x55; 32]), index: 0 },
                 cell_utxo,
+                0,
             )
             .argent_input(
                 "agent_app::Agent",
@@ -1706,6 +1764,7 @@ mod tests {
                 EntryCall::new("step").args(args![next_agent_state.clone()]),
                 TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x66; 32]), index: 0 },
                 agent_utxo,
+                0,
             )
             .argent_output("Cell", next_cell_state, CovenantBinding::new(0, controller_covenant_id), 2_000)
             .argent_output("agent_app::Agent", next_agent_state, CovenantBinding::new(1, agent_covenant_id), 1_000);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -509,7 +509,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                BuilderError::ObservedCountMismatch { ref observe, side: "output", expected: 1, found: 2 }
+                BuilderError::ObservedCountMismatch { ref observe, side: Side::Out, expected: 1, found: 2 }
                     if observe == "asset"
             ),
             "unexpected error: {err}"
@@ -544,7 +544,7 @@ mod tests {
                 err,
                 BuilderError::MissingObservedActorMetadata {
                     ref observe,
-                    side: "output",
+                    side: Side::Out,
                     ref handle,
                     index: 1
                 } if observe == "asset" && handle == "badge"
@@ -1309,7 +1309,7 @@ mod tests {
             .argent_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
             .argent_output("kcc20_asset::KCC20", recipient_state.clone(), CovenantBinding::new(1, asset_covenant_id), recipient_value);
         let missing_proxy_err = builder.build(&missing_proxy).expect_err("missing observed input is rejected by the runtime");
-        assert!(matches!(missing_proxy_err, BuilderError::ObservedCountMismatch { side: "input", expected: 1, found: 0, .. }));
+        assert!(matches!(missing_proxy_err, BuilderError::ObservedCountMismatch { side: Side::In, expected: 1, found: 0, .. }));
 
         let wrong_proxy_state = minter_proxy_state(Hash::from_bytes([0xd0; 32]));
         let wrong_proxy = TxContext::new()
@@ -1539,7 +1539,7 @@ mod tests {
         let missing_observed_err = builder.build(&missing_observed).expect_err("the declared observed input/output pair is required");
         assert!(
             matches!(&missing_observed_err, BuilderError::ObservedCountMismatch { observe, side, expected: 1, found: 0 }
-                if observe == "remote" && *side == "input"),
+                if observe == "remote" && *side == Side::In),
             "unexpected error: {missing_observed_err}"
         );
 
@@ -1582,7 +1582,7 @@ mod tests {
             matches!(
                 &bad_layout_err,
                 BuilderError::ObservedStateLayoutMismatch { observe, side, handle, state, actor }
-                    if observe == "remote" && *side == "input" && handle == "agent" && state == "AgentCapsule" && actor == "Agent"
+                    if observe == "remote" && *side == Side::In && handle == "agent" && state == "AgentCapsule" && actor == "Agent"
             ),
             "unexpected error: {bad_layout_err}"
         );

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -22,7 +22,6 @@ pub fn emit_build_app(program: &Program, app_name: &str, out_dir: impl AsRef<Pat
 fn emit_build_selected(program: &Program, app_name: Option<&str>, out_dir: impl AsRef<Path>) -> Result<()> {
     let out_dir = out_dir.as_ref();
     let sil_dir = out_dir.join("sil");
-    fs::create_dir_all(&sil_dir).map_err(|err| ArgentError::at(out_dir, err.to_string()))?;
 
     let model = match app_name {
         Some(app_name) => Model::from_program_app(program, app_name)?,
@@ -31,15 +30,24 @@ fn emit_build_selected(program: &Program, app_name: Option<&str>, out_dir: impl 
     let mut actor_sil = BTreeMap::new();
     for actor in &model.actors {
         let sil = emit_actor(actor, &model)?;
-        fs::write(sil_dir.join(format!("{}.sil", actor.name)), &sil)
-            .map_err(|err| ArgentError::at(sil_dir.join(format!("{}.sil", actor.name)), err.to_string()))?;
         actor_sil.insert(actor.name.clone(), sil);
     }
+    let manifest = emit_manifest(program, &model);
+    let artifact = emit_artifact_json(program, &model, &actor_sil)?;
 
-    fs::write(out_dir.join("manifest.json"), emit_manifest(program, &model))
+    if sil_dir.exists() {
+        fs::remove_dir_all(&sil_dir).map_err(|err| ArgentError::at(&sil_dir, err.to_string()))?;
+    }
+    fs::create_dir_all(&sil_dir).map_err(|err| ArgentError::at(&sil_dir, err.to_string()))?;
+    for (actor, sil) in &actor_sil {
+        let path = sil_dir.join(format!("{actor}.sil"));
+        fs::write(&path, sil).map_err(|err| ArgentError::at(path, err.to_string()))?;
+    }
+
+    fs::write(out_dir.join("manifest.json"), manifest)
         .map_err(|err| ArgentError::at(out_dir.join("manifest.json"), err.to_string()))?;
 
-    fs::write(out_dir.join("artifact.json"), emit_artifact_json(program, &model, &actor_sil)?)
+    fs::write(out_dir.join("artifact.json"), artifact)
         .map_err(|err| ArgentError::at(out_dir.join("artifact.json"), err.to_string()))?;
     Ok(())
 }

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -6293,6 +6293,19 @@ mod tests {
         handle.template.prefix_hex = encode_hex(&prefix);
         let err = corrupted.verify_template_plan().expect_err("corrupted capsule context is rejected");
         assert!(matches!(err, TemplatePlanError::ActorTypeHandleMismatch { .. }), "unexpected error: {err}");
+
+        let mut corrupted = artifact.clone();
+        let handle = corrupted
+            .argent
+            .template_plan
+            .templates
+            .iter_mut()
+            .find(|template| template.actor == "ReserveAsset")
+            .and_then(|template| template.actor_type_handle.as_mut())
+            .expect("ReserveAsset capsule handle exists");
+        handle.template.hash_hex = "00".repeat(32);
+        let err = corrupted.verify_template_plan().expect_err("corrupted capsule hash is rejected");
+        assert!(matches!(err, TemplatePlanError::ActorTypeHandleMismatch { .. }), "unexpected error: {err}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,27 @@ app RightApp {
     }
 
     #[test]
+    fn build_file_app_removes_stale_selected_app_contracts() {
+        let temp = std::env::temp_dir().join(format!("argent-build-file-app-clean-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir_all(&temp).expect("temp dir created");
+
+        let input = temp.join("pair.ag");
+        let out_dir = temp.join("build");
+        std::fs::write(&input, TWO_APPS).expect("source written");
+
+        build_file_app(&input, "LeftApp", &out_dir).expect("left app builds");
+        assert!(out_dir.join("sil/Left.sil").exists());
+
+        build_file_app(&input, "RightApp", &out_dir).expect("right app builds");
+        assert!(!out_dir.join("sil/Left.sil").exists());
+        assert!(out_dir.join("sil/Right.sil").exists());
+        assert!(out_dir.join("sil/RightAlt.sil").exists());
+
+        let _ = std::fs::remove_dir_all(temp);
+    }
+
+    #[test]
     fn build_file_requires_selection_for_multiple_root_apps() {
         let temp = std::env::temp_dir().join(format!("argent-build-file-ambiguous-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&temp);


### PR DESCRIPTION
This PR tightens artifact and build correctness while expanding the transaction builder surface:

- recomputes actor-type handles from canonical template data during artifact verification
- locks Argent’s template-hash implementation against Silverscript
- removes stale generated contracts when rebuilding a selected app
- adds explicit input sequences and transaction-level lock time, lane, gas, and payload settings
- supports fallible argument and sigscript callbacks
- preserves input indexes and typed input/output sides in builder errors

The explicit sequence parameter is an API change for transaction-context inputs.