### PR TITLE
Add context-managed genesis groups and spawn composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ let input_utxo = builder.covenant_utxo(
 )?;
 
 let context = TxContext::new()
-    .argent_input(
+    .actor_input(
         "Counter",
         input_state,
         EntryCall::new("bump").args(args![3]),
@@ -178,7 +178,7 @@ let context = TxContext::new()
         input_utxo,
         0, // sequence
     )
-    .argent_output(
+    .actor_output(
         "Counter",
         output_state,
         CovenantBinding::new(0, covenant_id),

--- a/crates/argent-runtime/src/context.rs
+++ b/crates/argent-runtime/src/context.rs
@@ -51,7 +51,7 @@ impl fmt::Display for ActorPath {
     }
 }
 
-type CallbackError = Box<dyn Error + Send + Sync + 'static>;
+pub(crate) type CallbackError = Box<dyn Error + Send + Sync + 'static>;
 type EntryArgsCallback<'a> = dyn Fn(&MutableTransaction<Transaction>, usize) -> Result<Vec<ArgValue>, CallbackError> + 'a;
 
 /// User arguments for an Argent entry call.
@@ -189,11 +189,67 @@ pub enum ContextInput<'a> {
     Ordinary(OrdinaryInput<'a>),
 }
 
+/// Context available while deferred actor output states are resolved.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct StateContext {}
+
+type OutputStateCallback<'a> = dyn Fn(&StateContext) -> Result<BTreeMap<String, ArtifactValue>, CallbackError> + 'a;
+
+/// Static actor state or state derived while the transaction is being built.
+pub enum OutputState<'a> {
+    /// State known when the transaction context is assembled.
+    Static(BTreeMap<String, ArtifactValue>),
+    /// State built later from the transaction state-resolution context.
+    WithContext(Box<OutputStateCallback<'a>>),
+}
+
+impl OutputState<'_> {
+    pub(crate) fn resolve(&self, context: &StateContext) -> Result<BTreeMap<String, ArtifactValue>, CallbackError> {
+        match self {
+            Self::Static(state) => Ok(state.clone()),
+            Self::WithContext(build) => build(context),
+        }
+    }
+
+    pub(crate) fn is_deferred(&self) -> bool {
+        matches!(self, Self::WithContext(_))
+    }
+}
+
+impl fmt::Debug for OutputState<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static(state) => formatter.debug_tuple("Static").field(state).finish(),
+            Self::WithContext(_) => formatter.write_str("WithContext(<callback>)"),
+        }
+    }
+}
+
+impl<'a> From<BTreeMap<String, ArtifactValue>> for OutputState<'a> {
+    fn from(state: BTreeMap<String, ArtifactValue>) -> Self {
+        Self::Static(state)
+    }
+}
+
+/// Build actor output state from transaction state-resolution context.
+pub fn state_with<'a>(build: impl Fn(&StateContext) -> BTreeMap<String, ArtifactValue> + 'a) -> OutputState<'a> {
+    OutputState::WithContext(Box::new(move |context| Ok(build(context))))
+}
+
+/// Fallibly build actor output state from transaction state-resolution context.
+pub fn try_state_with<'a, E>(build: impl Fn(&StateContext) -> Result<BTreeMap<String, ArtifactValue>, E> + 'a) -> OutputState<'a>
+where
+    E: Error + Send + Sync + 'static,
+{
+    OutputState::WithContext(Box::new(move |context| build(context).map_err(|error| Box::new(error) as CallbackError)))
+}
+
 /// The actor or script that controls one transaction output.
-#[derive(Clone, Debug)]
-pub enum OutputOwner {
+#[derive(Debug)]
+pub enum OutputOwner<'a> {
     /// An Argent actor whose P2SH script is derived from its artifact and state.
-    Actor { actor: ActorPath, state: BTreeMap<String, ArtifactValue> },
+    Actor { actor: ActorPath, state: OutputState<'a> },
     /// A concrete script supplied directly by the caller.
     Spk(ScriptPublicKey),
 }
@@ -210,9 +266,9 @@ pub enum OutputCovenant {
 }
 
 /// One ordered output in a transaction context.
-#[derive(Clone, Debug)]
-pub struct ContextOutput {
-    pub owner: OutputOwner,
+#[derive(Debug)]
+pub struct ContextOutput<'a> {
+    pub owner: OutputOwner<'a>,
     pub covenant: OutputCovenant,
     pub value: u64,
 }
@@ -231,7 +287,7 @@ pub struct ContextOutput {
 #[derive(Debug, Default)]
 pub struct TxContext<'a> {
     pub inputs: Vec<ContextInput<'a>>,
-    pub outputs: Vec<ContextOutput>,
+    pub outputs: Vec<ContextOutput<'a>>,
     pub lock_time: u64,
     pub subnetwork_id: SubnetworkId,
     pub gas: u64,
@@ -304,12 +360,12 @@ impl<'a> TxContext<'a> {
     pub fn argent_output(
         mut self,
         actor: impl Into<ActorPath>,
-        state: BTreeMap<String, ArtifactValue>,
+        state: impl Into<OutputState<'a>>,
         covenant: CovenantBinding,
         value: u64,
     ) -> Self {
         self.outputs.push(ContextOutput {
-            owner: OutputOwner::Actor { actor: actor.into(), state },
+            owner: OutputOwner::Actor { actor: actor.into(), state: state.into() },
             covenant: OutputCovenant::Existing(covenant),
             value,
         });
@@ -329,7 +385,7 @@ impl<'a> TxContext<'a> {
         value: u64,
     ) -> Self {
         self.outputs.push(ContextOutput {
-            owner: OutputOwner::Actor { actor: actor.into(), state },
+            owner: OutputOwner::Actor { actor: actor.into(), state: OutputState::Static(state) },
             covenant: OutputCovenant::Genesis { authorizing_input, subgroup: subgroup.into() },
             value,
         });

--- a/crates/argent-runtime/src/context.rs
+++ b/crates/argent-runtime/src/context.rs
@@ -388,8 +388,9 @@ impl<'a> TxContext<'a> {
 
     /// Append a statically defined Argent output to a new covenant group.
     ///
-    /// Repeating the same `launch::<name>` and authorizing input places
-    /// multiple outputs in one ordered genesis group.
+    /// Repeating the same genesis path and authorizing input places multiple
+    /// outputs in one ordered group. Use `launch::<name>` for an independent
+    /// launch or `spawn::<clause>` for an entry's declared spawn.
     pub fn argent_genesis_output(
         mut self,
         authorizing_input: u16,
@@ -417,6 +418,9 @@ impl<'a> TxContext<'a> {
     }
 
     /// Append a concrete-script output to a new covenant group.
+    ///
+    /// Spawn groups require actor metadata, so `spawn::<clause>` paths must use
+    /// [`Self::argent_genesis_output`].
     pub fn genesis_output(
         mut self,
         authorizing_input: u16,

--- a/crates/argent-runtime/src/context.rs
+++ b/crates/argent-runtime/src/context.rs
@@ -332,8 +332,8 @@ impl<'a> TxContext<'a> {
         self
     }
 
-    /// Append an Argent covenant input.
-    pub fn argent_input(
+    /// Append an actor covenant input.
+    pub fn actor_input(
         mut self,
         actor: impl Into<ActorPath>,
         state: BTreeMap<String, ArtifactValue>,
@@ -370,8 +370,8 @@ impl<'a> TxContext<'a> {
         self
     }
 
-    /// Append an Argent covenant output.
-    pub fn argent_output(
+    /// Append an actor covenant output.
+    pub fn actor_output(
         mut self,
         actor: impl Into<ActorPath>,
         state: impl Into<OutputState<'a>>,
@@ -386,12 +386,12 @@ impl<'a> TxContext<'a> {
         self
     }
 
-    /// Append a statically defined Argent output to a new covenant group.
+    /// Append a statically defined actor output to a new covenant group.
     ///
     /// Repeating the same genesis path and authorizing input places multiple
     /// outputs in one ordered group. Use `launch::<name>` for an independent
     /// launch or `spawn::<clause>` for an entry's declared spawn.
-    pub fn argent_genesis_output(
+    pub fn actor_genesis_output(
         mut self,
         authorizing_input: u16,
         subgroup: impl Into<String>,
@@ -420,7 +420,7 @@ impl<'a> TxContext<'a> {
     /// Append a concrete-script output to a new covenant group.
     ///
     /// Spawn groups require actor metadata, so `spawn::<clause>` paths must use
-    /// [`Self::argent_genesis_output`].
+    /// [`Self::actor_genesis_output`].
     pub fn genesis_output(
         mut self,
         authorizing_input: u16,
@@ -463,7 +463,7 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x42; 32]);
         let binding = CovenantBinding::new(0, covenant_id);
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Counter",
                 BTreeMap::from([("count".to_string(), ArtifactValue::Int(2))]),
                 EntryCall::new("bump").args(vec![ArgValue::Value(ArtifactValue::Int(3))]),
@@ -472,8 +472,8 @@ mod tests {
                 3,
             )
             .input(outpoint(2), utxo(None), vec![0xaa], 4)
-            .argent_output("Counter", BTreeMap::from([("count".to_string(), ArtifactValue::Int(5))]), binding, 900)
-            .argent_genesis_output(1, "launch::reserve", "Reserve", BTreeMap::new(), 50)
+            .actor_output("Counter", BTreeMap::from([("count".to_string(), ArtifactValue::Int(5))]), binding, 900)
+            .actor_genesis_output(1, "launch::reserve", "Reserve", BTreeMap::new(), 50)
             .output(ScriptPublicKey::default(), None, 100)
             .genesis_output(1, "launch::script", ScriptPublicKey::default(), 25)
             .lock_time(5)

--- a/crates/argent-runtime/src/context.rs
+++ b/crates/argent-runtime/src/context.rs
@@ -123,7 +123,7 @@ impl<'a> From<String> for EntryCall<'a> {
 
 type InputSigScriptCallback<'a> = dyn Fn(&MutableTransaction<Transaction>, usize) -> Result<Vec<u8>, CallbackError> + 'a;
 
-/// Signature script supplied for a non-Argent input.
+/// Signature script supplied for an ordinary non-actor input.
 pub enum InputSigScript<'a> {
     /// A complete signature script known before transaction assembly.
     Static(Vec<u8>),
@@ -163,9 +163,9 @@ impl<'a> From<Vec<u8>> for InputSigScript<'a> {
     }
 }
 
-/// One Argent covenant input in a transaction context.
+/// One actor covenant input in a transaction context.
 #[derive(Debug)]
-pub struct ArgentInput<'a> {
+pub struct ActorInput<'a> {
     pub actor: ActorPath,
     pub state: BTreeMap<String, ArtifactValue>,
     pub entry: EntryCall<'a>,
@@ -174,7 +174,7 @@ pub struct ArgentInput<'a> {
     pub sequence: u64,
 }
 
-/// One non-Argent input in a transaction context.
+/// One ordinary non-actor input in a transaction context.
 #[derive(Debug)]
 pub struct OrdinaryInput<'a> {
     pub outpoint: TransactionOutpoint,
@@ -186,7 +186,7 @@ pub struct OrdinaryInput<'a> {
 /// An ordered input in a transaction context.
 #[derive(Debug)]
 pub enum ContextInput<'a> {
-    Argent(ArgentInput<'a>),
+    Actor(ActorInput<'a>),
     Ordinary(OrdinaryInput<'a>),
 }
 
@@ -262,7 +262,7 @@ where
 /// The actor or script that controls one transaction output.
 #[derive(Debug)]
 pub enum OutputOwner<'a> {
-    /// An Argent actor whose P2SH script is derived from its artifact and state.
+    /// An actor whose P2SH script is derived from its artifact and state.
     Actor { actor: ActorPath, state: OutputState<'a> },
     /// A concrete script supplied directly by the caller.
     Spk(ScriptPublicKey),
@@ -291,7 +291,7 @@ pub struct ContextOutput<'a> {
 ///
 /// Inputs and outputs appear in transaction order. The context records only
 /// concrete transaction metadata; a [`crate::TxBuilder`] later resolves actor
-/// paths and fills Argent-generated scripts from its artifact bundle.
+/// paths and fills compiler-generated scripts from its artifact bundle.
 /// Callers provide only user-visible entry arguments and signature callbacks;
 /// the builder derives compiler-generated witness material from the context
 /// and artifact bundle.
@@ -342,7 +342,7 @@ impl<'a> TxContext<'a> {
         utxo: UtxoEntry,
         sequence: u64,
     ) -> Self {
-        self.inputs.push(ContextInput::Argent(ArgentInput {
+        self.inputs.push(ContextInput::Actor(ActorInput {
             actor: actor.into(),
             state,
             entry: entry.into(),
@@ -353,7 +353,7 @@ impl<'a> TxContext<'a> {
         self
     }
 
-    /// Append a non-Argent input.
+    /// Append an ordinary non-actor input.
     pub fn input(
         mut self,
         outpoint: TransactionOutpoint,
@@ -407,7 +407,7 @@ impl<'a> TxContext<'a> {
         self
     }
 
-    /// Append a non-Argent output.
+    /// Append an ordinary non-actor output.
     pub fn output(mut self, script_public_key: ScriptPublicKey, covenant: Option<CovenantBinding>, value: u64) -> Self {
         self.outputs.push(ContextOutput {
             owner: OutputOwner::Spk(script_public_key),
@@ -481,7 +481,7 @@ mod tests {
             .payload([0xaa, 0xbb]);
 
         assert!(
-            matches!(&context.inputs[0], ContextInput::Argent(input) if input.actor == ActorPath::primary("Counter") && input.sequence == 3)
+            matches!(&context.inputs[0], ContextInput::Actor(input) if input.actor == ActorPath::primary("Counter") && input.sequence == 3)
         );
         assert!(
             matches!(&context.inputs[1], ContextInput::Ordinary(input) if input.sequence == 4 && matches!(input.signature_script, InputSigScript::Static(ref script) if script == &[0xaa]))

--- a/crates/argent-runtime/src/context.rs
+++ b/crates/argent-runtime/src/context.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, error::Error, fmt};
 
 use kaspa_consensus_core::{
+    Hash,
     subnets::SubnetworkId,
     tx::{CovenantBinding, MutableTransaction, ScriptPublicKey, Transaction, TransactionOutpoint, UtxoEntry},
 };
@@ -192,7 +193,20 @@ pub enum ContextInput<'a> {
 /// Context available while deferred actor output states are resolved.
 #[derive(Debug, Default)]
 #[non_exhaustive]
-pub struct StateContext {}
+pub struct StateContext {
+    genesis_covenant_ids: BTreeMap<u16, BTreeMap<String, Hash>>,
+}
+
+impl StateContext {
+    /// Return the covenant ID assigned to one named genesis subgroup.
+    pub fn genesis_covenant_id(&self, authorizing_input: u16, subgroup: &str) -> Option<Hash> {
+        self.genesis_covenant_ids.get(&authorizing_input)?.get(subgroup).copied()
+    }
+
+    pub(crate) fn insert_genesis_covenant_id(&mut self, authorizing_input: u16, subgroup: String, covenant_id: Hash) {
+        self.genesis_covenant_ids.entry(authorizing_input).or_default().insert(subgroup, covenant_id);
+    }
+}
 
 type OutputStateCallback<'a> = dyn Fn(&StateContext) -> Result<BTreeMap<String, ArtifactValue>, CallbackError> + 'a;
 
@@ -262,7 +276,7 @@ pub enum OutputCovenant {
     /// The output carries an existing covenant binding.
     Existing(CovenantBinding),
     /// The builder assigns a new covenant ID shared by this named subgroup.
-    Genesis { authorizing_input: usize, subgroup: String },
+    Genesis { authorizing_input: u16, subgroup: String },
 }
 
 /// One ordered output in a transaction context.
@@ -378,7 +392,7 @@ impl<'a> TxContext<'a> {
     /// multiple outputs in one ordered genesis group.
     pub fn argent_genesis_output(
         mut self,
-        authorizing_input: usize,
+        authorizing_input: u16,
         subgroup: impl Into<String>,
         actor: impl Into<ActorPath>,
         state: BTreeMap<String, ArtifactValue>,
@@ -405,7 +419,7 @@ impl<'a> TxContext<'a> {
     /// Append a concrete-script output to a new covenant group.
     pub fn genesis_output(
         mut self,
-        authorizing_input: usize,
+        authorizing_input: u16,
         subgroup: impl Into<String>,
         script_public_key: ScriptPublicKey,
         value: u64,

--- a/crates/argent-runtime/src/context.rs
+++ b/crates/argent-runtime/src/context.rs
@@ -189,28 +189,32 @@ pub enum ContextInput<'a> {
     Ordinary(OrdinaryInput<'a>),
 }
 
-/// One Argent covenant output in a transaction context.
+/// The actor or script that controls one transaction output.
 #[derive(Clone, Debug)]
-pub struct ArgentOutput {
-    pub actor: ActorPath,
-    pub state: BTreeMap<String, ArtifactValue>,
-    pub covenant: CovenantBinding,
-    pub value: u64,
+pub enum OutputOwner {
+    /// An Argent actor whose P2SH script is derived from its artifact and state.
+    Actor { actor: ActorPath, state: BTreeMap<String, ArtifactValue> },
+    /// A concrete script supplied directly by the caller.
+    Spk(ScriptPublicKey),
 }
 
-/// One non-Argent output in a transaction context.
+/// How one transaction output participates in a covenant.
 #[derive(Clone, Debug)]
-pub struct OrdinaryOutput {
-    pub script_public_key: ScriptPublicKey,
-    pub covenant: Option<CovenantBinding>,
-    pub value: u64,
+pub enum OutputCovenant {
+    /// The output has no covenant binding.
+    Unbound,
+    /// The output carries an existing covenant binding.
+    Existing(CovenantBinding),
+    /// The builder assigns a new covenant ID shared by this named subgroup.
+    Genesis { authorizing_input: usize, subgroup: String },
 }
 
-/// An ordered output in a transaction context.
+/// One ordered output in a transaction context.
 #[derive(Clone, Debug)]
-pub enum ContextOutput {
-    Argent(ArgentOutput),
-    Ordinary(OrdinaryOutput),
+pub struct ContextOutput {
+    pub owner: OutputOwner,
+    pub covenant: OutputCovenant,
+    pub value: u64,
 }
 
 /// Artifact-independent description of one complete transaction.
@@ -304,13 +308,57 @@ impl<'a> TxContext<'a> {
         covenant: CovenantBinding,
         value: u64,
     ) -> Self {
-        self.outputs.push(ContextOutput::Argent(ArgentOutput { actor: actor.into(), state, covenant, value }));
+        self.outputs.push(ContextOutput {
+            owner: OutputOwner::Actor { actor: actor.into(), state },
+            covenant: OutputCovenant::Existing(covenant),
+            value,
+        });
+        self
+    }
+
+    /// Append a statically defined Argent output to a new covenant group.
+    ///
+    /// Repeating the same `launch::<name>` and authorizing input places
+    /// multiple outputs in one ordered genesis group.
+    pub fn argent_genesis_output(
+        mut self,
+        authorizing_input: usize,
+        subgroup: impl Into<String>,
+        actor: impl Into<ActorPath>,
+        state: BTreeMap<String, ArtifactValue>,
+        value: u64,
+    ) -> Self {
+        self.outputs.push(ContextOutput {
+            owner: OutputOwner::Actor { actor: actor.into(), state },
+            covenant: OutputCovenant::Genesis { authorizing_input, subgroup: subgroup.into() },
+            value,
+        });
         self
     }
 
     /// Append a non-Argent output.
     pub fn output(mut self, script_public_key: ScriptPublicKey, covenant: Option<CovenantBinding>, value: u64) -> Self {
-        self.outputs.push(ContextOutput::Ordinary(OrdinaryOutput { script_public_key, covenant, value }));
+        self.outputs.push(ContextOutput {
+            owner: OutputOwner::Spk(script_public_key),
+            covenant: covenant.map_or(OutputCovenant::Unbound, OutputCovenant::Existing),
+            value,
+        });
+        self
+    }
+
+    /// Append a concrete-script output to a new covenant group.
+    pub fn genesis_output(
+        mut self,
+        authorizing_input: usize,
+        subgroup: impl Into<String>,
+        script_public_key: ScriptPublicKey,
+        value: u64,
+    ) -> Self {
+        self.outputs.push(ContextOutput {
+            owner: OutputOwner::Spk(script_public_key),
+            covenant: OutputCovenant::Genesis { authorizing_input, subgroup: subgroup.into() },
+            value,
+        });
         self
     }
 }
@@ -351,7 +399,9 @@ mod tests {
             )
             .input(outpoint(2), utxo(None), vec![0xaa], 4)
             .argent_output("Counter", BTreeMap::from([("count".to_string(), ArtifactValue::Int(5))]), binding, 900)
+            .argent_genesis_output(1, "launch::reserve", "Reserve", BTreeMap::new(), 50)
             .output(ScriptPublicKey::default(), None, 100)
+            .genesis_output(1, "launch::script", ScriptPublicKey::default(), 25)
             .lock_time(5)
             .lane(SubnetworkId::from_namespace([1, 2, 3, 4]), 6)
             .payload([0xaa, 0xbb]);
@@ -362,8 +412,19 @@ mod tests {
         assert!(
             matches!(&context.inputs[1], ContextInput::Ordinary(input) if input.sequence == 4 && matches!(input.signature_script, InputSigScript::Static(ref script) if script == &[0xaa]))
         );
-        assert!(matches!(&context.outputs[0], ContextOutput::Argent(output) if output.covenant == binding));
-        assert!(matches!(&context.outputs[1], ContextOutput::Ordinary(output) if output.value == 100));
+        assert!(
+            matches!(&context.outputs[0], ContextOutput { owner: OutputOwner::Actor { actor, .. }, covenant: OutputCovenant::Existing(found), .. } if actor == &ActorPath::primary("Counter") && *found == binding)
+        );
+        assert!(
+            matches!(&context.outputs[1], ContextOutput { owner: OutputOwner::Actor { actor, .. }, covenant: OutputCovenant::Genesis { authorizing_input: 1, subgroup }, .. } if actor == &ActorPath::primary("Reserve") && subgroup == "launch::reserve")
+        );
+        assert!(matches!(
+            &context.outputs[2],
+            ContextOutput { owner: OutputOwner::Spk(_), covenant: OutputCovenant::Unbound, value: 100 }
+        ));
+        assert!(
+            matches!(&context.outputs[3], ContextOutput { owner: OutputOwner::Spk(_), covenant: OutputCovenant::Genesis { authorizing_input: 1, subgroup }, value: 25 } if subgroup == "launch::script")
+        );
         assert_eq!(context.lock_time, 5);
         assert_eq!(context.subnetwork_id, SubnetworkId::from_namespace([1, 2, 3, 4]));
         assert_eq!(context.gas, 6);

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -17,8 +17,8 @@ use std::{collections::BTreeMap, error::Error, fmt};
 
 pub use argent_artifact::Artifact;
 pub use context::{
-    ActorPath, ArgentInput, ArgentOutput, ContextInput, ContextOutput, EntryArgs, EntryCall, InputSigScript, OrdinaryInput,
-    OrdinaryOutput, TxContext,
+    ActorPath, ArgentInput, ContextInput, ContextOutput, EntryArgs, EntryCall, InputSigScript, OrdinaryInput, OutputCovenant,
+    OutputOwner, TxContext,
 };
 pub use silverscript_abi::ArtifactValue;
 
@@ -343,6 +343,14 @@ pub enum BuilderError {
     MissingSpawnOutput { spawn: String, handle: String, group_index: usize },
     #[error("spawn `{spawn}` has no compatible genesis output group")]
     MissingSpawnGroup { spawn: String },
+    #[error("invalid genesis path `{0}`; expected `launch::<name>`")]
+    InvalidGenesisPath(String),
+    #[error("genesis authorizing input index {0} does not fit a covenant binding")]
+    GenesisAuthorizingInputOverflow(usize),
+    #[error("genesis output index {0} does not fit a covenant group")]
+    GenesisOutputIndexOverflow(usize),
+    #[error("Argent output {output_index} `{actor}` must have an existing or genesis covenant binding")]
+    UnboundArgentOutput { output_index: usize, actor: String },
     #[error("observe `{observe}` spans apps `{expected}` and `{found}`")]
     ObservedAppMismatch { observe: String, expected: String, found: String },
     #[error("unknown entry `{actor}::{entry}`")]
@@ -449,6 +457,7 @@ pub struct GenesisOutput {
     pub utxo: UtxoEntry,
 }
 
+#[derive(Clone, Copy)]
 struct ContractRef<'a> {
     artifact: &'a Artifact,
     contract: &'a SilContractArtifact,

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -345,8 +345,8 @@ pub enum BuilderError {
     MissingSpawnGroup { spawn: String },
     #[error("invalid genesis path `{0}`; expected `launch::<name>`")]
     InvalidGenesisPath(String),
-    #[error("genesis authorizing input index {0} does not fit a covenant binding")]
-    GenesisAuthorizingInputOverflow(usize),
+    #[error("genesis authorizing input index {authorizing_input} is out of range for {input_count} inputs")]
+    GenesisAuthorizingInputOutOfRange { authorizing_input: u16, input_count: usize },
     #[error("genesis output index {0} does not fit a covenant group")]
     GenesisOutputIndexOverflow(usize),
     #[error("Argent output {output_index} `{actor}` must have an existing or genesis covenant binding")]

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -18,7 +18,7 @@ use std::{collections::BTreeMap, error::Error, fmt};
 pub use argent_artifact::Artifact;
 pub use context::{
     ActorPath, ArgentInput, ContextInput, ContextOutput, EntryArgs, EntryCall, InputSigScript, OrdinaryInput, OutputCovenant,
-    OutputOwner, TxContext,
+    OutputOwner, OutputState, StateContext, TxContext, state_with, try_state_with,
 };
 pub use silverscript_abi::ArtifactValue;
 
@@ -351,6 +351,15 @@ pub enum BuilderError {
     GenesisOutputIndexOverflow(usize),
     #[error("Argent output {output_index} `{actor}` must have an existing or genesis covenant binding")]
     UnboundArgentOutput { output_index: usize, actor: String },
+    #[error("genesis actor output {output_index} `{actor}` must have static state")]
+    GenesisOutputStateCallback { output_index: usize, actor: String },
+    #[error("failed to build state for actor output {output_index} `{actor}`: {source}")]
+    OutputStateCallback {
+        output_index: usize,
+        actor: String,
+        #[source]
+        source: Box<dyn Error + Send + Sync + 'static>,
+    },
     #[error("observe `{observe}` spans apps `{expected}` and `{found}`")]
     ObservedAppMismatch { observe: String, expected: String, found: String },
     #[error("unknown entry `{actor}::{entry}`")]

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, error::Error, fmt};
 
 pub use argent_artifact::Artifact;
 pub use context::{
-    ActorPath, ArgentInput, ContextInput, ContextOutput, EntryArgs, EntryCall, InputSigScript, OrdinaryInput, OutputCovenant,
+    ActorInput, ActorPath, ContextInput, ContextOutput, EntryArgs, EntryCall, InputSigScript, OrdinaryInput, OutputCovenant,
     OutputOwner, OutputState, StateContext, TxContext, state_with, try_state_with,
 };
 pub use silverscript_abi::ArtifactValue;
@@ -337,7 +337,7 @@ pub enum BuilderError {
     InvalidObservedCovenantId { observe: String },
     #[error("observe `{observe}` expects {expected} {side}s for its covenant id, found {found}")]
     ObservedCountMismatch { observe: String, side: Side, expected: usize, found: usize },
-    #[error("observed {side} `{observe}.{handle}` at transaction index {index} has no Argent actor metadata")]
+    #[error("observed {side} `{observe}.{handle}` at transaction index {index} has no actor metadata")]
     MissingObservedActorMetadata { observe: String, side: Side, handle: String, index: usize },
     #[error("spawn `{spawn}` has no genesis output `{handle}` at group index {group_index}")]
     MissingSpawnOutput { spawn: String, handle: String, group_index: usize },
@@ -345,8 +345,8 @@ pub enum BuilderError {
     MissingSpawnGroup(usize, String),
     #[error("spawn `{0}` group is invalid: {1}")]
     InvalidSpawnGroup(String, String),
-    #[error("spawn `{1}` requires Argent authorizing input {0}")]
-    SpawnAuthorizingInputNotArgent(u16, String),
+    #[error("spawn `{1}` requires actor authorizing input {0}")]
+    SpawnAuthorizingInputNotActor(u16, String),
     #[error("input {0}'s selected entry does not declare spawn `{1}`")]
     UnknownSpawn(u16, String),
     #[error("invalid genesis path `{0}`; expected `launch::<name>` or `spawn::<clause>`")]
@@ -357,8 +357,8 @@ pub enum BuilderError {
     GenesisAuthorizingInputIndexOverflow(usize),
     #[error("genesis output index {0} does not fit a covenant group")]
     GenesisOutputIndexOverflow(usize),
-    #[error("Argent output {output_index} `{actor}` must have an existing or genesis covenant binding")]
-    UnboundArgentOutput { output_index: usize, actor: String },
+    #[error("actor output {output_index} `{actor}` must have an existing or genesis covenant binding")]
+    UnboundActorOutput { output_index: usize, actor: String },
     #[error("genesis actor output {output_index} `{actor}` must have static state")]
     GenesisOutputStateCallback { output_index: usize, actor: String },
     #[error("failed to build state for actor output {output_index} `{actor}`: {source}")]
@@ -372,12 +372,12 @@ pub enum BuilderError {
     ObservedAppMismatch { observe: String, expected: String, found: String },
     #[error("unknown entry `{actor}::{entry}`")]
     UnknownEntry { actor: String, entry: String },
-    #[error("Argent input {input_index} `{actor}` has no covenant id")]
-    MissingArgentInputCovenantId { input_index: usize, actor: String },
-    #[error("Argent input {input_index} `{actor}` UTXO script does not match its declared state")]
-    ArgentInputScriptMismatch { input_index: usize, actor: String },
+    #[error("actor input {input_index} `{actor}` has no covenant id")]
+    MissingActorInputCovenantId { input_index: usize, actor: String },
+    #[error("actor input {input_index} `{actor}` UTXO script does not match its declared state")]
+    ActorInputScriptMismatch { input_index: usize, actor: String },
     #[error(
-        "Argent input {input_index} `{actor}::{entry}` requires exactly {expected} same-covenant inputs, found {found}; actor is a leader actor trusted by delegates {leader_for:?}"
+        "actor input {input_index} `{actor}::{entry}` requires exactly {expected} same-covenant inputs, found {found}; actor is a leader actor trusted by delegates {leader_for:?}"
     )]
     LeaderActorInputCountMismatch {
         input_index: usize,
@@ -387,7 +387,7 @@ pub enum BuilderError {
         found: usize,
         leader_for: Vec<String>,
     },
-    #[error("failed to build arguments for Argent input {input_index} `{actor}::{entry}`: {source}")]
+    #[error("failed to build arguments for actor input {input_index} `{actor}::{entry}`: {source}")]
     EntryArgsCallback {
         input_index: usize,
         actor: String,
@@ -648,13 +648,13 @@ impl<'a> TxBuilder<'a> {
         &self,
         artifact: &'a Artifact,
         contract: &'a SilContractArtifact,
-        argent_entry: &'a EntryArtifact,
+        artifact_entry: &'a EntryArtifact,
         input_source_state: &BTreeMap<String, ArtifactValue>,
         template_selectors: &BTreeMap<String, String>,
         contexts: HiddenArgContexts<'_>,
     ) -> BuilderResult<Vec<ArtifactValue>> {
-        let mut args = Vec::with_capacity(argent_entry.hidden_params.len());
-        for hidden in &argent_entry.hidden_params {
+        let mut args = Vec::with_capacity(artifact_entry.hidden_params.len());
+        for hidden in &artifact_entry.hidden_params {
             args.push(match &hidden.purpose {
                 HiddenParamPurposeArtifact::SpawnOutputIndex => {
                     let HiddenParamSubjectArtifact::SpawnActor { spawn, handle, .. } = &hidden.subject else {
@@ -666,7 +666,7 @@ impl<'a> TxBuilder<'a> {
                         .ok_or_else(|| BuilderError::MissingSpawnOutput {
                             spawn: spawn.clone(),
                             handle: handle.clone(),
-                            group_index: argent_entry
+                            group_index: artifact_entry
                                 .spawns
                                 .iter()
                                 .find(|candidate| candidate.name == *spawn)
@@ -678,23 +678,23 @@ impl<'a> TxBuilder<'a> {
                     ArtifactValue::Int(output_index as i64)
                 }
                 HiddenParamPurposeArtifact::TemplatePrefixBytes => {
-                    let template = self.hidden_template(artifact, hidden, argent_entry, template_selectors, contexts)?;
+                    let template = self.hidden_template(artifact, hidden, artifact_entry, template_selectors, contexts)?;
                     ArtifactValue::Bytes(decode_hex(&template.prefix_hex)?)
                 }
                 HiddenParamPurposeArtifact::TemplateSuffixBytes => {
-                    let template = self.hidden_template(artifact, hidden, argent_entry, template_selectors, contexts)?;
+                    let template = self.hidden_template(artifact, hidden, artifact_entry, template_selectors, contexts)?;
                     ArtifactValue::Bytes(decode_hex(&template.suffix_hex)?)
                 }
                 HiddenParamPurposeArtifact::TemplatePrefixLen => {
-                    let template = self.hidden_template(artifact, hidden, argent_entry, template_selectors, contexts)?;
+                    let template = self.hidden_template(artifact, hidden, artifact_entry, template_selectors, contexts)?;
                     ArtifactValue::Int(decode_hex(&template.prefix_hex)?.len() as i64)
                 }
                 HiddenParamPurposeArtifact::TemplateSuffixLen => {
-                    let template = self.hidden_template(artifact, hidden, argent_entry, template_selectors, contexts)?;
+                    let template = self.hidden_template(artifact, hidden, artifact_entry, template_selectors, contexts)?;
                     ArtifactValue::Int(decode_hex(&template.suffix_hex)?.len() as i64)
                 }
                 HiddenParamPurposeArtifact::TemplateHash => {
-                    let template = self.hidden_template(artifact, hidden, argent_entry, template_selectors, contexts)?;
+                    let template = self.hidden_template(artifact, hidden, artifact_entry, template_selectors, contexts)?;
                     ArtifactValue::Bytes(decode_hex(&template.hash_hex)?)
                 }
                 HiddenParamPurposeArtifact::RouteTemplateLeaf => {
@@ -744,7 +744,7 @@ impl<'a> TxBuilder<'a> {
         actor_name: &str,
         entry_name: &str,
         sil_entry: &SilEntryArtifact,
-        argent_entry: &EntryArtifact,
+        artifact_entry: &EntryArtifact,
         user_args: Vec<ArgValue>,
     ) -> BuilderResult<(Vec<ArtifactValue>, BTreeMap<String, String>)> {
         let mut artifact_args = Vec::with_capacity(user_args.len());
@@ -763,7 +763,7 @@ impl<'a> TxBuilder<'a> {
                         });
                     };
                     let selector =
-                        argent_entry.template_selectors.iter().find(|selector| selector.name == param.name).ok_or_else(|| {
+                        artifact_entry.template_selectors.iter().find(|selector| selector.name == param.name).ok_or_else(|| {
                             BuilderError::ActorArgumentWithoutSelector {
                                 actor: actor_name.to_string(),
                                 entry: entry_name.to_string(),
@@ -788,7 +788,7 @@ impl<'a> TxBuilder<'a> {
         artifact: &'a Artifact,
         contract: &'a SilContractArtifact,
         entry: &SilEntryArtifact,
-        argent_entry: &EntryArtifact,
+        artifact_entry: &EntryArtifact,
         user_args: Vec<ArtifactValue>,
     ) -> BuilderResult<Vec<ArtifactValue>> {
         let mut args = Vec::with_capacity(user_args.len());
@@ -796,7 +796,7 @@ impl<'a> TxBuilder<'a> {
             let runtime_contract = match entry.params.get(idx) {
                 Some(param) => match &param.ty {
                     TypeArtifact::Struct { name } => {
-                        self.runtime_contract_for_param(artifact, contract, argent_entry, &param.name, name)?
+                        self.runtime_contract_for_param(artifact, contract, artifact_entry, &param.name, name)?
                     }
                     _ => None,
                 },
@@ -817,7 +817,7 @@ impl<'a> TxBuilder<'a> {
         artifact: &'a Artifact,
         contract: &'a SilContractArtifact,
         entry: &'a SilEntryArtifact,
-        argent_entry: &EntryArtifact,
+        artifact_entry: &EntryArtifact,
         args: &[ArtifactValue],
     ) -> BuilderResult<Vec<u8>> {
         let mut abi = artifact.sil_abi.clone();
@@ -826,7 +826,8 @@ impl<'a> TxBuilder<'a> {
             let TypeArtifact::Struct { name } = &param.ty else {
                 continue;
             };
-            let Some(runtime_contract) = self.runtime_contract_for_param(artifact, contract, argent_entry, &param.name, name)? else {
+            let Some(runtime_contract) = self.runtime_contract_for_param(artifact, contract, artifact_entry, &param.name, name)?
+            else {
                 continue;
             };
             if name == "State" {
@@ -1139,7 +1140,7 @@ impl<'a> TxBuilder<'a> {
         artifact.argent.template_plan.runtime_states.iter().find(|state| state.contract == contract_name)
     }
 
-    fn argent_actor_ref_in_artifact(&self, artifact: &'a Artifact, name: &str) -> BuilderResult<ActorRef<'a>> {
+    fn actor_ref_in_artifact(&self, artifact: &'a Artifact, name: &str) -> BuilderResult<ActorRef<'a>> {
         artifact
             .argent
             .actors
@@ -1312,7 +1313,7 @@ impl<'a> TxBuilder<'a> {
         found_actor: &str,
     ) -> BuilderResult<()> {
         if let Some(expected_state) = expected.open_state.as_deref() {
-            let found = self.argent_actor_ref_in_artifact(self.bundle.app(app)?, found_actor)?;
+            let found = self.actor_ref_in_artifact(self.bundle.app(app)?, found_actor)?;
             if !state_satisfies(found.artifact, &found.actor.state, expected_state) {
                 return Err(BuilderError::ObservedStateLayoutMismatch {
                     observe: observe_name.to_string(),

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -402,8 +402,10 @@ pub enum BuilderError {
     ComputeMassLimitExceeded { compute_mass: u64, limit: u64 },
     #[error("transaction transient mass {transient_mass} exceeds limit {limit}")]
     TransientMassLimitExceeded { transient_mass: u64, limit: u64 },
-    #[error("genesis covenant output {0} was not populated")]
-    MissingGenesisCovenantOutput(u32),
+    #[error("transaction output {0} has no covenant binding")]
+    MissingOutputCovenant(u32),
+    #[error("transaction output {0} does not exist")]
+    UnknownTransactionOutput(u32),
     #[error("genesis covenant output {0} does not exist")]
     UnknownGenesisOutput(u32),
 }
@@ -428,7 +430,7 @@ pub struct GenesisCovenants {
 
 impl GenesisCovenants {
     /// Return the populated genesis output by transaction output index.
-    pub fn output(&self, index: u32) -> BuilderResult<&GenesisOutput> {
+    pub fn output(&self, index: u32) -> BuilderResult<&CovenantOutput> {
         self.groups
             .iter()
             .flat_map(|group| group.outputs.iter())
@@ -444,17 +446,29 @@ impl GenesisCovenants {
 pub struct GenesisCovenant {
     pub authorizing_input: u16,
     pub covenant_id: Hash,
-    pub outputs: Vec<GenesisOutput>,
+    pub outputs: Vec<CovenantOutput>,
 }
 
-/// A concrete output created by a genesis covenant transaction.
-///
-/// The `outpoint` and `utxo` are the handles needed by the first covenant spend.
-pub struct GenesisOutput {
+/// A concrete covenant output and the handles needed to spend it.
+pub struct CovenantOutput {
     pub index: u32,
     pub covenant_id: Hash,
     pub outpoint: TransactionOutpoint,
     pub utxo: UtxoEntry,
+}
+
+impl CovenantOutput {
+    /// Derive a covenant output and its spendable UTXO metadata from a transaction output index.
+    pub fn from_tx(tx: &Transaction, index: u32) -> BuilderResult<Self> {
+        let output = tx.outputs.get(index as usize).ok_or(BuilderError::UnknownTransactionOutput(index))?;
+        let covenant_id = output.covenant.ok_or(BuilderError::MissingOutputCovenant(index))?.covenant_id;
+        Ok(Self {
+            index,
+            covenant_id,
+            outpoint: TransactionOutpoint::new(tx.id(), index),
+            utxo: UtxoEntry::new(output.value, output.script_public_key.clone(), 0, tx.is_coinbase(), Some(covenant_id)),
+        })
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -603,25 +617,10 @@ impl<'a> TxBuilder<'a> {
         tx.populate_genesis_covenants(groups)?;
         tx.finalize();
 
-        let tx_id = tx.id();
-        let is_coinbase = tx.is_coinbase();
         let mut populated_groups = Vec::with_capacity(groups.len());
         for group in groups {
-            let first_output_index = group.outputs.first().copied().ok_or(PopulateGenesisCovenantsError::EmptyOutputs)?;
-            let first_output =
-                tx.outputs.get(first_output_index as usize).ok_or(BuilderError::UnknownGenesisOutput(first_output_index))?;
-            let covenant_id = first_output.covenant.ok_or(BuilderError::MissingGenesisCovenantOutput(first_output_index))?.covenant_id;
-            let mut outputs = Vec::with_capacity(group.outputs.len());
-            for &index in &group.outputs {
-                let output = tx.outputs.get(index as usize).ok_or(BuilderError::UnknownGenesisOutput(index))?;
-                let binding = output.covenant.ok_or(BuilderError::MissingGenesisCovenantOutput(index))?;
-                outputs.push(GenesisOutput {
-                    index,
-                    covenant_id: binding.covenant_id,
-                    outpoint: TransactionOutpoint::new(tx_id, index),
-                    utxo: UtxoEntry::new(output.value, output.script_public_key.clone(), 0, is_coinbase, Some(binding.covenant_id)),
-                });
-            }
+            let outputs = group.outputs.iter().map(|&index| CovenantOutput::from_tx(tx, index)).collect::<BuilderResult<Vec<_>>>()?;
+            let covenant_id = outputs.first().ok_or(PopulateGenesisCovenantsError::EmptyOutputs)?.covenant_id;
             populated_groups.push(GenesisCovenant { authorizing_input: group.authorizing_input, covenant_id, outputs });
         }
 
@@ -1904,6 +1903,10 @@ mod tests {
         assert_eq!(output_0.utxo.amount, tx.outputs[0].value);
         assert_eq!(output_0.utxo.script_public_key, tx.outputs[0].script_public_key);
         assert_eq!(output_0.utxo.covenant_id, Some(output_0.covenant_id));
+        let direct_output_0 = CovenantOutput::from_tx(&tx, 0).expect("covenant output derives directly from transaction");
+        assert_eq!(direct_output_0.covenant_id, output_0.covenant_id);
+        assert_eq!(direct_output_0.outpoint, output_0.outpoint);
+        assert_eq!(direct_output_0.utxo, output_0.utxo);
 
         let output_1 = genesis.output(1).expect("output 1 handle exists");
         let output_3 = genesis.output(3).expect("output 3 handle exists");
@@ -1911,5 +1914,9 @@ mod tests {
         assert_eq!(output_3.covenant_id, genesis.groups[1].covenant_id);
         assert_eq!(tx.outputs[1].covenant.expect("output 1 covenant").covenant_id, output_1.covenant_id);
         assert!(matches!(genesis.output(99), Err(BuilderError::UnknownGenesisOutput(99))));
+        assert!(matches!(CovenantOutput::from_tx(&tx, 99), Err(BuilderError::UnknownTransactionOutput(99))));
+
+        let unbound_tx = TxBuilder::transaction(Vec::new(), vec![TransactionOutput::new(1_000, Default::default())]);
+        assert!(matches!(CovenantOutput::from_tx(&unbound_tx, 0), Err(BuilderError::MissingOutputCovenant(0))));
     }
 }

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -341,12 +341,20 @@ pub enum BuilderError {
     MissingObservedActorMetadata { observe: String, side: Side, handle: String, index: usize },
     #[error("spawn `{spawn}` has no genesis output `{handle}` at group index {group_index}")]
     MissingSpawnOutput { spawn: String, handle: String, group_index: usize },
-    #[error("spawn `{spawn}` has no compatible genesis output group")]
-    MissingSpawnGroup { spawn: String },
-    #[error("invalid genesis path `{0}`; expected `launch::<name>`")]
+    #[error("input {0} has no explicit genesis group `spawn::{1}`")]
+    MissingSpawnGroup(usize, String),
+    #[error("spawn `{0}` group is invalid: {1}")]
+    InvalidSpawnGroup(String, String),
+    #[error("spawn `{1}` requires Argent authorizing input {0}")]
+    SpawnAuthorizingInputNotArgent(u16, String),
+    #[error("input {0}'s selected entry does not declare spawn `{1}`")]
+    UnknownSpawn(u16, String),
+    #[error("invalid genesis path `{0}`; expected `launch::<name>` or `spawn::<clause>`")]
     InvalidGenesisPath(String),
     #[error("genesis authorizing input index {authorizing_input} is out of range for {input_count} inputs")]
     GenesisAuthorizingInputOutOfRange { authorizing_input: u16, input_count: usize },
+    #[error("transaction input index {0} does not fit a genesis authorizing input")]
+    GenesisAuthorizingInputIndexOverflow(usize),
     #[error("genesis output index {0} does not fit a covenant group")]
     GenesisOutputIndexOverflow(usize),
     #[error("Argent output {output_index} `{actor}` must have an existing or genesis covenant binding")]

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -8,15 +8,16 @@ use kaspa_consensus_core::{
     Hash,
     constants::TX_VERSION_TOCCATA,
     subnets::SubnetworkId,
-    tx::{MutableTransaction, Transaction, TransactionInput, TransactionOutput},
+    tx::{GenesisCovenantGroup, MutableTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutput},
 };
 use kaspa_txscript::{covenants::CovenantsContext, pay_to_script_hash_script, pay_to_script_hash_signature_script_with_flags};
 use kaspa_txscript_errors::TxScriptError;
 
 use crate::{
-    ActorPath, ArgentInput, ArgentOutput, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput,
-    ContractRef, EntryArgs, HiddenArgContexts, InputSigScript, ObservedCovenantContext, ObservedInput, ObservedOutput, OrdinaryInput,
-    OrdinaryOutput, Side, SpawnedActorContext, TxBuilder, TxContext, covenant_engine_flags, execute_transaction_with_covenants,
+    ActorPath, ArgentInput, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput, ContractRef, EntryArgs,
+    HiddenArgContexts, InputSigScript, ObservedCovenantContext, ObservedInput, ObservedOutput, OrdinaryInput, OutputCovenant,
+    OutputOwner, Side, SpawnedActorContext, TxBuilder, TxContext, artifact_app_alias, covenant_engine_flags,
+    execute_transaction_with_covenants,
 };
 
 type ResolvedObservations = BTreeMap<String, ObservedCovenantContext>;
@@ -33,6 +34,24 @@ struct GenesisGroup {
     output_indices: Vec<usize>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct LaunchGroupKey {
+    authorizing_input: usize,
+    name: String,
+}
+
+impl LaunchGroupKey {
+    fn parse(authorizing_input: usize, path: &str) -> BuilderResult<Self> {
+        let Some(name) = path.strip_prefix("launch::") else {
+            return Err(BuilderError::InvalidGenesisPath(path.to_string()));
+        };
+        if name.is_empty() || name.contains("::") {
+            return Err(BuilderError::InvalidGenesisPath(path.to_string()));
+        }
+        Ok(Self { authorizing_input, name: name.to_string() })
+    }
+}
+
 /// Artifact-bound working representation of a [`TxContext`].
 ///
 /// Actor paths are resolved once into concrete app, contract, and entry
@@ -42,6 +61,7 @@ struct GenesisGroup {
 struct ResolveContext<'artifact, 'context, 'args> {
     inputs: Vec<ResolveInput<'artifact, 'context, 'args>>,
     outputs: Vec<ResolveOutput<'artifact, 'context>>,
+    launch_groups: BTreeMap<LaunchGroupKey, GenesisGroup>,
     lock_time: u64,
     subnetwork_id: SubnetworkId,
     gas: u64,
@@ -55,7 +75,6 @@ enum ResolveInput<'artifact, 'context, 'args> {
 
 struct ResolveArgentInput<'artifact, 'context, 'args> {
     source: &'context ArgentInput<'args>,
-    app: String,
     artifact: &'artifact Artifact,
     actor: &'artifact ActorArtifact,
     contract: &'artifact SilContractArtifact,
@@ -73,29 +92,26 @@ impl<'artifact> ResolveArgentInput<'artifact, '_, '_> {
     }
 }
 
-enum ResolveOutput<'artifact, 'context> {
-    Argent(ResolveArgentOutput<'artifact, 'context>),
-    Ordinary(&'context OrdinaryOutput),
+struct ResolvedActor<'artifact, 'context> {
+    contract: ContractRef<'artifact>,
+    state: &'context BTreeMap<String, ArtifactValue>,
 }
 
-struct ResolveArgentOutput<'artifact, 'context> {
-    source: &'context ArgentOutput,
-    app: String,
-    artifact: &'artifact Artifact,
-    contract: &'artifact SilContractArtifact,
+enum ResolveOutputOwner<'artifact, 'context> {
+    Actor(ResolvedActor<'artifact, 'context>),
+    Spk(&'context ScriptPublicKey),
 }
 
-impl<'artifact> ResolveArgentOutput<'artifact, '_> {
-    fn contract_ref(&self) -> ContractRef<'artifact> {
-        ContractRef { artifact: self.artifact, contract: self.contract }
-    }
+struct ResolveOutput<'artifact, 'context> {
+    source: &'context ContextOutput,
+    owner: ResolveOutputOwner<'artifact, 'context>,
 }
 
 impl<'artifact> TxBuilder<'artifact> {
-    fn bind_actor(&self, actor: &ActorPath) -> BuilderResult<(String, ContractRef<'artifact>)> {
+    fn bind_actor(&self, actor: &ActorPath) -> BuilderResult<ContractRef<'artifact>> {
         let app = actor.app.as_deref().unwrap_or_else(|| self.bundle.primary_alias());
         let artifact = self.bundle.app(app)?;
-        Ok((app.to_string(), self.contract_ref_in_artifact(artifact, &actor.actor)?))
+        self.contract_ref_in_artifact(artifact, &actor.actor)
     }
 
     /// Bind every actor path to one canonical app and its verified artifact objects.
@@ -107,7 +123,7 @@ impl<'artifact> TxBuilder<'artifact> {
         for input in &context.inputs {
             match input {
                 ContextInput::Argent(input) => {
-                    let (app, contract_ref) = self.bind_actor(&input.actor)?;
+                    let contract_ref = self.bind_actor(&input.actor)?;
                     let actor_ref = self.argent_actor_ref_in_artifact(contract_ref.artifact, &input.actor.actor)?;
                     let argent_entry = self.entry_ref_for_actor(actor_ref, &input.actor.actor, &input.entry.name)?;
                     let sil_entry = contract_ref.contract.entry(&input.entry.name).ok_or_else(|| BuilderError::UnknownEntry {
@@ -116,7 +132,6 @@ impl<'artifact> TxBuilder<'artifact> {
                     })?;
                     inputs.push(ResolveInput::Argent(ResolveArgentInput {
                         source: input,
-                        app,
                         artifact: contract_ref.artifact,
                         actor: actor_ref.actor,
                         contract: contract_ref.contract,
@@ -133,24 +148,27 @@ impl<'artifact> TxBuilder<'artifact> {
         }
 
         let mut outputs = Vec::with_capacity(context.outputs.len());
-        for output in &context.outputs {
-            match output {
-                ContextOutput::Argent(output) => {
-                    let (app, contract_ref) = self.bind_actor(&output.actor)?;
-                    outputs.push(ResolveOutput::Argent(ResolveArgentOutput {
-                        source: output,
-                        app,
-                        artifact: contract_ref.artifact,
-                        contract: contract_ref.contract,
-                    }));
+        let mut launch_groups = BTreeMap::<LaunchGroupKey, GenesisGroup>::new();
+        for (output_index, output) in context.outputs.iter().enumerate() {
+            let owner = match &output.owner {
+                OutputOwner::Actor { actor, state } => {
+                    ResolveOutputOwner::Actor(ResolvedActor { contract: self.bind_actor(actor)?, state })
                 }
-                ContextOutput::Ordinary(output) => outputs.push(ResolveOutput::Ordinary(output)),
+                OutputOwner::Spk(script_public_key) => ResolveOutputOwner::Spk(script_public_key),
+            };
+            if let OutputCovenant::Genesis { authorizing_input, subgroup } = &output.covenant {
+                let launch = LaunchGroupKey::parse(*authorizing_input, subgroup)?;
+                launch_groups.entry(launch).or_default().output_indices.push(output_index);
+            } else if let (OutputOwner::Actor { actor, .. }, OutputCovenant::Unbound) = (&output.owner, &output.covenant) {
+                return Err(BuilderError::UnboundArgentOutput { output_index, actor: actor.to_string() });
             }
+            outputs.push(ResolveOutput { source: output, owner });
         }
 
         Ok(ResolveContext {
             inputs,
             outputs,
+            launch_groups,
             lock_time: context.lock_time,
             subnetwork_id: context.subnetwork_id,
             gas: context.gas,
@@ -195,21 +213,17 @@ impl<'artifact> TxBuilder<'artifact> {
 
         let mut outputs = Vec::with_capacity(context.outputs.len());
         for output in &context.outputs {
-            match output {
-                ResolveOutput::Argent(output) => {
-                    let script_public_key = pay_to_script_hash_script(
-                        &self.redeem_script_for_contract(output.contract_ref(), output.source.state.clone())?,
-                    );
-                    outputs.push(TransactionOutput::with_covenant(
-                        output.source.value,
-                        script_public_key,
-                        Some(output.source.covenant),
-                    ));
+            let script_public_key = match &output.owner {
+                ResolveOutputOwner::Actor(actor) => {
+                    pay_to_script_hash_script(&self.redeem_script_for_contract(actor.contract, actor.state.clone())?)
                 }
-                ResolveOutput::Ordinary(output) => {
-                    outputs.push(TransactionOutput::with_covenant(output.value, output.script_public_key.clone(), output.covenant));
-                }
-            }
+                ResolveOutputOwner::Spk(script_public_key) => (*script_public_key).clone(),
+            };
+            let covenant = match output.source.covenant {
+                OutputCovenant::Existing(binding) => Some(binding),
+                OutputCovenant::Unbound | OutputCovenant::Genesis { .. } => None,
+            };
+            outputs.push(TransactionOutput::with_covenant(output.source.value, script_public_key, covenant));
         }
 
         let transaction = Transaction::new(
@@ -222,6 +236,32 @@ impl<'artifact> TxBuilder<'artifact> {
             context.payload.to_vec(),
         );
         Ok(MutableTransaction::with_entries(transaction, entries))
+    }
+
+    /// Populate context-declared `launch::<name>` groups through rusty-kaspa.
+    ///
+    /// The materialized transaction remains the authoritative source for the
+    /// populated bindings used by later resolution passes.
+    fn populate_launch_covenants(
+        &self,
+        context: &ResolveContext<'artifact, '_, '_>,
+        unsigned: &mut MutableTransaction<Transaction>,
+    ) -> BuilderResult<()> {
+        let groups = context
+            .launch_groups
+            .iter()
+            .map(|(launch, group)| {
+                let authorizing_input = u16::try_from(launch.authorizing_input)
+                    .map_err(|_| BuilderError::GenesisAuthorizingInputOverflow(launch.authorizing_input))?;
+                let outputs = group
+                    .output_indices
+                    .iter()
+                    .map(|&index| u32::try_from(index).map_err(|_| BuilderError::GenesisOutputIndexOverflow(index)))
+                    .collect::<BuilderResult<Vec<_>>>()?;
+                Ok(GenesisCovenantGroup::new(authorizing_input, outputs))
+            })
+            .collect::<BuilderResult<Vec<_>>>()?;
+        unsigned.tx.populate_genesis_covenants(&groups).map_err(Into::into)
     }
 
     /// Resolve user-visible entry arguments for every Argent input.
@@ -285,7 +325,11 @@ impl<'artifact> TxBuilder<'artifact> {
 
     /// Resolve every `observes` declaration from the concrete transaction
     /// inputs and outputs selected by its covenant id.
-    fn resolve_context_observations(&self, context: &mut ResolveContext<'artifact, '_, '_>) -> BuilderResult<()> {
+    fn resolve_context_observations(
+        &self,
+        context: &mut ResolveContext<'artifact, '_, '_>,
+        unsigned: &MutableTransaction<Transaction>,
+    ) -> BuilderResult<()> {
         for input_index in 0..context.inputs.len() {
             let ResolveInput::Argent(input) = &context.inputs[input_index] else {
                 continue;
@@ -296,7 +340,7 @@ impl<'artifact> TxBuilder<'artifact> {
 
             for observe in &input.argent_entry.observes {
                 let covenant_id = observed_covenant_id(input.source, args, observe)?;
-                let observation = resolve_observation(context, input.source, observe, covenant_id)?;
+                let observation = resolve_observation(context, unsigned, input.source, observe, covenant_id)?;
                 observations.insert(observe.name.clone(), observation);
             }
 
@@ -327,7 +371,7 @@ impl<'artifact> TxBuilder<'artifact> {
             };
 
             let input_covenant_id = input.source.utxo.covenant_id.expect("Argent input covenant id checked before spawn resolution");
-            let genesis_groups = collect_genesis_groups(context, input_index, input_covenant_id);
+            let genesis_groups = collect_genesis_groups(context, unsigned, input_index, input_covenant_id);
             let mut spawned_actors = BTreeMap::new();
             let mut candidate_groups = genesis_groups.iter();
             for spawn in &input.argent_entry.spawns {
@@ -371,29 +415,25 @@ impl<'artifact> TxBuilder<'artifact> {
 
         let mut spawned_actors = BTreeMap::new();
         for (output, &output_index) in spawn.outputs.iter().zip(&group.output_indices) {
-            let ResolveOutput::Argent(resolved_output) = &context.outputs[output_index] else {
+            let resolved_output = &context.outputs[output_index];
+            let ResolveOutputOwner::Actor(actor) = &resolved_output.owner else {
                 return Ok(None);
             };
+            let actor_name = &actor.contract.contract.name;
             let expected_handle = spawn_actor_type_handle(input, &output.actor)?;
-            let found_handle =
-                match self.actor_type_handle_in_artifact(resolved_output.artifact, &resolved_output.source.actor.actor, &output.state)
-                {
-                    Ok(handle) => handle,
-                    Err(BuilderError::MissingActorTypeHandle { .. }) => {
-                        return Ok(None);
-                    }
-                    Err(error) => return Err(error),
-                };
+            let found_handle = match self.actor_type_handle_in_artifact(actor.contract.artifact, actor_name, &output.state) {
+                Ok(handle) => handle,
+                Err(BuilderError::MissingActorTypeHandle { .. }) => {
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
+            };
             if found_handle != expected_handle {
                 return Ok(None);
             }
             spawned_actors.insert(
                 (spawn.name.clone(), output.name.clone()),
-                SpawnedActorContext {
-                    app: resolved_output.app.clone(),
-                    actor: resolved_output.source.actor.actor.clone(),
-                    output_index,
-                },
+                SpawnedActorContext { app: artifact_app_alias(&actor.contract.artifact.app), actor: actor_name.clone(), output_index },
             );
         }
         Ok(Some(spawned_actors))
@@ -474,10 +514,11 @@ impl<'artifact> TxBuilder<'artifact> {
     /// compiler-generated witness arguments.
     pub fn build(&self, context: &TxContext<'_>) -> BuilderResult<Transaction> {
         let mut context = self.bind_context(context)?;
-        let unsigned = self.unsigned_transaction(&context)?;
+        let mut unsigned = self.unsigned_transaction(&context)?;
+        self.populate_launch_covenants(&context, &mut unsigned)?;
         self.validate_leader_actor_input_counts(&context)?;
         self.resolve_context_args(&mut context, &unsigned)?;
-        self.resolve_context_observations(&mut context)?;
+        self.resolve_context_observations(&mut context, &unsigned)?;
         self.resolve_context_spawns(&mut context, &unsigned)?;
         self.resolve_context_hidden_args(&mut context)?;
         let mut signature_scripts = Vec::with_capacity(context.inputs.len());
@@ -531,13 +572,20 @@ impl<'artifact> TxBuilder<'artifact> {
 /// Collect genesis groups authorized by one input, following consensus's
 /// `(authorizing input, covenant ID)` grouping. Outputs within a group retain
 /// global transaction order; groups are ordered by their first output.
-fn collect_genesis_groups(context: &ResolveContext<'_, '_, '_>, input_index: usize, input_covenant_id: Hash) -> Vec<GenesisGroup> {
+/// Explicit `launch::<name>` groups are independent and do not satisfy an AG
+/// `spawns` clause.
+fn collect_genesis_groups(
+    context: &ResolveContext<'_, '_, '_>,
+    unsigned: &MutableTransaction<Transaction>,
+    input_index: usize,
+    input_covenant_id: Hash,
+) -> Vec<GenesisGroup> {
     let mut groups = BTreeMap::<Hash, GenesisGroup>::new();
     for (output_index, output) in context.outputs.iter().enumerate() {
-        let binding = match output {
-            ResolveOutput::Argent(output) => Some(output.source.covenant),
-            ResolveOutput::Ordinary(output) => output.covenant,
-        };
+        if matches!(output.source.covenant, OutputCovenant::Genesis { .. }) {
+            continue;
+        }
+        let binding = unsigned.tx.outputs[output_index].covenant;
         let Some(binding) = binding else {
             continue;
         };
@@ -609,13 +657,14 @@ fn observed_covenant_id(input: &ArgentInput<'_>, args: &ResolvedEntryArgs, obser
 
 fn resolve_observation(
     context: &ResolveContext<'_, '_, '_>,
+    unsigned: &MutableTransaction<Transaction>,
     input: &ArgentInput<'_>,
     observe: &ObserveArtifact,
     covenant_id: Hash,
 ) -> BuilderResult<ObservedCovenantContext> {
     let matching_inputs = matching_observed_inputs(context, covenant_id);
     require_observed_count(&observe.name, Side::In, observe.inputs.len(), matching_inputs.len())?;
-    let matching_outputs = matching_observed_outputs(context, covenant_id);
+    let matching_outputs = matching_observed_outputs(unsigned, covenant_id);
     require_observed_count(&observe.name, Side::Out, observe.outputs.len(), matching_outputs.len())?;
 
     // Pair both sides positionally: covenant members are indexed by transaction
@@ -653,17 +702,13 @@ fn matching_observed_inputs(context: &ResolveContext<'_, '_, '_>, covenant_id: H
         .collect()
 }
 
-fn matching_observed_outputs(context: &ResolveContext<'_, '_, '_>, covenant_id: Hash) -> Vec<usize> {
-    context
+fn matching_observed_outputs(unsigned: &MutableTransaction<Transaction>, covenant_id: Hash) -> Vec<usize> {
+    unsigned
+        .tx
         .outputs
         .iter()
         .enumerate()
-        .filter(|(_, candidate)| match candidate {
-            ResolveOutput::Argent(candidate) => candidate.source.covenant.covenant_id == covenant_id,
-            ResolveOutput::Ordinary(candidate) => {
-                candidate.covenant.as_ref().is_some_and(|binding| binding.covenant_id == covenant_id)
-            }
-        })
+        .filter(|(_, candidate)| candidate.covenant.as_ref().is_some_and(|binding| binding.covenant_id == covenant_id))
         .map(|(index, _)| index)
         .collect()
 }
@@ -690,7 +735,7 @@ fn resolve_observed_input(
             index,
         });
     };
-    merge_observed_app(observe, app, &candidate.app)?;
+    merge_observed_app(observe, app, &artifact_app_alias(&candidate.artifact.app))?;
     Ok((
         declaration.name.clone(),
         ObservedInput {
@@ -708,7 +753,7 @@ fn resolve_observed_output(
     candidate: &ResolveOutput<'_, '_>,
     app: &mut Option<String>,
 ) -> BuilderResult<(String, ObservedOutput)> {
-    let ResolveOutput::Argent(candidate) = candidate else {
+    let ResolveOutputOwner::Actor(actor) = &candidate.owner else {
         return Err(BuilderError::MissingObservedActorMetadata {
             observe: observe.to_string(),
             side: Side::Out,
@@ -716,11 +761,8 @@ fn resolve_observed_output(
             index,
         });
     };
-    merge_observed_app(observe, app, &candidate.app)?;
-    Ok((
-        declaration.name.clone(),
-        ObservedOutput { actor: candidate.source.actor.actor.clone(), state: candidate.source.state.clone() },
-    ))
+    merge_observed_app(observe, app, &artifact_app_alias(&actor.contract.artifact.app))?;
+    Ok((declaration.name.clone(), ObservedOutput { actor: actor.contract.contract.name.clone(), state: actor.state.clone() }))
 }
 
 fn merge_observed_app(observe: &str, app: &mut Option<String>, candidate: &str) -> BuilderResult<()> {
@@ -892,10 +934,14 @@ mod tests {
             .payload([0xaa, 0xbb]);
 
         let resolved = builder.bind_context(&context).expect("context binds");
-        assert!(matches!(&resolved.inputs[0], ResolveInput::Argent(input) if input.app == "primary"));
-        assert!(matches!(&resolved.inputs[2], ResolveInput::Argent(input) if input.app == "asset"));
-        assert!(matches!(&resolved.outputs[0], ResolveOutput::Argent(output) if output.app == "primary"));
-        assert!(matches!(&resolved.outputs[2], ResolveOutput::Argent(output) if output.app == "asset"));
+        assert!(matches!(&resolved.inputs[0], ResolveInput::Argent(input) if artifact_app_alias(&input.artifact.app) == "primary"));
+        assert!(matches!(&resolved.inputs[2], ResolveInput::Argent(input) if artifact_app_alias(&input.artifact.app) == "asset"));
+        assert!(
+            matches!(&resolved.outputs[0].owner, ResolveOutputOwner::Actor(actor) if artifact_app_alias(&actor.contract.artifact.app) == "primary")
+        );
+        assert!(
+            matches!(&resolved.outputs[2].owner, ResolveOutputOwner::Actor(actor) if artifact_app_alias(&actor.contract.artifact.app) == "asset")
+        );
 
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
 

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -713,7 +713,6 @@ fn spawn_actor_type_handle(input: &ResolveArgentInput<'_, '_, '_>, actor: &str) 
             .take(args.values.len())
             .position(|param| param.name == actor)
             .and_then(|index| args.values.get(index))
-            .or_else(|| input.source.state.get(actor))
     };
     let Some(ArtifactValue::Bytes(handle)) = value else {
         return Err(BuilderError::InvalidTransition {

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -16,7 +16,7 @@ use kaspa_txscript_errors::TxScriptError;
 use crate::{
     ActorPath, ArgentInput, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput, ContractRef, EntryArgs,
     HiddenArgContexts, InputSigScript, ObservedCovenantContext, ObservedInput, ObservedOutput, OrdinaryInput, OutputCovenant,
-    OutputOwner, Side, SpawnedActorContext, TxBuilder, TxContext, artifact_app_alias, covenant_engine_flags,
+    OutputOwner, Side, SpawnedActorContext, StateContext, TxBuilder, TxContext, artifact_app_alias, covenant_engine_flags,
     execute_transaction_with_covenants,
 };
 
@@ -60,7 +60,7 @@ impl LaunchGroupKey {
 /// hidden witnesses before the final signature scripts are assembled.
 struct ResolveContext<'artifact, 'context, 'args> {
     inputs: Vec<ResolveInput<'artifact, 'context, 'args>>,
-    outputs: Vec<ResolveOutput<'artifact, 'context>>,
+    outputs: Vec<ResolveOutput<'artifact, 'context, 'args>>,
     launch_groups: BTreeMap<LaunchGroupKey, GenesisGroup>,
     lock_time: u64,
     subnetwork_id: SubnetworkId,
@@ -92,18 +92,18 @@ impl<'artifact> ResolveArgentInput<'artifact, '_, '_> {
     }
 }
 
-struct ResolvedActor<'artifact, 'context> {
+struct ResolvedActor<'artifact> {
     contract: ContractRef<'artifact>,
-    state: &'context BTreeMap<String, ArtifactValue>,
+    state: BTreeMap<String, ArtifactValue>,
 }
 
 enum ResolveOutputOwner<'artifact, 'context> {
-    Actor(ResolvedActor<'artifact, 'context>),
+    Actor(ResolvedActor<'artifact>),
     Spk(&'context ScriptPublicKey),
 }
 
-struct ResolveOutput<'artifact, 'context> {
-    source: &'context ContextOutput,
+struct ResolveOutput<'artifact, 'context, 'args> {
+    source: &'context ContextOutput<'args>,
     owner: ResolveOutputOwner<'artifact, 'context>,
 }
 
@@ -149,19 +149,30 @@ impl<'artifact> TxBuilder<'artifact> {
 
         let mut outputs = Vec::with_capacity(context.outputs.len());
         let mut launch_groups = BTreeMap::<LaunchGroupKey, GenesisGroup>::new();
+        let state_context = StateContext::default();
         for (output_index, output) in context.outputs.iter().enumerate() {
-            let owner = match &output.owner {
-                OutputOwner::Actor { actor, state } => {
-                    ResolveOutputOwner::Actor(ResolvedActor { contract: self.bind_actor(actor)?, state })
-                }
-                OutputOwner::Spk(script_public_key) => ResolveOutputOwner::Spk(script_public_key),
-            };
             if let OutputCovenant::Genesis { authorizing_input, subgroup } = &output.covenant {
+                if let OutputOwner::Actor { actor, state } = &output.owner
+                    && state.is_deferred()
+                {
+                    return Err(BuilderError::GenesisOutputStateCallback { output_index, actor: actor.to_string() });
+                }
                 let launch = LaunchGroupKey::parse(*authorizing_input, subgroup)?;
                 launch_groups.entry(launch).or_default().output_indices.push(output_index);
             } else if let (OutputOwner::Actor { actor, .. }, OutputCovenant::Unbound) = (&output.owner, &output.covenant) {
                 return Err(BuilderError::UnboundArgentOutput { output_index, actor: actor.to_string() });
             }
+            let owner = match &output.owner {
+                OutputOwner::Actor { actor, state } => ResolveOutputOwner::Actor(ResolvedActor {
+                    contract: self.bind_actor(actor)?,
+                    state: state.resolve(&state_context).map_err(|source| BuilderError::OutputStateCallback {
+                        output_index,
+                        actor: actor.to_string(),
+                        source,
+                    })?,
+                }),
+                OutputOwner::Spk(script_public_key) => ResolveOutputOwner::Spk(script_public_key),
+            };
             outputs.push(ResolveOutput { source: output, owner });
         }
 
@@ -750,7 +761,7 @@ fn resolve_observed_output(
     observe: &str,
     declaration: &ObservedActorArtifact,
     index: usize,
-    candidate: &ResolveOutput<'_, '_>,
+    candidate: &ResolveOutput<'_, '_, '_>,
     app: &mut Option<String>,
 ) -> BuilderResult<(String, ObservedOutput)> {
     let ResolveOutputOwner::Actor(actor) = &candidate.owner else {
@@ -797,7 +808,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{ArgValue, ArtifactBundle, ArtifactValue, EntryCall, InputSigScript, actor};
+    use crate::{ArgValue, ArtifactBundle, ArtifactValue, EntryCall, InputSigScript, actor, state_with, try_state_with};
 
     fn artifact(app: &str, actor: &str, entry: &str) -> Artifact {
         artifact_with_entry(app, actor, entry, Vec::new(), Vec::new())
@@ -976,6 +987,77 @@ mod tests {
         assert_eq!(unsigned.tx.outputs[2].covenant, Some(CovenantBinding::new(2, reserve_id)));
         assert!(!args_called.get());
         assert!(!script_called.get());
+    }
+
+    #[test]
+    fn output_state_callback_resolves_once_before_materialization() {
+        let artifact = artifact("primary", "Counter", "bump");
+        let builder = TxBuilder::new(&artifact).expect("artifact builds");
+        let covenant_id = Hash::from_bytes([0x31; 32]);
+        let calls = Cell::new(0);
+        let context = TxContext::new().argent_output(
+            "Counter",
+            state_with(|_| {
+                calls.set(calls.get() + 1);
+                state(3)
+            }),
+            CovenantBinding::new(0, covenant_id),
+            900,
+        );
+
+        let resolved = builder.bind_context(&context).expect("deferred state resolves");
+        assert_eq!(calls.get(), 1);
+        assert!(matches!(&resolved.outputs[0].owner, ResolveOutputOwner::Actor(actor) if actor.state == state(3)));
+        let unsigned = builder.unsigned_transaction(&resolved).expect("resolved state materializes");
+        assert_eq!(calls.get(), 1);
+        assert_eq!(
+            unsigned.tx.outputs[0].script_public_key,
+            builder
+                .covenant_utxo("Counter", state(3), 900, 0, false, Some(covenant_id))
+                .expect("expected output script builds")
+                .script_public_key
+        );
+    }
+
+    #[test]
+    fn output_state_callback_error_reports_output_context() {
+        let artifact = artifact("primary", "Counter", "bump");
+        let builder = TxBuilder::new(&artifact).expect("artifact builds");
+        let covenant_id = Hash::from_bytes([0x31; 32]);
+        let fallible = TxContext::new().argent_output(
+            "Counter",
+            try_state_with(|_| -> Result<_, std::io::Error> { Err(std::io::Error::other("state failed")) }),
+            CovenantBinding::new(0, covenant_id),
+            900,
+        );
+        assert!(matches!(
+            builder.bind_context(&fallible),
+            Err(BuilderError::OutputStateCallback { output_index: 0, actor, .. }) if actor == "Counter"
+        ));
+    }
+
+    #[test]
+    fn genesis_output_rejects_deferred_state_without_calling_it() {
+        let artifact = artifact("primary", "Counter", "bump");
+        let builder = TxBuilder::new(&artifact).expect("artifact builds");
+        let genesis_calls = Cell::new(0);
+        let mut genesis = TxContext::new();
+        genesis.outputs.push(ContextOutput {
+            owner: OutputOwner::Actor {
+                actor: ActorPath::primary("Counter"),
+                state: state_with(|_| {
+                    genesis_calls.set(genesis_calls.get() + 1);
+                    state(3)
+                }),
+            },
+            covenant: OutputCovenant::Genesis { authorizing_input: 0, subgroup: "launch::counter".to_string() },
+            value: 900,
+        });
+        assert!(matches!(
+            builder.bind_context(&genesis),
+            Err(BuilderError::GenesisOutputStateCallback { output_index: 0, actor }) if actor == "Counter"
+        ));
+        assert_eq!(genesis_calls.get(), 0);
     }
 
     #[test]

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -7,8 +7,9 @@ use argent_artifact::{
 use kaspa_consensus_core::{
     Hash,
     constants::TX_VERSION_TOCCATA,
+    hashing::covenant_id as rk_hashing,
     subnets::SubnetworkId,
-    tx::{GenesisCovenantGroup, MutableTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutput},
+    tx::{CovenantBinding, MutableTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutput},
 };
 use kaspa_txscript::{covenants::CovenantsContext, pay_to_script_hash_script, pay_to_script_hash_signature_script_with_flags};
 use kaspa_txscript_errors::TxScriptError;
@@ -16,8 +17,8 @@ use kaspa_txscript_errors::TxScriptError;
 use crate::{
     ActorPath, ArgentInput, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput, ContractRef, EntryArgs,
     HiddenArgContexts, InputSigScript, ObservedCovenantContext, ObservedInput, ObservedOutput, OrdinaryInput, OutputCovenant,
-    OutputOwner, Side, SpawnedActorContext, StateContext, TxBuilder, TxContext, artifact_app_alias, covenant_engine_flags,
-    execute_transaction_with_covenants,
+    OutputOwner, OutputState, Side, SpawnedActorContext, StateContext, TxBuilder, TxContext, artifact_app_alias,
+    covenant_engine_flags, execute_transaction_with_covenants,
 };
 
 type ResolvedObservations = BTreeMap<String, ObservedCovenantContext>;
@@ -36,12 +37,12 @@ struct GenesisGroup {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct LaunchGroupKey {
-    authorizing_input: usize,
+    authorizing_input: u16,
     name: String,
 }
 
 impl LaunchGroupKey {
-    fn parse(authorizing_input: usize, path: &str) -> BuilderResult<Self> {
+    fn parse(authorizing_input: u16, path: &str) -> BuilderResult<Self> {
         let Some(name) = path.strip_prefix("launch::") else {
             return Err(BuilderError::InvalidGenesisPath(path.to_string()));
         };
@@ -61,7 +62,6 @@ impl LaunchGroupKey {
 struct ResolveContext<'artifact, 'context, 'args> {
     inputs: Vec<ResolveInput<'artifact, 'context, 'args>>,
     outputs: Vec<ResolveOutput<'artifact, 'context, 'args>>,
-    launch_groups: BTreeMap<LaunchGroupKey, GenesisGroup>,
     lock_time: u64,
     subnetwork_id: SubnetworkId,
     gas: u64,
@@ -105,6 +105,7 @@ enum ResolveOutputOwner<'artifact, 'context> {
 struct ResolveOutput<'artifact, 'context, 'args> {
     source: &'context ContextOutput<'args>,
     owner: ResolveOutputOwner<'artifact, 'context>,
+    covenant: Option<CovenantBinding>,
 }
 
 impl<'artifact> TxBuilder<'artifact> {
@@ -119,6 +120,17 @@ impl<'artifact> TxBuilder<'artifact> {
         &self,
         context: &'context TxContext<'args>,
     ) -> BuilderResult<ResolveContext<'artifact, 'context, 'args>> {
+        enum BoundOutputOwner<'a, 'c, 's> {
+            Actor { path: &'c ActorPath, contract: ContractRef<'a>, state: &'c OutputState<'s> },
+            Spk(&'c ScriptPublicKey),
+        }
+
+        struct BoundOutput<'a, 'c, 's> {
+            source: &'c ContextOutput<'s>,
+            owner: BoundOutputOwner<'a, 'c, 's>,
+        }
+
+        // Bind input actors and entries to their verified artifact metadata.
         let mut inputs = Vec::with_capacity(context.inputs.len());
         for input in &context.inputs {
             match input {
@@ -147,9 +159,9 @@ impl<'artifact> TxBuilder<'artifact> {
             }
         }
 
-        let mut outputs = Vec::with_capacity(context.outputs.len());
+        // First output pass: bind actors, validate genesis declarations, and collect their ordered groups.
+        let mut bound_outputs = Vec::with_capacity(context.outputs.len());
         let mut launch_groups = BTreeMap::<LaunchGroupKey, GenesisGroup>::new();
-        let state_context = StateContext::default();
         for (output_index, output) in context.outputs.iter().enumerate() {
             if let OutputCovenant::Genesis { authorizing_input, subgroup } = &output.covenant {
                 if let OutputOwner::Actor { actor, state } = &output.owner
@@ -163,23 +175,79 @@ impl<'artifact> TxBuilder<'artifact> {
                 return Err(BuilderError::UnboundArgentOutput { output_index, actor: actor.to_string() });
             }
             let owner = match &output.owner {
-                OutputOwner::Actor { actor, state } => ResolveOutputOwner::Actor(ResolvedActor {
-                    contract: self.bind_actor(actor)?,
+                OutputOwner::Actor { actor, state } => {
+                    BoundOutputOwner::Actor { path: actor, contract: self.bind_actor(actor)?, state }
+                }
+                OutputOwner::Spk(script_public_key) => BoundOutputOwner::Spk(script_public_key),
+            };
+            bound_outputs.push(BoundOutput { source: output, owner });
+        }
+
+        // Derive every genesis covenant ID before any deferred output state is evaluated.
+        let mut state_context = StateContext::default();
+        for (launch, group) in &launch_groups {
+            let authorizing_input =
+                context.inputs.get(usize::from(launch.authorizing_input)).ok_or(BuilderError::GenesisAuthorizingInputOutOfRange {
+                    authorizing_input: launch.authorizing_input,
+                    input_count: context.inputs.len(),
+                })?;
+            let outpoint = match authorizing_input {
+                ContextInput::Argent(input) => input.outpoint,
+                ContextInput::Ordinary(input) => input.outpoint,
+            };
+            let genesis_outputs = group
+                .output_indices
+                .iter()
+                .map(|&output_index| {
+                    let output = &bound_outputs[output_index];
+                    let spk = match &output.owner {
+                        BoundOutputOwner::Actor { contract, state, .. } => {
+                            let OutputState::Static(state) = state else {
+                                unreachable!("genesis actor output callbacks are rejected while outputs are bound")
+                            };
+                            pay_to_script_hash_script(&self.redeem_script_for_contract(*contract, state.clone())?)
+                        }
+                        BoundOutputOwner::Spk(spk) => (*spk).clone(),
+                    };
+                    let output_index =
+                        u32::try_from(output_index).map_err(|_| BuilderError::GenesisOutputIndexOverflow(output_index))?;
+                    Ok((output_index, TransactionOutput::new(output.source.value, spk)))
+                })
+                .collect::<BuilderResult<Vec<_>>>()?;
+            let covenant_id = rk_hashing::covenant_id(outpoint, genesis_outputs.iter().map(|(index, output)| (*index, output)));
+            state_context.insert_genesis_covenant_id(launch.authorizing_input, format!("launch::{}", launch.name), covenant_id);
+        }
+
+        // Second output pass: attach resolved bindings and evaluate states against the complete genesis context.
+        let mut outputs = Vec::with_capacity(bound_outputs.len());
+        for (output_index, output) in bound_outputs.into_iter().enumerate() {
+            let covenant = match &output.source.covenant {
+                OutputCovenant::Existing(binding) => Some(*binding),
+                OutputCovenant::Unbound => None,
+                OutputCovenant::Genesis { authorizing_input, subgroup } => {
+                    let covenant_id = state_context
+                        .genesis_covenant_id(*authorizing_input, subgroup)
+                        .expect("genesis covenant IDs are populated before output states resolve");
+                    Some(CovenantBinding::new(*authorizing_input, covenant_id))
+                }
+            };
+            let owner = match output.owner {
+                BoundOutputOwner::Actor { path, contract, state } => ResolveOutputOwner::Actor(ResolvedActor {
+                    contract,
                     state: state.resolve(&state_context).map_err(|source| BuilderError::OutputStateCallback {
                         output_index,
-                        actor: actor.to_string(),
+                        actor: path.to_string(),
                         source,
                     })?,
                 }),
-                OutputOwner::Spk(script_public_key) => ResolveOutputOwner::Spk(script_public_key),
+                BoundOutputOwner::Spk(script_public_key) => ResolveOutputOwner::Spk(script_public_key),
             };
-            outputs.push(ResolveOutput { source: output, owner });
+            outputs.push(ResolveOutput { source: output.source, owner, covenant });
         }
 
         Ok(ResolveContext {
             inputs,
             outputs,
-            launch_groups,
             lock_time: context.lock_time,
             subnetwork_id: context.subnetwork_id,
             gas: context.gas,
@@ -230,11 +298,7 @@ impl<'artifact> TxBuilder<'artifact> {
                 }
                 ResolveOutputOwner::Spk(script_public_key) => (*script_public_key).clone(),
             };
-            let covenant = match output.source.covenant {
-                OutputCovenant::Existing(binding) => Some(binding),
-                OutputCovenant::Unbound | OutputCovenant::Genesis { .. } => None,
-            };
-            outputs.push(TransactionOutput::with_covenant(output.source.value, script_public_key, covenant));
+            outputs.push(TransactionOutput::with_covenant(output.source.value, script_public_key, output.covenant));
         }
 
         let transaction = Transaction::new(
@@ -247,32 +311,6 @@ impl<'artifact> TxBuilder<'artifact> {
             context.payload.to_vec(),
         );
         Ok(MutableTransaction::with_entries(transaction, entries))
-    }
-
-    /// Populate context-declared `launch::<name>` groups through rusty-kaspa.
-    ///
-    /// The materialized transaction remains the authoritative source for the
-    /// populated bindings used by later resolution passes.
-    fn populate_launch_covenants(
-        &self,
-        context: &ResolveContext<'artifact, '_, '_>,
-        unsigned: &mut MutableTransaction<Transaction>,
-    ) -> BuilderResult<()> {
-        let groups = context
-            .launch_groups
-            .iter()
-            .map(|(launch, group)| {
-                let authorizing_input = u16::try_from(launch.authorizing_input)
-                    .map_err(|_| BuilderError::GenesisAuthorizingInputOverflow(launch.authorizing_input))?;
-                let outputs = group
-                    .output_indices
-                    .iter()
-                    .map(|&index| u32::try_from(index).map_err(|_| BuilderError::GenesisOutputIndexOverflow(index)))
-                    .collect::<BuilderResult<Vec<_>>>()?;
-                Ok(GenesisCovenantGroup::new(authorizing_input, outputs))
-            })
-            .collect::<BuilderResult<Vec<_>>>()?;
-        unsigned.tx.populate_genesis_covenants(&groups).map_err(Into::into)
     }
 
     /// Resolve user-visible entry arguments for every Argent input.
@@ -525,8 +563,7 @@ impl<'artifact> TxBuilder<'artifact> {
     /// compiler-generated witness arguments.
     pub fn build(&self, context: &TxContext<'_>) -> BuilderResult<Transaction> {
         let mut context = self.bind_context(context)?;
-        let mut unsigned = self.unsigned_transaction(&context)?;
-        self.populate_launch_covenants(&context, &mut unsigned)?;
+        let unsigned = self.unsigned_transaction(&context)?;
         self.validate_leader_actor_input_counts(&context)?;
         self.resolve_context_args(&mut context, &unsigned)?;
         self.resolve_context_observations(&mut context, &unsigned)?;
@@ -990,33 +1027,85 @@ mod tests {
     }
 
     #[test]
-    fn output_state_callback_resolves_once_before_materialization() {
+    fn output_state_callback_reads_launch_covenant_id_before_materialization() {
         let artifact = artifact("primary", "Counter", "bump");
         let builder = TxBuilder::new(&artifact).expect("artifact builds");
-        let covenant_id = Hash::from_bytes([0x31; 32]);
+        let existing_id = Hash::from_bytes([0x31; 32]);
         let calls = Cell::new(0);
-        let context = TxContext::new().argent_output(
-            "Counter",
-            state_with(|_| {
-                calls.set(calls.get() + 1);
-                state(3)
-            }),
-            CovenantBinding::new(0, covenant_id),
-            900,
-        );
+        let launch_id = Cell::new(None);
+        let authorizing_utxo = UtxoEntry::new(1_000, ScriptPublicKey::default(), 0, false, None);
+        let context = TxContext::new()
+            .input(outpoint(9), authorizing_utxo, Vec::new(), 0)
+            .argent_genesis_output(0, "launch::child", "Counter", state(1), 100)
+            .argent_output(
+                "Counter",
+                state_with(|context| {
+                    calls.set(calls.get() + 1);
+                    launch_id.set(context.genesis_covenant_id(0, "launch::child"));
+                    state(3)
+                }),
+                CovenantBinding::new(0, existing_id),
+                900,
+            )
+            .genesis_output(0, "launch::child", ScriptPublicKey::default(), 50);
 
         let resolved = builder.bind_context(&context).expect("deferred state resolves");
         assert_eq!(calls.get(), 1);
-        assert!(matches!(&resolved.outputs[0].owner, ResolveOutputOwner::Actor(actor) if actor.state == state(3)));
+        let launch_id = launch_id.get().expect("callback sees launch covenant ID");
+        assert!(matches!(&resolved.outputs[1].owner, ResolveOutputOwner::Actor(actor) if actor.state == state(3)));
         let unsigned = builder.unsigned_transaction(&resolved).expect("resolved state materializes");
         assert_eq!(calls.get(), 1);
+        assert_eq!(unsigned.tx.outputs[0].covenant, Some(CovenantBinding::new(0, launch_id)));
+        assert_eq!(unsigned.tx.outputs[2].covenant, Some(CovenantBinding::new(0, launch_id)));
         assert_eq!(
-            unsigned.tx.outputs[0].script_public_key,
+            unsigned.tx.outputs[1].script_public_key,
             builder
-                .covenant_utxo("Counter", state(3), 900, 0, false, Some(covenant_id))
+                .covenant_utxo("Counter", state(3), 900, 0, false, Some(existing_id))
                 .expect("expected output script builds")
                 .script_public_key
         );
+    }
+
+    #[test]
+    fn state_context_scopes_genesis_subgroups_by_authorizing_input() {
+        let artifact = artifact("primary", "Counter", "bump");
+        let builder = TxBuilder::new(&artifact).expect("artifact builds");
+        let first = UtxoEntry::new(1_000, ScriptPublicKey::default(), 0, false, None);
+        let second = UtxoEntry::new(1_000, ScriptPublicKey::default(), 0, false, None);
+        let ids = Cell::new(None);
+        let context = TxContext::new()
+            .input(outpoint(1), first, Vec::new(), 0)
+            .input(outpoint(2), second, Vec::new(), 0)
+            .argent_genesis_output(0, "launch::child", "Counter", state(1), 100)
+            .argent_genesis_output(1, "launch::child", "Counter", state(1), 100)
+            .argent_output(
+                "Counter",
+                state_with(|context| {
+                    ids.set(Some((
+                        context.genesis_covenant_id(0, "launch::child").expect("first launch exists"),
+                        context.genesis_covenant_id(1, "launch::child").expect("second launch exists"),
+                    )));
+                    state(2)
+                }),
+                CovenantBinding::new(0, Hash::from_bytes([0x41; 32])),
+                100,
+            );
+
+        builder.bind_context(&context).expect("context binds");
+        let (first, second) = ids.get().expect("callback sees both launches");
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn context_binding_rejects_out_of_range_genesis_authorizing_input() {
+        let artifact = artifact("primary", "Counter", "bump");
+        let builder = TxBuilder::new(&artifact).expect("artifact builds");
+        let context = TxContext::new().argent_genesis_output(1, "launch::child", "Counter", state(1), 100);
+
+        assert!(matches!(
+            builder.bind_context(&context),
+            Err(BuilderError::GenesisAuthorizingInputOutOfRange { authorizing_input: 1, input_count: 0 })
+        ));
     }
 
     #[test]

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -14,7 +14,7 @@ use kaspa_consensus_core::{
 use kaspa_txscript::{pay_to_script_hash_script, pay_to_script_hash_signature_script_with_flags};
 
 use crate::{
-    ActorPath, ArgentInput, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput, ContractRef, EntryArgs,
+    ActorInput, ActorPath, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput, ContractRef, EntryArgs,
     HiddenArgContexts, InputSigScript, ObservedCovenantContext, ObservedInput, ObservedOutput, OrdinaryInput, OutputCovenant,
     OutputOwner, OutputState, Side, SpawnedActorContext, StateContext, TxBuilder, TxContext, artifact_app_alias,
     covenant_engine_flags, execute_transaction_with_covenants,
@@ -81,7 +81,7 @@ impl GenesisGroupKey {
 /// hidden witnesses before the final signature scripts are assembled.
 struct ResolveContext<'artifact, 'context, 'args> {
     inputs: Vec<ResolveInput<'artifact, 'context, 'args>>,
-    outputs: Vec<ResolveOutput<'artifact>>,
+    outputs: Vec<ResolvedOutput<'artifact>>,
     lock_time: u64,
     subnetwork_id: SubnetworkId,
     gas: u64,
@@ -89,16 +89,16 @@ struct ResolveContext<'artifact, 'context, 'args> {
 }
 
 enum ResolveInput<'artifact, 'context, 'args> {
-    Argent(ResolveArgentInput<'artifact, 'context, 'args>),
+    Actor(ResolveActorInput<'artifact, 'context, 'args>),
     Ordinary(&'context OrdinaryInput<'args>),
 }
 
-struct ResolveArgentInput<'artifact, 'context, 'args> {
-    source: &'context ArgentInput<'args>,
+struct ResolveActorInput<'artifact, 'context, 'args> {
+    source: &'context ActorInput<'args>,
     artifact: &'artifact Artifact,
     actor: &'artifact ActorArtifact,
     contract: &'artifact SilContractArtifact,
-    argent_entry: &'artifact EntryArtifact,
+    artifact_entry: &'artifact EntryArtifact,
     sil_entry: &'artifact SilEntryArtifact,
     args: Option<ResolvedEntryArgs>,
     observations: Option<ResolvedObservations>,
@@ -106,7 +106,7 @@ struct ResolveArgentInput<'artifact, 'context, 'args> {
     hidden_args: Option<Vec<ArtifactValue>>,
 }
 
-impl<'artifact> ResolveArgentInput<'artifact, '_, '_> {
+impl<'artifact> ResolveActorInput<'artifact, '_, '_> {
     fn contract_ref(&self) -> ContractRef<'artifact> {
         ContractRef { artifact: self.artifact, contract: self.contract }
     }
@@ -117,18 +117,18 @@ struct ResolvedActor<'artifact> {
     state: BTreeMap<String, ArtifactValue>,
 }
 
-enum ResolveOutputOwner<'artifact> {
+enum ResolvedOutputOwner<'artifact> {
     Actor(ResolvedActor<'artifact>),
     Spk(ScriptPublicKey),
 }
 
-enum ResolveOutputBinding {
+enum ResolvedOutputBinding {
     Unbound,
     Existing(CovenantBinding),
     Genesis { binding: CovenantBinding, group: GenesisGroupName },
 }
 
-impl ResolveOutputBinding {
+impl ResolvedOutputBinding {
     fn covenant(&self) -> Option<CovenantBinding> {
         match self {
             Self::Unbound => None,
@@ -137,9 +137,9 @@ impl ResolveOutputBinding {
     }
 }
 
-struct ResolveOutput<'artifact> {
-    owner: ResolveOutputOwner<'artifact>,
-    binding: ResolveOutputBinding,
+struct ResolvedOutput<'artifact> {
+    owner: ResolvedOutputOwner<'artifact>,
+    binding: ResolvedOutputBinding,
     value: u64,
 }
 
@@ -169,20 +169,20 @@ impl<'artifact> TxBuilder<'artifact> {
         let mut inputs = Vec::with_capacity(context.inputs.len());
         for input in &context.inputs {
             match input {
-                ContextInput::Argent(input) => {
+                ContextInput::Actor(input) => {
                     let contract_ref = self.bind_actor(&input.actor)?;
-                    let actor_ref = self.argent_actor_ref_in_artifact(contract_ref.artifact, &input.actor.actor)?;
-                    let argent_entry = self.entry_ref_for_actor(actor_ref, &input.actor.actor, &input.entry.name)?;
+                    let actor_ref = self.actor_ref_in_artifact(contract_ref.artifact, &input.actor.actor)?;
+                    let artifact_entry = self.entry_ref_for_actor(actor_ref, &input.actor.actor, &input.entry.name)?;
                     let sil_entry = contract_ref.contract.entry(&input.entry.name).ok_or_else(|| BuilderError::UnknownEntry {
                         actor: input.actor.to_string(),
                         entry: input.entry.name.clone(),
                     })?;
-                    inputs.push(ResolveInput::Argent(ResolveArgentInput {
+                    inputs.push(ResolveInput::Actor(ResolveActorInput {
                         source: input,
                         artifact: contract_ref.artifact,
                         actor: actor_ref.actor,
                         contract: contract_ref.contract,
-                        argent_entry,
+                        artifact_entry,
                         sil_entry,
                         args: None,
                         observations: None,
@@ -211,16 +211,16 @@ impl<'artifact> TxBuilder<'artifact> {
                         input_count: inputs.len(),
                     })?;
                 if let GenesisGroupName::Spawn(spawn) = &group.name {
-                    let ResolveInput::Argent(input) = authorizer else {
-                        return Err(BuilderError::SpawnAuthorizingInputNotArgent(*authorizing_input, spawn.clone()));
+                    let ResolveInput::Actor(input) = authorizer else {
+                        return Err(BuilderError::SpawnAuthorizingInputNotActor(*authorizing_input, spawn.clone()));
                     };
-                    if !input.argent_entry.spawns.iter().any(|declared| declared.name == *spawn) {
+                    if !input.artifact_entry.spawns.iter().any(|declared| declared.name == *spawn) {
                         return Err(BuilderError::UnknownSpawn(*authorizing_input, spawn.clone()));
                     }
                 }
                 genesis_groups.entry(group).or_default().output_indices.push(output_index);
             } else if let (OutputOwner::Actor { actor, .. }, OutputCovenant::Unbound) = (&output.owner, &output.covenant) {
-                return Err(BuilderError::UnboundArgentOutput { output_index, actor: actor.to_string() });
+                return Err(BuilderError::UnboundActorOutput { output_index, actor: actor.to_string() });
             }
             let owner = match &output.owner {
                 OutputOwner::Actor { actor, state } => {
@@ -240,7 +240,7 @@ impl<'artifact> TxBuilder<'artifact> {
                     input_count: context.inputs.len(),
                 })?;
             let outpoint = match authorizing_input {
-                ContextInput::Argent(input) => input.outpoint,
+                ContextInput::Actor(input) => input.outpoint,
                 ContextInput::Ordinary(input) => input.outpoint,
             };
             let genesis_outputs = group
@@ -268,18 +268,18 @@ impl<'artifact> TxBuilder<'artifact> {
         let mut outputs = Vec::with_capacity(bound_outputs.len());
         for (output_index, output) in bound_outputs.into_iter().enumerate() {
             let binding = match &output.source.covenant {
-                OutputCovenant::Existing(binding) => ResolveOutputBinding::Existing(*binding),
-                OutputCovenant::Unbound => ResolveOutputBinding::Unbound,
+                OutputCovenant::Existing(binding) => ResolvedOutputBinding::Existing(*binding),
+                OutputCovenant::Unbound => ResolvedOutputBinding::Unbound,
                 OutputCovenant::Genesis { authorizing_input, subgroup } => {
                     let group = GenesisGroupKey::parse(*authorizing_input, subgroup)?;
                     let covenant_id =
                         state_context.genesis_covenant_id(*authorizing_input, subgroup).expect("expected by output phase 2");
                     let binding = CovenantBinding::new(*authorizing_input, covenant_id);
-                    ResolveOutputBinding::Genesis { binding, group: group.name }
+                    ResolvedOutputBinding::Genesis { binding, group: group.name }
                 }
             };
             let owner = match output.owner {
-                BoundOutputOwner::Actor { path, contract, state } => ResolveOutputOwner::Actor(ResolvedActor {
+                BoundOutputOwner::Actor { path, contract, state } => ResolvedOutputOwner::Actor(ResolvedActor {
                     contract,
                     state: state.resolve(&state_context).map_err(|source| BuilderError::OutputStateCallback {
                         output_index,
@@ -287,9 +287,9 @@ impl<'artifact> TxBuilder<'artifact> {
                         source,
                     })?,
                 }),
-                BoundOutputOwner::Spk(spk) => ResolveOutputOwner::Spk(spk.clone()),
+                BoundOutputOwner::Spk(spk) => ResolvedOutputOwner::Spk(spk.clone()),
             };
-            outputs.push(ResolveOutput { owner, binding, value: output.source.value });
+            outputs.push(ResolvedOutput { owner, binding, value: output.source.value });
         }
 
         Ok(ResolveContext {
@@ -313,14 +313,14 @@ impl<'artifact> TxBuilder<'artifact> {
 
         for (input_index, input) in context.inputs.iter().enumerate() {
             match input {
-                ResolveInput::Argent(input) => {
+                ResolveInput::Actor(input) => {
                     if input.source.utxo.covenant_id.is_none() {
-                        return Err(BuilderError::MissingArgentInputCovenantId { input_index, actor: input.source.actor.to_string() });
+                        return Err(BuilderError::MissingActorInputCovenantId { input_index, actor: input.source.actor.to_string() });
                     }
                     let expected_script =
                         pay_to_script_hash_script(&self.redeem_script_for_contract(input.contract_ref(), input.source.state.clone())?);
                     if input.source.utxo.script_public_key != expected_script {
-                        return Err(BuilderError::ArgentInputScriptMismatch { input_index, actor: input.source.actor.to_string() });
+                        return Err(BuilderError::ActorInputScriptMismatch { input_index, actor: input.source.actor.to_string() });
                     }
                     inputs.push(TransactionInput::new_with_compute_budget(
                         input.source.outpoint,
@@ -340,10 +340,10 @@ impl<'artifact> TxBuilder<'artifact> {
         let mut outputs = Vec::with_capacity(context.outputs.len());
         for output in &context.outputs {
             let script_public_key = match &output.owner {
-                ResolveOutputOwner::Actor(actor) => {
+                ResolvedOutputOwner::Actor(actor) => {
                     pay_to_script_hash_script(&self.redeem_script_for_contract(actor.contract, actor.state.clone())?)
                 }
-                ResolveOutputOwner::Spk(script_public_key) => script_public_key.clone(),
+                ResolvedOutputOwner::Spk(spk) => spk.clone(),
             };
             outputs.push(TransactionOutput::with_covenant(output.value, script_public_key, output.binding.covenant()));
         }
@@ -360,7 +360,7 @@ impl<'artifact> TxBuilder<'artifact> {
         Ok(MutableTransaction::with_entries(transaction, entries))
     }
 
-    /// Resolve user-visible entry arguments for every Argent input.
+    /// Resolve user-visible entry arguments for every actor input.
     ///
     /// Resolved values are stored on their corresponding inputs. Hidden
     /// arguments are filled by later passes over the same context.
@@ -370,18 +370,18 @@ impl<'artifact> TxBuilder<'artifact> {
         unsigned: &MutableTransaction<Transaction>,
     ) -> BuilderResult<()> {
         for (input_index, input) in context.inputs.iter_mut().enumerate() {
-            let ResolveInput::Argent(input) = input else {
+            let ResolveInput::Actor(input) = input else {
                 continue;
             };
 
             let expected_arg_count =
-                input.sil_entry.params.len().checked_sub(input.argent_entry.hidden_params.len()).ok_or_else(|| {
+                input.sil_entry.params.len().checked_sub(input.artifact_entry.hidden_params.len()).ok_or_else(|| {
                     BuilderError::InvalidTransition {
                         actor: input.source.actor.to_string(),
                         entry: input.source.entry.name.clone(),
                         message: format!(
                             "artifact has {} hidden parameters but the Sil entry has {} total parameters",
-                            input.argent_entry.hidden_params.len(),
+                            input.artifact_entry.hidden_params.len(),
                             input.sil_entry.params.len()
                         ),
                     }
@@ -409,10 +409,10 @@ impl<'artifact> TxBuilder<'artifact> {
                 &input.source.actor.actor,
                 &input.source.entry.name,
                 input.sil_entry,
-                input.argent_entry,
+                input.artifact_entry,
                 source_args,
             )?;
-            let values = self.runtime_entry_args(input.artifact, input.contract, input.sil_entry, input.argent_entry, values)?;
+            let values = self.runtime_entry_args(input.artifact, input.contract, input.sil_entry, input.artifact_entry, values)?;
             input.args = Some(ResolvedEntryArgs { values, template_selectors });
         }
 
@@ -427,14 +427,14 @@ impl<'artifact> TxBuilder<'artifact> {
         unsigned: &MutableTransaction<Transaction>,
     ) -> BuilderResult<()> {
         for input_index in 0..context.inputs.len() {
-            let ResolveInput::Argent(input) = &context.inputs[input_index] else {
+            let ResolveInput::Actor(input) = &context.inputs[input_index] else {
                 continue;
             };
 
             let args = input.args.as_ref().expect("argument resolution precedes observation resolution");
             let mut observations = BTreeMap::new();
 
-            for observe in &input.argent_entry.observes {
+            for observe in &input.artifact_entry.observes {
                 let covenant_id = observed_covenant_id(input.source, args, observe)?;
                 let observation = resolve_observation(context, unsigned, input.source, observe, covenant_id)?;
                 observations.insert(observe.name.clone(), observation);
@@ -444,10 +444,10 @@ impl<'artifact> TxBuilder<'artifact> {
                 input.artifact,
                 &input.source.actor.actor,
                 &input.source.entry.name,
-                input.argent_entry,
+                input.artifact_entry,
                 &observations,
             )?;
-            let ResolveInput::Argent(input) = &mut context.inputs[input_index] else { unreachable!() };
+            let ResolveInput::Actor(input) = &mut context.inputs[input_index] else { unreachable!() };
             input.observations = Some(observations);
         }
 
@@ -457,13 +457,13 @@ impl<'artifact> TxBuilder<'artifact> {
     /// Resolve each declared spawn from its explicitly named genesis group.
     fn resolve_context_spawns(&self, context: &mut ResolveContext<'artifact, '_, '_>) -> BuilderResult<()> {
         for input_index in 0..context.inputs.len() {
-            let ResolveInput::Argent(input) = &context.inputs[input_index] else {
+            let ResolveInput::Actor(input) = &context.inputs[input_index] else {
                 continue;
             };
 
             let mut spawned_actors = BTreeMap::new();
             let mut previous_first_output = None;
-            for spawn in &input.argent_entry.spawns {
+            for spawn in &input.artifact_entry.spawns {
                 let authorizing_input =
                     u16::try_from(input_index).map_err(|_| BuilderError::GenesisAuthorizingInputIndexOverflow(input_index))?;
                 let key = GenesisGroupKey { authorizing_input, name: GenesisGroupName::Spawn(spawn.name.clone()) };
@@ -481,7 +481,7 @@ impl<'artifact> TxBuilder<'artifact> {
                 spawned_actors.extend(self.resolve_spawn_group(context, input, spawn, &group)?);
             }
 
-            let ResolveInput::Argent(input) = &mut context.inputs[input_index] else { unreachable!() };
+            let ResolveInput::Actor(input) = &mut context.inputs[input_index] else { unreachable!() };
             input.spawned_actors = Some(spawned_actors);
         }
         Ok(())
@@ -490,13 +490,13 @@ impl<'artifact> TxBuilder<'artifact> {
     /// Validate one explicitly named genesis group against a spawn declaration.
     ///
     /// Validation requires the exact declared output count and, in declaration
-    /// order, Argent output metadata whose concrete actors expose the declared
+    /// order, actor output metadata whose concrete actors expose the declared
     /// `actor_type<State>` handles. State values remain the generated script's
     /// responsibility.
     fn resolve_spawn_group(
         &self,
         context: &ResolveContext<'artifact, '_, '_>,
-        input: &ResolveArgentInput<'artifact, '_, '_>,
+        input: &ResolveActorInput<'artifact, '_, '_>,
         spawn: &SpawnArtifact,
         group: &GenesisGroup,
     ) -> BuilderResult<ResolvedSpawnActors> {
@@ -510,10 +510,10 @@ impl<'artifact> TxBuilder<'artifact> {
         let mut spawned_actors = BTreeMap::new();
         for (output, &output_index) in spawn.outputs.iter().zip(&group.output_indices) {
             let resolved_output = &context.outputs[output_index];
-            let ResolveOutputOwner::Actor(actor) = &resolved_output.owner else {
+            let ResolvedOutputOwner::Actor(actor) = &resolved_output.owner else {
                 return Err(BuilderError::InvalidSpawnGroup(
                     spawn.name.clone(),
-                    format!("output `{}` at transaction index {output_index} has no Argent actor metadata", output.name),
+                    format!("output `{}` at transaction index {output_index} has no actor metadata", output.name),
                 ));
             };
             let actor_name = &actor.contract.contract.name;
@@ -556,7 +556,7 @@ impl<'artifact> TxBuilder<'artifact> {
     /// concrete observed actors selected by the transaction.
     fn resolve_context_hidden_args(&self, context: &mut ResolveContext<'artifact, '_, '_>) -> BuilderResult<()> {
         for input in &mut context.inputs {
-            let ResolveInput::Argent(input) = input else {
+            let ResolveInput::Actor(input) = input else {
                 continue;
             };
 
@@ -566,7 +566,7 @@ impl<'artifact> TxBuilder<'artifact> {
             input.hidden_args = Some(self.resolve_hidden_args_in_artifact(
                 input.artifact,
                 input.contract,
-                input.argent_entry,
+                input.artifact_entry,
                 &input.source.state,
                 &args.template_selectors,
                 HiddenArgContexts { observed: Some(observations), spawned: Some(spawned_actors) },
@@ -584,10 +584,10 @@ impl<'artifact> TxBuilder<'artifact> {
     /// reason before callbacks and script execution obscure it.
     fn validate_leader_actor_input_counts(&self, context: &ResolveContext<'artifact, '_, '_>) -> BuilderResult<()> {
         for (input_index, input) in context.inputs.iter().enumerate() {
-            let ResolveInput::Argent(input) = input else {
+            let ResolveInput::Actor(input) = input else {
                 continue;
             };
-            if input.argent_entry.kind != EntryKindArtifact::Leader {
+            if input.artifact_entry.kind != EntryKindArtifact::Leader {
                 continue;
             }
             if input.actor.leader_for.is_empty() {
@@ -597,12 +597,12 @@ impl<'artifact> TxBuilder<'artifact> {
                 continue;
             };
 
-            let expected = input.argent_entry.consumes.len() + 1;
+            let expected = input.artifact_entry.consumes.len() + 1;
             let found = context
                 .inputs
                 .iter()
                 .filter(|candidate| match candidate {
-                    ResolveInput::Argent(candidate) => candidate.source.utxo.covenant_id == Some(covenant_id),
+                    ResolveInput::Actor(candidate) => candidate.source.utxo.covenant_id == Some(covenant_id),
                     ResolveInput::Ordinary(candidate) => candidate.utxo.covenant_id == Some(covenant_id),
                 })
                 .count();
@@ -637,7 +637,7 @@ impl<'artifact> TxBuilder<'artifact> {
 
         for (input_index, input) in context.inputs.iter().enumerate() {
             let signature_script = match input {
-                ResolveInput::Argent(input) => {
+                ResolveInput::Actor(input) => {
                     let mut args = input.args.as_ref().expect("argument resolution precedes sigscript construction").values.clone();
                     args.extend(
                         input
@@ -651,7 +651,7 @@ impl<'artifact> TxBuilder<'artifact> {
                         input.artifact,
                         input.contract,
                         input.sil_entry,
-                        input.argent_entry,
+                        input.artifact_entry,
                         &args,
                     )?;
                     pay_to_script_hash_signature_script_with_flags(
@@ -688,7 +688,7 @@ fn named_genesis_group(context: &ResolveContext<'_, '_, '_>, key: &GenesisGroupK
         .iter()
         .enumerate()
         .filter_map(|(output_index, output)| match &output.binding {
-            ResolveOutputBinding::Genesis { binding, group }
+            ResolvedOutputBinding::Genesis { binding, group }
                 if binding.authorizing_input == key.authorizing_input && group == &key.name =>
             {
                 Some(output_index)
@@ -701,7 +701,7 @@ fn named_genesis_group(context: &ResolveContext<'_, '_, '_>, key: &GenesisGroupK
 
 /// Resolve a spawn actor expression from the input's source state or user
 /// arguments into its concrete 32-byte actor-type handle.
-fn spawn_actor_type_handle(input: &ResolveArgentInput<'_, '_, '_>, actor: &str) -> BuilderResult<Vec<u8>> {
+fn spawn_actor_type_handle(input: &ResolveActorInput<'_, '_, '_>, actor: &str) -> BuilderResult<Vec<u8>> {
     let args = input.args.as_ref().expect("argument resolution precedes spawn resolution");
     let value = if let Some(field) = actor.strip_prefix("self.") {
         input.source.state.get(field)
@@ -731,7 +731,7 @@ fn spawn_actor_type_handle(input: &ResolveArgentInput<'_, '_, '_>, actor: &str) 
     Ok(handle.clone())
 }
 
-fn observed_covenant_id(input: &ArgentInput<'_>, args: &ResolvedEntryArgs, observe: &ObserveArtifact) -> BuilderResult<Hash> {
+fn observed_covenant_id(input: &ActorInput<'_>, args: &ResolvedEntryArgs, observe: &ObserveArtifact) -> BuilderResult<Hash> {
     let value = match &observe.covenant_id_source {
         CovenantIdSourceArtifact::StateField { field } => input.state.get(field).ok_or_else(|| BuilderError::InvalidTransition {
             actor: input.actor.to_string(),
@@ -757,7 +757,7 @@ fn observed_covenant_id(input: &ArgentInput<'_>, args: &ResolvedEntryArgs, obser
 fn resolve_observation(
     context: &ResolveContext<'_, '_, '_>,
     unsigned: &MutableTransaction<Transaction>,
-    input: &ArgentInput<'_>,
+    input: &ActorInput<'_>,
     observe: &ObserveArtifact,
     covenant_id: Hash,
 ) -> BuilderResult<ObservedCovenantContext> {
@@ -794,7 +794,7 @@ fn matching_observed_inputs(context: &ResolveContext<'_, '_, '_>, covenant_id: H
         .iter()
         .enumerate()
         .filter(|(_, candidate)| match candidate {
-            ResolveInput::Argent(candidate) => candidate.source.utxo.covenant_id == Some(covenant_id),
+            ResolveInput::Actor(candidate) => candidate.source.utxo.covenant_id == Some(covenant_id),
             ResolveInput::Ordinary(candidate) => candidate.utxo.covenant_id == Some(covenant_id),
         })
         .map(|(index, _)| index)
@@ -826,7 +826,7 @@ fn resolve_observed_input(
     candidate: &ResolveInput<'_, '_, '_>,
     app: &mut Option<String>,
 ) -> BuilderResult<(String, ObservedInput)> {
-    let ResolveInput::Argent(candidate) = candidate else {
+    let ResolveInput::Actor(candidate) = candidate else {
         return Err(BuilderError::MissingObservedActorMetadata {
             observe: observe.to_string(),
             side: Side::In,
@@ -849,10 +849,10 @@ fn resolve_observed_output(
     observe: &str,
     declaration: &ObservedActorArtifact,
     index: usize,
-    candidate: &ResolveOutput<'_>,
+    candidate: &ResolvedOutput<'_>,
     app: &mut Option<String>,
 ) -> BuilderResult<(String, ObservedOutput)> {
-    let ResolveOutputOwner::Actor(actor) = &candidate.owner else {
+    let ResolvedOutputOwner::Actor(actor) = &candidate.owner else {
         return Err(BuilderError::MissingObservedActorMetadata {
             observe: observe.to_string(),
             side: Side::Out,
@@ -982,7 +982,7 @@ mod tests {
 
     fn resolved_args<'a>(context: &'a ResolveContext<'_, '_, '_>, input_index: usize) -> Option<&'a ResolvedEntryArgs> {
         match &context.inputs[input_index] {
-            ResolveInput::Argent(input) => input.args.as_ref(),
+            ResolveInput::Actor(input) => input.args.as_ref(),
             ResolveInput::Ordinary(_) => None,
         }
     }
@@ -1033,13 +1033,13 @@ mod tests {
             .payload([0xaa, 0xbb]);
 
         let resolved = builder.bind_context(&context).expect("context binds");
-        assert!(matches!(&resolved.inputs[0], ResolveInput::Argent(input) if artifact_app_alias(&input.artifact.app) == "primary"));
-        assert!(matches!(&resolved.inputs[2], ResolveInput::Argent(input) if artifact_app_alias(&input.artifact.app) == "asset"));
+        assert!(matches!(&resolved.inputs[0], ResolveInput::Actor(input) if artifact_app_alias(&input.artifact.app) == "primary"));
+        assert!(matches!(&resolved.inputs[2], ResolveInput::Actor(input) if artifact_app_alias(&input.artifact.app) == "asset"));
         assert!(
-            matches!(&resolved.outputs[0].owner, ResolveOutputOwner::Actor(actor) if artifact_app_alias(&actor.contract.artifact.app) == "primary")
+            matches!(&resolved.outputs[0].owner, ResolvedOutputOwner::Actor(actor) if artifact_app_alias(&actor.contract.artifact.app) == "primary")
         );
         assert!(
-            matches!(&resolved.outputs[2].owner, ResolveOutputOwner::Actor(actor) if artifact_app_alias(&actor.contract.artifact.app) == "asset")
+            matches!(&resolved.outputs[2].owner, ResolvedOutputOwner::Actor(actor) if artifact_app_alias(&actor.contract.artifact.app) == "asset")
         );
 
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
@@ -1103,7 +1103,7 @@ mod tests {
         let resolved = builder.bind_context(&context).expect("deferred state resolves");
         assert_eq!(calls.get(), 1);
         let launch_id = launch_id.get().expect("callback sees launch covenant ID");
-        assert!(matches!(&resolved.outputs[1].owner, ResolveOutputOwner::Actor(actor) if actor.state == state(3)));
+        assert!(matches!(&resolved.outputs[1].owner, ResolvedOutputOwner::Actor(actor) if actor.state == state(3)));
         let unsigned = builder.unsigned_transaction(&resolved).expect("resolved state materializes");
         assert_eq!(calls.get(), 1);
         assert_eq!(unsigned.tx.outputs[0].covenant, Some(CovenantBinding::new(0, launch_id)));
@@ -1214,14 +1214,14 @@ mod tests {
         let missing_id = builder.bind_context(&missing_id).expect("context binds");
         assert!(matches!(
             builder.unsigned_transaction(&missing_id),
-            Err(BuilderError::MissingArgentInputCovenantId { input_index: 0, actor }) if actor == "Counter"
+            Err(BuilderError::MissingActorInputCovenantId { input_index: 0, actor }) if actor == "Counter"
         ));
 
         let wrong_state = TxContext::new().actor_input("Counter", state(3), "bump", outpoint(1), matching_utxo, 0);
         let wrong_state = builder.bind_context(&wrong_state).expect("context binds");
         assert!(matches!(
             builder.unsigned_transaction(&wrong_state),
-            Err(BuilderError::ArgentInputScriptMismatch { input_index: 0, actor }) if actor == "Counter"
+            Err(BuilderError::ActorInputScriptMismatch { input_index: 0, actor }) if actor == "Counter"
         ));
     }
 
@@ -1301,9 +1301,9 @@ mod tests {
 
         builder.resolve_context_args(&mut resolved, &unsigned).expect("arguments resolve");
 
-        assert_eq!(resolved_args(&resolved, 0).expect("input 0 is Argent").values, vec![ArtifactValue::Int(3)]);
+        assert_eq!(resolved_args(&resolved, 0).expect("input 0 is an actor").values, vec![ArtifactValue::Int(3)]);
         assert!(resolved_args(&resolved, 1).is_none());
-        assert_eq!(resolved_args(&resolved, 2).expect("input 2 is Argent").values, vec![ArtifactValue::Int(4)]);
+        assert_eq!(resolved_args(&resolved, 2).expect("input 2 is an actor").values, vec![ArtifactValue::Int(4)]);
         assert!(entry_callback_called.get());
         assert!(!ordinary_callback_called.get());
     }
@@ -1338,7 +1338,7 @@ mod tests {
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
 
         builder.resolve_context_args(&mut resolved, &unsigned).expect("arguments resolve");
-        let resolved = resolved_args(&resolved, 0).expect("input is Argent");
+        let resolved = resolved_args(&resolved, 0).expect("input is an actor");
 
         assert_eq!(resolved.values, vec![ArtifactValue::Int(1)]);
         assert_eq!(resolved.template_selectors, BTreeMap::from([("target".to_string(), "Beta".to_string())]));
@@ -1370,7 +1370,7 @@ mod tests {
 
         builder.resolve_context_args(&mut resolved, &unsigned).expect("arguments resolve");
 
-        assert_eq!(resolved_args(&resolved, 0).expect("input is Argent").values, vec![ArtifactValue::Object(state(9))]);
+        assert_eq!(resolved_args(&resolved, 0).expect("input is an actor").values, vec![ArtifactValue::Object(state(9))]);
     }
 
     #[test]

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -11,8 +11,7 @@ use kaspa_consensus_core::{
     subnets::SubnetworkId,
     tx::{CovenantBinding, MutableTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutput},
 };
-use kaspa_txscript::{covenants::CovenantsContext, pay_to_script_hash_script, pay_to_script_hash_signature_script_with_flags};
-use kaspa_txscript_errors::TxScriptError;
+use kaspa_txscript::{pay_to_script_hash_script, pay_to_script_hash_signature_script_with_flags};
 
 use crate::{
     ActorPath, ArgentInput, Artifact, ArtifactValue, BuilderError, BuilderResult, ContextInput, ContextOutput, ContractRef, EntryArgs,
@@ -36,20 +35,41 @@ struct GenesisGroup {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-struct LaunchGroupKey {
-    authorizing_input: u16,
-    name: String,
+enum GenesisGroupName {
+    Launch(String),
+    Spawn(String),
 }
 
-impl LaunchGroupKey {
-    fn parse(authorizing_input: u16, path: &str) -> BuilderResult<Self> {
-        let Some(name) = path.strip_prefix("launch::") else {
-            return Err(BuilderError::InvalidGenesisPath(path.to_string()));
-        };
+impl GenesisGroupName {
+    fn parse(path: &str) -> BuilderResult<Self> {
+        let (namespace, name) = path.split_once("::").ok_or_else(|| BuilderError::InvalidGenesisPath(path.to_string()))?;
         if name.is_empty() || name.contains("::") {
             return Err(BuilderError::InvalidGenesisPath(path.to_string()));
         }
-        Ok(Self { authorizing_input, name: name.to_string() })
+        match namespace {
+            "launch" => Ok(Self::Launch(name.to_string())),
+            "spawn" => Ok(Self::Spawn(name.to_string())),
+            _ => Err(BuilderError::InvalidGenesisPath(path.to_string())),
+        }
+    }
+
+    fn path(&self) -> String {
+        match self {
+            Self::Launch(name) => format!("launch::{name}"),
+            Self::Spawn(name) => format!("spawn::{name}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct GenesisGroupKey {
+    authorizing_input: u16,
+    name: GenesisGroupName,
+}
+
+impl GenesisGroupKey {
+    fn parse(authorizing_input: u16, path: &str) -> BuilderResult<Self> {
+        Ok(Self { authorizing_input, name: GenesisGroupName::parse(path)? })
     }
 }
 
@@ -61,7 +81,7 @@ impl LaunchGroupKey {
 /// hidden witnesses before the final signature scripts are assembled.
 struct ResolveContext<'artifact, 'context, 'args> {
     inputs: Vec<ResolveInput<'artifact, 'context, 'args>>,
-    outputs: Vec<ResolveOutput<'artifact, 'context, 'args>>,
+    outputs: Vec<ResolveOutput<'artifact>>,
     lock_time: u64,
     subnetwork_id: SubnetworkId,
     gas: u64,
@@ -97,15 +117,30 @@ struct ResolvedActor<'artifact> {
     state: BTreeMap<String, ArtifactValue>,
 }
 
-enum ResolveOutputOwner<'artifact, 'context> {
+enum ResolveOutputOwner<'artifact> {
     Actor(ResolvedActor<'artifact>),
-    Spk(&'context ScriptPublicKey),
+    Spk(ScriptPublicKey),
 }
 
-struct ResolveOutput<'artifact, 'context, 'args> {
-    source: &'context ContextOutput<'args>,
-    owner: ResolveOutputOwner<'artifact, 'context>,
-    covenant: Option<CovenantBinding>,
+enum ResolveOutputBinding {
+    Unbound,
+    Existing(CovenantBinding),
+    Genesis { binding: CovenantBinding, group: GenesisGroupName },
+}
+
+impl ResolveOutputBinding {
+    fn covenant(&self) -> Option<CovenantBinding> {
+        match self {
+            Self::Unbound => None,
+            Self::Existing(binding) | Self::Genesis { binding, .. } => Some(*binding),
+        }
+    }
+}
+
+struct ResolveOutput<'artifact> {
+    owner: ResolveOutputOwner<'artifact>,
+    binding: ResolveOutputBinding,
+    value: u64,
 }
 
 impl<'artifact> TxBuilder<'artifact> {
@@ -159,9 +194,9 @@ impl<'artifact> TxBuilder<'artifact> {
             }
         }
 
-        // First output pass: bind actors, validate genesis declarations, and collect their ordered groups.
+        // Output phase 1: bind actors, validate genesis declarations, and collect their ordered groups.
         let mut bound_outputs = Vec::with_capacity(context.outputs.len());
-        let mut launch_groups = BTreeMap::<LaunchGroupKey, GenesisGroup>::new();
+        let mut genesis_groups = BTreeMap::<GenesisGroupKey, GenesisGroup>::new();
         for (output_index, output) in context.outputs.iter().enumerate() {
             if let OutputCovenant::Genesis { authorizing_input, subgroup } = &output.covenant {
                 if let OutputOwner::Actor { actor, state } = &output.owner
@@ -169,8 +204,21 @@ impl<'artifact> TxBuilder<'artifact> {
                 {
                     return Err(BuilderError::GenesisOutputStateCallback { output_index, actor: actor.to_string() });
                 }
-                let launch = LaunchGroupKey::parse(*authorizing_input, subgroup)?;
-                launch_groups.entry(launch).or_default().output_indices.push(output_index);
+                let group = GenesisGroupKey::parse(*authorizing_input, subgroup)?;
+                let authorizer =
+                    inputs.get(usize::from(*authorizing_input)).ok_or(BuilderError::GenesisAuthorizingInputOutOfRange {
+                        authorizing_input: *authorizing_input,
+                        input_count: inputs.len(),
+                    })?;
+                if let GenesisGroupName::Spawn(spawn) = &group.name {
+                    let ResolveInput::Argent(input) = authorizer else {
+                        return Err(BuilderError::SpawnAuthorizingInputNotArgent(*authorizing_input, spawn.clone()));
+                    };
+                    if !input.argent_entry.spawns.iter().any(|declared| declared.name == *spawn) {
+                        return Err(BuilderError::UnknownSpawn(*authorizing_input, spawn.clone()));
+                    }
+                }
+                genesis_groups.entry(group).or_default().output_indices.push(output_index);
             } else if let (OutputOwner::Actor { actor, .. }, OutputCovenant::Unbound) = (&output.owner, &output.covenant) {
                 return Err(BuilderError::UnboundArgentOutput { output_index, actor: actor.to_string() });
             }
@@ -183,12 +231,12 @@ impl<'artifact> TxBuilder<'artifact> {
             bound_outputs.push(BoundOutput { source: output, owner });
         }
 
-        // Derive every genesis covenant ID before any deferred output state is evaluated.
+        // Output phase 2: derive every genesis covenant ID before evaluating deferred states.
         let mut state_context = StateContext::default();
-        for (launch, group) in &launch_groups {
+        for (key, group) in &genesis_groups {
             let authorizing_input =
-                context.inputs.get(usize::from(launch.authorizing_input)).ok_or(BuilderError::GenesisAuthorizingInputOutOfRange {
-                    authorizing_input: launch.authorizing_input,
+                context.inputs.get(usize::from(key.authorizing_input)).ok_or(BuilderError::GenesisAuthorizingInputOutOfRange {
+                    authorizing_input: key.authorizing_input,
                     input_count: context.inputs.len(),
                 })?;
             let outpoint = match authorizing_input {
@@ -202,9 +250,7 @@ impl<'artifact> TxBuilder<'artifact> {
                     let output = &bound_outputs[output_index];
                     let spk = match &output.owner {
                         BoundOutputOwner::Actor { contract, state, .. } => {
-                            let OutputState::Static(state) = state else {
-                                unreachable!("genesis actor output callbacks are rejected while outputs are bound")
-                            };
+                            let OutputState::Static(state) = state else { unreachable!("expected by output phase 1") };
                             pay_to_script_hash_script(&self.redeem_script_for_contract(*contract, state.clone())?)
                         }
                         BoundOutputOwner::Spk(spk) => (*spk).clone(),
@@ -215,20 +261,21 @@ impl<'artifact> TxBuilder<'artifact> {
                 })
                 .collect::<BuilderResult<Vec<_>>>()?;
             let covenant_id = rk_hashing::covenant_id(outpoint, genesis_outputs.iter().map(|(index, output)| (*index, output)));
-            state_context.insert_genesis_covenant_id(launch.authorizing_input, format!("launch::{}", launch.name), covenant_id);
+            state_context.insert_genesis_covenant_id(key.authorizing_input, key.name.path(), covenant_id);
         }
 
-        // Second output pass: attach resolved bindings and evaluate states against the complete genesis context.
+        // Output phase 3: attach resolved bindings and evaluate states against the complete genesis context.
         let mut outputs = Vec::with_capacity(bound_outputs.len());
         for (output_index, output) in bound_outputs.into_iter().enumerate() {
-            let covenant = match &output.source.covenant {
-                OutputCovenant::Existing(binding) => Some(*binding),
-                OutputCovenant::Unbound => None,
+            let binding = match &output.source.covenant {
+                OutputCovenant::Existing(binding) => ResolveOutputBinding::Existing(*binding),
+                OutputCovenant::Unbound => ResolveOutputBinding::Unbound,
                 OutputCovenant::Genesis { authorizing_input, subgroup } => {
-                    let covenant_id = state_context
-                        .genesis_covenant_id(*authorizing_input, subgroup)
-                        .expect("genesis covenant IDs are populated before output states resolve");
-                    Some(CovenantBinding::new(*authorizing_input, covenant_id))
+                    let group = GenesisGroupKey::parse(*authorizing_input, subgroup)?;
+                    let covenant_id =
+                        state_context.genesis_covenant_id(*authorizing_input, subgroup).expect("expected by output phase 2");
+                    let binding = CovenantBinding::new(*authorizing_input, covenant_id);
+                    ResolveOutputBinding::Genesis { binding, group: group.name }
                 }
             };
             let owner = match output.owner {
@@ -240,9 +287,9 @@ impl<'artifact> TxBuilder<'artifact> {
                         source,
                     })?,
                 }),
-                BoundOutputOwner::Spk(script_public_key) => ResolveOutputOwner::Spk(script_public_key),
+                BoundOutputOwner::Spk(spk) => ResolveOutputOwner::Spk(spk.clone()),
             };
-            outputs.push(ResolveOutput { source: output.source, owner, covenant });
+            outputs.push(ResolveOutput { owner, binding, value: output.source.value });
         }
 
         Ok(ResolveContext {
@@ -296,9 +343,9 @@ impl<'artifact> TxBuilder<'artifact> {
                 ResolveOutputOwner::Actor(actor) => {
                     pay_to_script_hash_script(&self.redeem_script_for_contract(actor.contract, actor.state.clone())?)
                 }
-                ResolveOutputOwner::Spk(script_public_key) => (*script_public_key).clone(),
+                ResolveOutputOwner::Spk(script_public_key) => script_public_key.clone(),
             };
-            outputs.push(TransactionOutput::with_covenant(output.source.value, script_public_key, output.covenant));
+            outputs.push(TransactionOutput::with_covenant(output.value, script_public_key, output.binding.covenant()));
         }
 
         let transaction = Transaction::new(
@@ -407,35 +454,31 @@ impl<'artifact> TxBuilder<'artifact> {
         Ok(())
     }
 
-    /// Resolve each declared spawn from the genesis groups authorized by this input.
-    /// Before reporting a missing group, prefer any canonical covenant-binding error.
-    fn resolve_context_spawns(
-        &self,
-        context: &mut ResolveContext<'artifact, '_, '_>,
-        unsigned: &MutableTransaction<Transaction>,
-    ) -> BuilderResult<()> {
+    /// Resolve each declared spawn from its explicitly named genesis group.
+    fn resolve_context_spawns(&self, context: &mut ResolveContext<'artifact, '_, '_>) -> BuilderResult<()> {
         for input_index in 0..context.inputs.len() {
             let ResolveInput::Argent(input) = &context.inputs[input_index] else {
                 continue;
             };
 
-            let input_covenant_id = input.source.utxo.covenant_id.expect("Argent input covenant id checked before spawn resolution");
-            let genesis_groups = collect_genesis_groups(context, unsigned, input_index, input_covenant_id);
             let mut spawned_actors = BTreeMap::new();
-            let mut candidate_groups = genesis_groups.iter();
+            let mut previous_first_output = None;
             for spawn in &input.argent_entry.spawns {
-                let matched = loop {
-                    let Some(group) = candidate_groups.next() else {
-                        // A malformed binding may have hidden the intended group from this input.
-                        let verifiable = unsigned.as_verifiable();
-                        CovenantsContext::from_tx(&verifiable).map_err(TxScriptError::from)?;
-                        return Err(BuilderError::MissingSpawnGroup { spawn: spawn.name.clone() });
-                    };
-                    if let Some(matched) = self.match_spawn_group(context, input, spawn, group)? {
-                        break matched;
-                    }
-                };
-                spawned_actors.extend(matched);
+                let authorizing_input =
+                    u16::try_from(input_index).map_err(|_| BuilderError::GenesisAuthorizingInputIndexOverflow(input_index))?;
+                let key = GenesisGroupKey { authorizing_input, name: GenesisGroupName::Spawn(spawn.name.clone()) };
+                let group = named_genesis_group(context, &key)
+                    .ok_or_else(|| BuilderError::MissingSpawnGroup(input_index, spawn.name.clone()))?;
+                let first_output = group.output_indices[0];
+                if previous_first_output.is_some_and(|previous| previous >= first_output) {
+                    return Err(BuilderError::InvalidSpawnGroup(
+                        spawn.name.clone(),
+                        "spawned genesis subgroups must appear in the input's `spawns` clause order (by first output index)"
+                            .to_string(),
+                    ));
+                }
+                previous_first_output = Some(first_output);
+                spawned_actors.extend(self.resolve_spawn_group(context, input, spawn, &group)?);
             }
 
             let ResolveInput::Argent(input) = &mut context.inputs[input_index] else { unreachable!() };
@@ -444,48 +487,69 @@ impl<'artifact> TxBuilder<'artifact> {
         Ok(())
     }
 
-    /// Test one concrete genesis group against a spawn declaration.
+    /// Validate one explicitly named genesis group against a spawn declaration.
     ///
-    /// A match requires the exact declared output count and, in declaration
+    /// Validation requires the exact declared output count and, in declaration
     /// order, Argent output metadata whose concrete actors expose the declared
     /// `actor_type<State>` handles. State values remain the generated script's
-    /// responsibility. Logical mismatches may be skipped by the caller; invalid
-    /// source values or artifact data are returned as builder errors.
-    fn match_spawn_group(
+    /// responsibility.
+    fn resolve_spawn_group(
         &self,
         context: &ResolveContext<'artifact, '_, '_>,
         input: &ResolveArgentInput<'artifact, '_, '_>,
         spawn: &SpawnArtifact,
         group: &GenesisGroup,
-    ) -> BuilderResult<Option<ResolvedSpawnActors>> {
+    ) -> BuilderResult<ResolvedSpawnActors> {
         if group.output_indices.len() != spawn.outputs.len() {
-            return Ok(None);
+            return Err(BuilderError::InvalidSpawnGroup(
+                spawn.name.clone(),
+                format!("expected {} outputs, found {}", spawn.outputs.len(), group.output_indices.len()),
+            ));
         }
 
         let mut spawned_actors = BTreeMap::new();
         for (output, &output_index) in spawn.outputs.iter().zip(&group.output_indices) {
             let resolved_output = &context.outputs[output_index];
             let ResolveOutputOwner::Actor(actor) = &resolved_output.owner else {
-                return Ok(None);
+                return Err(BuilderError::InvalidSpawnGroup(
+                    spawn.name.clone(),
+                    format!("output `{}` at transaction index {output_index} has no Argent actor metadata", output.name),
+                ));
             };
             let actor_name = &actor.contract.contract.name;
             let expected_handle = spawn_actor_type_handle(input, &output.actor)?;
             let found_handle = match self.actor_type_handle_in_artifact(actor.contract.artifact, actor_name, &output.state) {
                 Ok(handle) => handle,
                 Err(BuilderError::MissingActorTypeHandle { .. }) => {
-                    return Ok(None);
+                    return Err(BuilderError::InvalidSpawnGroup(
+                        spawn.name.clone(),
+                        format!(
+                            "output `{}` actor `{}::{actor_name}` does not expose actor_type<{}>",
+                            output.name,
+                            artifact_app_alias(&actor.contract.artifact.app),
+                            output.state
+                        ),
+                    ));
                 }
                 Err(error) => return Err(error),
             };
             if found_handle != expected_handle {
-                return Ok(None);
+                return Err(BuilderError::InvalidSpawnGroup(
+                    spawn.name.clone(),
+                    format!(
+                        "output `{}` actor `{}::{actor_name}` does not match `{}`",
+                        output.name,
+                        artifact_app_alias(&actor.contract.artifact.app),
+                        output.actor
+                    ),
+                ));
             }
             spawned_actors.insert(
                 (spawn.name.clone(), output.name.clone()),
                 SpawnedActorContext { app: artifact_app_alias(&actor.contract.artifact.app), actor: actor_name.clone(), output_index },
             );
         }
-        Ok(Some(spawned_actors))
+        Ok(spawned_actors)
     }
 
     /// Resolve compiler-generated arguments from artifact-local routes and the
@@ -567,7 +631,7 @@ impl<'artifact> TxBuilder<'artifact> {
         self.validate_leader_actor_input_counts(&context)?;
         self.resolve_context_args(&mut context, &unsigned)?;
         self.resolve_context_observations(&mut context, &unsigned)?;
-        self.resolve_context_spawns(&mut context, &unsigned)?;
+        self.resolve_context_spawns(&mut context)?;
         self.resolve_context_hidden_args(&mut context)?;
         let mut signature_scripts = Vec::with_capacity(context.inputs.len());
 
@@ -617,34 +681,22 @@ impl<'artifact> TxBuilder<'artifact> {
     }
 }
 
-/// Collect genesis groups authorized by one input, following consensus's
-/// `(authorizing input, covenant ID)` grouping. Outputs within a group retain
-/// global transaction order; groups are ordered by their first output.
-/// Explicit `launch::<name>` groups are independent and do not satisfy an AG
-/// `spawns` clause.
-fn collect_genesis_groups(
-    context: &ResolveContext<'_, '_, '_>,
-    unsigned: &MutableTransaction<Transaction>,
-    input_index: usize,
-    input_covenant_id: Hash,
-) -> Vec<GenesisGroup> {
-    let mut groups = BTreeMap::<Hash, GenesisGroup>::new();
-    for (output_index, output) in context.outputs.iter().enumerate() {
-        if matches!(output.source.covenant, OutputCovenant::Genesis { .. }) {
-            continue;
-        }
-        let binding = unsigned.tx.outputs[output_index].covenant;
-        let Some(binding) = binding else {
-            continue;
-        };
-        if usize::from(binding.authorizing_input) != input_index || binding.covenant_id == input_covenant_id {
-            continue;
-        }
-        groups.entry(binding.covenant_id).or_default().output_indices.push(output_index);
-    }
-    let mut groups = groups.into_values().collect::<Vec<_>>();
-    groups.sort_by_key(|group| group.output_indices[0]);
-    groups
+/// Collect one explicitly named genesis group in global output order.
+fn named_genesis_group(context: &ResolveContext<'_, '_, '_>, key: &GenesisGroupKey) -> Option<GenesisGroup> {
+    let output_indices = context
+        .outputs
+        .iter()
+        .enumerate()
+        .filter_map(|(output_index, output)| match &output.binding {
+            ResolveOutputBinding::Genesis { binding, group }
+                if binding.authorizing_input == key.authorizing_input && group == &key.name =>
+            {
+                Some(output_index)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    (!output_indices.is_empty()).then_some(GenesisGroup { output_indices })
 }
 
 /// Resolve a spawn actor expression from the input's source state or user
@@ -798,7 +850,7 @@ fn resolve_observed_output(
     observe: &str,
     declaration: &ObservedActorArtifact,
     index: usize,
-    candidate: &ResolveOutput<'_, '_, '_>,
+    candidate: &ResolveOutput<'_>,
     app: &mut Option<String>,
 ) -> BuilderResult<(String, ObservedOutput)> {
     let ResolveOutputOwner::Actor(actor) = &candidate.owner else {

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -1004,7 +1004,7 @@ mod tests {
         let script_called = Cell::new(false);
 
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Counter",
                 state(2),
                 EntryCall::new("bump").args_with(|_, _| {
@@ -1024,10 +1024,10 @@ mod tests {
                 }),
                 12,
             )
-            .argent_input("asset::Reserve", state(7), "move", outpoint(3), reserve_utxo.clone(), 13)
-            .argent_output("Counter", state(3), CovenantBinding::new(0, counter_id), 900)
+            .actor_input("asset::Reserve", state(7), "move", outpoint(3), reserve_utxo.clone(), 13)
+            .actor_output("Counter", state(3), CovenantBinding::new(0, counter_id), 900)
             .output(ScriptPublicKey::default(), Some(CovenantBinding::new(0, counter_id)), 100)
-            .argent_output("asset::Reserve", state(8), CovenantBinding::new(2, reserve_id), 2_000)
+            .actor_output("asset::Reserve", state(8), CovenantBinding::new(2, reserve_id), 2_000)
             .lock_time(14)
             .lane(SubnetworkId::from_namespace([1, 2, 3, 4]), 15)
             .payload([0xaa, 0xbb]);
@@ -1087,8 +1087,8 @@ mod tests {
         let authorizing_utxo = UtxoEntry::new(1_000, ScriptPublicKey::default(), 0, false, None);
         let context = TxContext::new()
             .input(outpoint(9), authorizing_utxo, Vec::new(), 0)
-            .argent_genesis_output(0, "launch::child", "Counter", state(1), 100)
-            .argent_output(
+            .actor_genesis_output(0, "launch::child", "Counter", state(1), 100)
+            .actor_output(
                 "Counter",
                 state_with(|context| {
                     calls.set(calls.get() + 1);
@@ -1127,9 +1127,9 @@ mod tests {
         let context = TxContext::new()
             .input(outpoint(1), first, Vec::new(), 0)
             .input(outpoint(2), second, Vec::new(), 0)
-            .argent_genesis_output(0, "launch::child", "Counter", state(1), 100)
-            .argent_genesis_output(1, "launch::child", "Counter", state(1), 100)
-            .argent_output(
+            .actor_genesis_output(0, "launch::child", "Counter", state(1), 100)
+            .actor_genesis_output(1, "launch::child", "Counter", state(1), 100)
+            .actor_output(
                 "Counter",
                 state_with(|context| {
                     ids.set(Some((
@@ -1151,7 +1151,7 @@ mod tests {
     fn context_binding_rejects_out_of_range_genesis_authorizing_input() {
         let artifact = artifact("primary", "Counter", "bump");
         let builder = TxBuilder::new(&artifact).expect("artifact builds");
-        let context = TxContext::new().argent_genesis_output(1, "launch::child", "Counter", state(1), 100);
+        let context = TxContext::new().actor_genesis_output(1, "launch::child", "Counter", state(1), 100);
 
         assert!(matches!(
             builder.bind_context(&context),
@@ -1164,7 +1164,7 @@ mod tests {
         let artifact = artifact("primary", "Counter", "bump");
         let builder = TxBuilder::new(&artifact).expect("artifact builds");
         let covenant_id = Hash::from_bytes([0x31; 32]);
-        let fallible = TxContext::new().argent_output(
+        let fallible = TxContext::new().actor_output(
             "Counter",
             try_state_with(|_| -> Result<_, std::io::Error> { Err(std::io::Error::other("state failed")) }),
             CovenantBinding::new(0, covenant_id),
@@ -1210,14 +1210,14 @@ mod tests {
         let mut unbound_utxo = matching_utxo.clone();
         unbound_utxo.covenant_id = None;
 
-        let missing_id = TxContext::new().argent_input("Counter", state(2), "bump", outpoint(1), unbound_utxo, 0);
+        let missing_id = TxContext::new().actor_input("Counter", state(2), "bump", outpoint(1), unbound_utxo, 0);
         let missing_id = builder.bind_context(&missing_id).expect("context binds");
         assert!(matches!(
             builder.unsigned_transaction(&missing_id),
             Err(BuilderError::MissingArgentInputCovenantId { input_index: 0, actor }) if actor == "Counter"
         ));
 
-        let wrong_state = TxContext::new().argent_input("Counter", state(3), "bump", outpoint(1), matching_utxo, 0);
+        let wrong_state = TxContext::new().actor_input("Counter", state(3), "bump", outpoint(1), matching_utxo, 0);
         let wrong_state = builder.bind_context(&wrong_state).expect("context binds");
         assert!(matches!(
             builder.unsigned_transaction(&wrong_state),
@@ -1232,13 +1232,13 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x44; 32]);
         let utxo = builder.covenant_utxo("Counter", state(2), 1_000, 0, false, Some(covenant_id)).expect("counter UTXO builds");
 
-        let unknown_app = TxContext::new().argent_input("missing::Counter", state(2), "bump", outpoint(1), utxo.clone(), 0);
+        let unknown_app = TxContext::new().actor_input("missing::Counter", state(2), "bump", outpoint(1), utxo.clone(), 0);
         assert!(matches!(builder.bind_context(&unknown_app), Err(BuilderError::UnknownAppAlias(app)) if app == "missing"));
 
-        let unknown_actor = TxContext::new().argent_input("Missing", state(2), "bump", outpoint(1), utxo.clone(), 0);
+        let unknown_actor = TxContext::new().actor_input("Missing", state(2), "bump", outpoint(1), utxo.clone(), 0);
         assert!(matches!(builder.bind_context(&unknown_actor), Err(BuilderError::UnknownActor(actor)) if actor == "Missing"));
 
-        let unknown_entry = TxContext::new().argent_input("Counter", state(2), "missing", outpoint(1), utxo, 0);
+        let unknown_entry = TxContext::new().actor_input("Counter", state(2), "missing", outpoint(1), utxo, 0);
         assert!(matches!(
             builder.bind_context(&unknown_entry),
             Err(BuilderError::UnknownEntry { actor, entry }) if actor == "Counter" && entry == "missing"
@@ -1262,7 +1262,7 @@ mod tests {
         let entry_callback_called = Cell::new(false);
         let ordinary_callback_called = Cell::new(false);
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Counter",
                 state(2),
                 EntryCall::new("bump").args(vec![ArgValue::Value(ArtifactValue::Int(3))]),
@@ -1279,7 +1279,7 @@ mod tests {
                 }),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "Counter",
                 state(2),
                 EntryCall::new("bump").args_with(|tx, input_index| {
@@ -1295,7 +1295,7 @@ mod tests {
                 counter_utxo,
                 0,
             )
-            .argent_output("Counter", state(3), CovenantBinding::new(0, covenant_id), 900);
+            .actor_output("Counter", state(3), CovenantBinding::new(0, covenant_id), 900);
         let mut resolved = builder.bind_context(&context).expect("context binds");
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
 
@@ -1326,7 +1326,7 @@ mod tests {
         let builder = TxBuilder::new(&artifact).expect("artifact builds");
         let covenant_id = Hash::from_bytes([0x66; 32]);
         let router_utxo = builder.covenant_utxo("Router", state(2), 1_000, 0, false, Some(covenant_id)).expect("router UTXO builds");
-        let context = TxContext::new().argent_input(
+        let context = TxContext::new().actor_input(
             "Router",
             state(2),
             EntryCall::new("choose").args(vec![actor("Beta")]),
@@ -1357,7 +1357,7 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x76; 32]);
         let counter_utxo =
             builder.covenant_utxo("Counter", state(2), 1_000, 0, false, Some(covenant_id)).expect("counter UTXO builds");
-        let context = TxContext::new().argent_input(
+        let context = TxContext::new().actor_input(
             "Counter",
             state(2),
             EntryCall::new("replace").args(vec![ArgValue::Value(ArtifactValue::Object(state(9)))]),
@@ -1386,7 +1386,7 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x77; 32]);
         let counter_utxo =
             builder.covenant_utxo("Counter", state(2), 1_000, 0, false, Some(covenant_id)).expect("counter UTXO builds");
-        let context = TxContext::new().argent_input("Counter", state(2), "bump", outpoint(1), counter_utxo, 0);
+        let context = TxContext::new().actor_input("Counter", state(2), "bump", outpoint(1), counter_utxo, 0);
         let mut resolved = builder.bind_context(&context).expect("context binds");
         let unsigned = builder.unsigned_transaction(&resolved).expect("context materializes");
 
@@ -1403,7 +1403,7 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x78; 32]);
         let counter_utxo =
             builder.covenant_utxo("Counter", state(2), 1_000, 0, false, Some(covenant_id)).expect("counter UTXO builds");
-        let context = TxContext::new().argent_input(
+        let context = TxContext::new().actor_input(
             "Counter",
             state(2),
             EntryCall::new("bump").try_args_with(|_, _| Err::<Vec<ArgValue>, _>(std::io::Error::other("signer unavailable"))),

--- a/examples/open_icc/README.md
+++ b/examples/open_icc/README.md
@@ -107,16 +107,16 @@ let bundle = ArtifactBundle::new(&core_artifact)?
     .with_app("open_agent", &agent_artifact)?;
 
 let context = TxContext::new()
-    .argent_input("Cell", cell_state, "advance", cell_outpoint, cell_utxo)
-    .argent_input(
+    .actor_input("Cell", cell_state, "advance", cell_outpoint, cell_utxo)
+    .actor_input(
         "open_agent::Forager",
         forager_state,
         EntryCall::new("step").args(args![next_x, next_y, next_energy]),
         agent_outpoint,
         agent_utxo,
     )
-    .argent_output("Cell", next_cell_state, cell_binding, cell_value)
-    .argent_output("open_agent::Forager", next_forager_state, agent_binding, agent_value);
+    .actor_output("Cell", next_cell_state, cell_binding, cell_value)
+    .actor_output("open_agent::Forager", next_forager_state, agent_binding, agent_value);
 
 let tx = TxBuilder::from_bundle(&bundle)?.build(&context)?;
 ```

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -103,7 +103,7 @@ mod tests {
             .covenant_utxo("Ticket", initial_state.clone(), input_value, 0, false, Some(covenant_id))
             .expect("ticket utxo builds");
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Ticket",
                 initial_state.clone(),
                 EntryCall::new("redeem").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), owner_pk.clone()]),
@@ -111,12 +111,12 @@ mod tests {
                 input_utxo.clone(),
                 0,
             )
-            .argent_output("Ticket", redeemed_state, CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Ticket", redeemed_state, CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&context).expect("valid redeem tx passes");
 
         let wrong_pk = keypair_from_byte(2).x_only_public_key().0.serialize().to_vec();
         let bad_args = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Ticket",
                 initial_state.clone(),
                 EntryCall::new("redeem").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), wrong_pk.clone()]),
@@ -124,11 +124,11 @@ mod tests {
                 input_utxo.clone(),
                 0,
             )
-            .argent_output("Ticket", ticket_state(owner_hash.clone(), 7, 1), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Ticket", ticket_state(owner_hash.clone(), 7, 1), CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&bad_args).is_err());
 
         let stale_output = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Ticket",
                 initial_state.clone(),
                 EntryCall::new("redeem").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), owner_pk.clone()]),
@@ -136,7 +136,7 @@ mod tests {
                 input_utxo,
                 0,
             )
-            .argent_output("Ticket", initial_state, CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Ticket", initial_state, CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&stale_output).is_err());
     }
 
@@ -156,7 +156,7 @@ mod tests {
         let input_utxo =
             builder.covenant_utxo("Issuer", source_state.clone(), 1_000, 0, false, Some(covenant_id)).expect("issuer UTXO builds");
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Issuer",
                 source_state.clone(),
                 EntryCall::new("issue")
@@ -165,7 +165,7 @@ mod tests {
                 input_utxo,
                 0,
             )
-            .argent_output(
+            .actor_output(
                 "Issuer",
                 state! {
                     admin: blake2b32(&admin_pk),
@@ -174,7 +174,7 @@ mod tests {
                 CovenantBinding::new(0, covenant_id),
                 1_000,
             )
-            .argent_output("Ticket", ticket_state(blake2b32(&owner_pk), 11, 0), CovenantBinding::new(0, covenant_id), 500);
+            .actor_output("Ticket", ticket_state(blake2b32(&owner_pk), 11, 0), CovenantBinding::new(0, covenant_id), 500);
         let transaction = builder.build(&context).expect("issue transaction builds");
         let redeem_script = p2sh_redeem_script(&transaction.inputs[0].signature_script);
         let state_span = &actor.compiled.state_span;
@@ -193,7 +193,7 @@ mod tests {
         let mut explicit_hidden_state = source_state;
         explicit_hidden_state.insert("gen__ticket_template".to_string(), ArtifactValue::Bytes(vec![0; 32]));
         let explicit_hidden =
-            TxContext::new().argent_output("Issuer", explicit_hidden_state, CovenantBinding::new(0, covenant_id), 1_000);
+            TxContext::new().actor_output("Issuer", explicit_hidden_state, CovenantBinding::new(0, covenant_id), 1_000);
         let err = builder.build(&explicit_hidden).expect_err("hidden runtime state fields must be filled by the runtime");
         assert!(
             matches!(err, BuilderError::HiddenRuntimeFieldProvided { ref field, .. } if field == "gen__ticket_template"),
@@ -229,7 +229,7 @@ mod tests {
             .expect("ReserveAsset UTXO builds");
         let context = TxContext::new()
             .input(TransactionOutpoint::new(TransactionId::from_bytes([0x33; 32]), 0), owner_utxo, Vec::new(), 0)
-            .argent_input(
+            .actor_input(
                 "ReserveAsset",
                 state,
                 EntryCall::new("settle").args(args![100]),
@@ -237,7 +237,7 @@ mod tests {
                 asset_utxo,
                 0,
             )
-            .argent_output("ReserveAsset", next_state, CovenantBinding::new(1, asset_covenant_id), 1_000);
+            .actor_output("ReserveAsset", next_state, CovenantBinding::new(1, asset_covenant_id), 1_000);
         let transaction = builder.build(&context).expect("expanded actor transaction builds");
         let redeem_script = p2sh_redeem_script(&transaction.inputs[1].signature_script);
         let receipt = artifact
@@ -276,7 +276,7 @@ mod tests {
         let covenant_id = Hash::from_bytes([0x41; 32]);
         let input_utxo =
             builder.covenant_utxo("Ticket", source_state.clone(), 1_000, 0, false, Some(covenant_id)).expect("ticket UTXO builds");
-        let context = TxContext::new().argent_input(
+        let context = TxContext::new().actor_input(
             "Ticket",
             source_state,
             EntryCall::new("redeem").args(args![vec![1; 65], owner_pk, vec![2; 32], vec![3; 32]]),
@@ -329,7 +329,7 @@ mod tests {
             builder.covenant_utxo("Counter", initial.clone(), input_value, 0, false, Some(covenant_id)).expect("counter UTXO builds");
 
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Counter",
                 initial.clone(),
                 EntryCall::new("bump").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), 3]),
@@ -337,7 +337,7 @@ mod tests {
                 input_utxo.clone(),
                 0,
             )
-            .argent_output("Counter", next, CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Counter", next, CovenantBinding::new(0, covenant_id), input_value);
         let transaction = builder.build(&context).expect("context builds");
 
         assert_eq!(transaction.inputs.len(), 1);
@@ -348,7 +348,7 @@ mod tests {
         assert_eq!(transaction.outputs[0].covenant, Some(CovenantBinding { authorizing_input: 0, covenant_id }));
 
         let wrong_state = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Counter",
                 initial.clone(),
                 EntryCall::new("bump").args_with(|tx, input_idx| args![sign_mutable_input(tx, input_idx, &owner), 3]),
@@ -356,7 +356,7 @@ mod tests {
                 input_utxo,
                 0,
             )
-            .argent_output("Counter", initial, CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Counter", initial, CovenantBinding::new(0, covenant_id), input_value);
         let err = builder.build(&wrong_state).expect_err("incorrect expected state must fail contract execution");
         assert!(matches!(err, BuilderError::InputScript { input_index: 0, .. }), "unexpected error: {err}");
     }
@@ -410,7 +410,7 @@ mod tests {
         let entries = vec![left_utxo.clone(), right_utxo.clone()];
 
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Left",
                 left_initial,
                 EntryCall::new("shift").args(args![3]),
@@ -418,7 +418,7 @@ mod tests {
                 left_utxo,
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "Right",
                 right_initial,
                 "accept_shift",
@@ -426,8 +426,8 @@ mod tests {
                 right_utxo,
                 0,
             )
-            .argent_output("Left", state! { units: 7 }, CovenantBinding::new(0, covenant_id), 3_000)
-            .argent_output("Right", state! { units: 4 }, CovenantBinding::new(0, covenant_id), 2_000);
+            .actor_output("Left", state! { units: 7 }, CovenantBinding::new(0, covenant_id), 3_000)
+            .actor_output("Right", state! { units: 4 }, CovenantBinding::new(0, covenant_id), 2_000);
         let transaction = builder.build(&context).expect("paired transition builds");
 
         assert_eq!(transaction.inputs.len(), 2);
@@ -479,7 +479,7 @@ mod tests {
             .expect("badge UTXO builds");
 
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Controller",
                 controller_initial.clone(),
                 EntryCall::new("mint").args(args![asset_covenant_id, 7]),
@@ -487,7 +487,7 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "badge_asset::Badge",
                 badge_initial.clone(),
                 EntryCall::new("apply").args_with(|tx, input_idx| args![17, sign_mutable_input(tx, input_idx, &badge_owner)]),
@@ -495,8 +495,8 @@ mod tests {
                 badge_utxo.clone(),
                 0,
             )
-            .argent_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
-            .argent_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
+            .actor_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
+            .actor_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
         let context_tx = builder.build(&context).expect("context resolves the closed observed covenant");
         assert_eq!(context_tx.inputs.len(), 2);
         assert_eq!(context_tx.outputs.len(), 2);
@@ -505,7 +505,7 @@ mod tests {
         assert!(context_tx.inputs.iter().all(|input| input.compute_commit.compute_budget().is_some()));
 
         let extra_output = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Controller",
                 controller_initial.clone(),
                 EntryCall::new("mint").args(args![asset_covenant_id, 7]),
@@ -513,7 +513,7 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "badge_asset::Badge",
                 badge_initial.clone(),
                 EntryCall::new("apply").args(args![17, vec![0; 65]]),
@@ -521,9 +521,9 @@ mod tests {
                 badge_utxo.clone(),
                 0,
             )
-            .argent_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
-            .argent_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000)
-            .argent_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
+            .actor_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
+            .actor_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000)
+            .actor_output("badge_asset::Badge", badge_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
         let err = builder.build(&extra_output).expect_err("observed covenant output cardinality must be exact");
         assert!(
             matches!(
@@ -539,7 +539,7 @@ mod tests {
             .expect("ordinary output can reproduce the Badge script")
             .script_public_key;
         let missing_metadata = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Controller",
                 controller_initial,
                 EntryCall::new("mint").args(args![asset_covenant_id, 7]),
@@ -547,7 +547,7 @@ mod tests {
                 controller_utxo,
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "badge_asset::Badge",
                 badge_initial,
                 EntryCall::new("apply").args(args![17, vec![0; 65]]),
@@ -555,7 +555,7 @@ mod tests {
                 badge_utxo,
                 0,
             )
-            .argent_output("Controller", controller_next, CovenantBinding::new(0, controller_covenant_id), 4_000)
+            .actor_output("Controller", controller_next, CovenantBinding::new(0, controller_covenant_id), 4_000)
             .output(ordinary_badge_script, Some(CovenantBinding::new(1, asset_covenant_id)), 2_000);
         let err = builder.build(&missing_metadata).expect_err("observed outputs must retain Argent metadata");
         assert!(
@@ -585,10 +585,10 @@ mod tests {
         let genesis_spk = ScriptPublicKey::new(0, vec![OpTrue].into());
         let context = TxContext::new()
             .input(funding_outpoint, funding_utxo, Vec::new(), 0)
-            .argent_genesis_output(0, "launch::pair", "Pair", state! { value: 7 }, 2_000)
+            .actor_genesis_output(0, "launch::pair", "Pair", state! { value: 7 }, 2_000)
             .output(unrelated_spk, None, 1_000)
             .genesis_output(0, "launch::pair", genesis_spk.clone(), 500)
-            .argent_genesis_output(0, "launch::pair", "Pair", state! { value: 8 }, 2_000)
+            .actor_genesis_output(0, "launch::pair", "Pair", state! { value: 8 }, 2_000)
             .genesis_output(0, "launch::other", genesis_spk, 500);
 
         let transaction = builder.build(&context).expect("ordinary input launches both named covenant groups");
@@ -612,7 +612,7 @@ mod tests {
                 Vec::new(),
                 0,
             )
-            .argent_genesis_output(0, "pair", "Pair", state! { value: 7 }, 2_000);
+            .actor_genesis_output(0, "pair", "Pair", state! { value: 7 }, 2_000);
         let err = builder.build(&invalid_path).expect_err("genesis paths require the launch namespace");
         assert!(matches!(err, BuilderError::InvalidGenesisPath(ref path) if path == "pair"), "unexpected error: {err}");
 
@@ -623,7 +623,7 @@ mod tests {
                 Vec::new(),
                 0,
             )
-            .argent_genesis_output(1, "launch::pair", "Pair", state! { value: 7 }, 2_000);
+            .actor_genesis_output(1, "launch::pair", "Pair", state! { value: 7 }, 2_000);
         let err = builder.build(&missing_input).expect_err("launch paths must name an existing authorizing input");
         assert!(
             matches!(err, BuilderError::GenesisAuthorizingInputOutOfRange { authorizing_input: 1, input_count: 1 }),
@@ -662,7 +662,7 @@ mod tests {
         let callback_pair_id = Cell::new(None);
         let unrelated_spk = ScriptPublicKey::new(0, vec![OpTrue].into());
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 controller_state,
                 EntryCall::new("launch").args(args![42, 43]),
@@ -670,7 +670,7 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_output(
+            .actor_output(
                 "controller_app::Controller",
                 state_with(|state_context| {
                     callback_pair_id.set(state_context.genesis_covenant_id(0, "spawn::new_pair"));
@@ -679,9 +679,9 @@ mod tests {
                 CovenantBinding::new(0, controller_id),
                 5_000,
             )
-            .argent_genesis_output(0, "spawn::new_pair", "pair_app::Pair", left_pair_state.clone(), 2_000)
+            .actor_genesis_output(0, "spawn::new_pair", "pair_app::Pair", left_pair_state.clone(), 2_000)
             .output(unrelated_spk.clone(), None, 1_000)
-            .argent_genesis_output(0, "spawn::new_pair", "pair_app::Pair", right_pair_state.clone(), 2_000);
+            .actor_genesis_output(0, "spawn::new_pair", "pair_app::Pair", right_pair_state.clone(), 2_000);
         let transaction = builder.build(&context).expect("explicit spawn group executes");
         let pair_id = transaction.outputs[1].covenant.expect("spawn output has a covenant binding").covenant_id;
         let expected_pair_id =
@@ -691,7 +691,7 @@ mod tests {
         assert_eq!(callback_pair_id.get(), Some(pair_id));
 
         let unknown_spawn = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 },
                 EntryCall::new("launch").args(args![42, 43]),
@@ -699,15 +699,15 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_genesis_output(0, "spawn::other", "pair_app::Pair", left_pair_state.clone(), 2_000)
+            .actor_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
+            .actor_genesis_output(0, "spawn::other", "pair_app::Pair", left_pair_state.clone(), 2_000)
             .output(unrelated_spk, None, 1_000)
-            .argent_genesis_output(0, "spawn::other", "pair_app::Pair", right_pair_state.clone(), 2_000);
+            .actor_genesis_output(0, "spawn::other", "pair_app::Pair", right_pair_state.clone(), 2_000);
         let err = builder.build(&unknown_spawn).expect_err("spawn paths must name a clause on the selected entry");
         assert!(matches!(err, BuilderError::UnknownSpawn(0, ref spawn) if spawn == "other"), "unexpected error: {err}");
 
         let incomplete_spawn = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 },
                 EntryCall::new("launch").args(args![42, 43]),
@@ -715,13 +715,13 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_genesis_output(0, "spawn::new_pair", "pair_app::Pair", left_pair_state.clone(), 2_000);
+            .actor_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
+            .actor_genesis_output(0, "spawn::new_pair", "pair_app::Pair", left_pair_state.clone(), 2_000);
         let err = builder.build(&incomplete_spawn).expect_err("spawn groups must contain every declared output");
         assert!(matches!(err, BuilderError::InvalidSpawnGroup(ref spawn, _) if spawn == "new_pair"), "unexpected error: {err}");
 
         let missing_spawn = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 },
                 EntryCall::new("launch").args(args![42, 43]),
@@ -729,13 +729,13 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000);
+            .actor_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000);
         let err = builder.build(&missing_spawn).expect_err("every spawn clause requires an explicit named genesis group");
         assert!(matches!(err, BuilderError::MissingSpawnGroup(0, ref spawn) if spawn == "new_pair"), "unexpected error: {err}");
 
         let wrong_actor_state = state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 };
         let wrong_actor = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 wrong_actor_state.clone(),
                 EntryCall::new("launch").args(args![42, 43]),
@@ -743,15 +743,15 @@ mod tests {
                 controller_utxo,
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_genesis_output(0, "spawn::new_pair", "controller_app::Controller", wrong_actor_state.clone(), 2_000)
-            .argent_genesis_output(0, "spawn::new_pair", "controller_app::Controller", wrong_actor_state, 2_000);
+            .actor_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
+            .actor_genesis_output(0, "spawn::new_pair", "controller_app::Controller", wrong_actor_state.clone(), 2_000)
+            .actor_genesis_output(0, "spawn::new_pair", "controller_app::Controller", wrong_actor_state, 2_000);
         let err = builder.build(&wrong_actor).expect_err("spawn output actors must match the declared actor type");
         assert!(matches!(err, BuilderError::InvalidSpawnGroup(ref spawn, _) if spawn == "new_pair"), "unexpected error: {err}");
 
         let funding_outpoint = TransactionOutpoint::new(TransactionId::from_bytes([0x24; 32]), 1);
         let funding_utxo = UtxoEntry::new(2_000, ScriptPublicKey::new(0, vec![OpTrue].into()), 0, false, None);
-        let ordinary_spawn = TxContext::new().input(funding_outpoint, funding_utxo, Vec::new(), 0).argent_genesis_output(
+        let ordinary_spawn = TxContext::new().input(funding_outpoint, funding_utxo, Vec::new(), 0).actor_genesis_output(
             0,
             "spawn::new_pair",
             "pair_app::Pair",
@@ -794,7 +794,7 @@ mod tests {
         // The first group occupies global outputs 1 and 3, while the second
         // occupies output 2. Group identity, not adjacency, keeps each spawn together.
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 controller_state.clone(),
                 EntryCall::new("launch").args(args![11, 12, 21, 11, 12]),
@@ -802,12 +802,12 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state.clone(), 2_000)
-            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state.clone(), 3_000)
-            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state.clone(), 2_000)
-            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_left_state.clone(), 2_000)
-            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_right_state.clone(), 2_000);
+            .actor_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
+            .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state.clone(), 2_000)
+            .actor_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state.clone(), 3_000)
+            .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state.clone(), 2_000)
+            .actor_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_left_state.clone(), 2_000)
+            .actor_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_right_state.clone(), 2_000);
         let transaction = builder.build(&context).expect("explicit interleaved genesis groups resolve by clause name");
 
         // Security regressions: bypass spawn resolution and invoke the generated Sil directly. The first and third clauses
@@ -880,7 +880,7 @@ mod tests {
         );
 
         let reversed_groups = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 controller_state.clone(),
                 EntryCall::new("launch").args(args![11, 12, 21, 11, 12]),
@@ -888,10 +888,10 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state.clone(), 3_000)
-            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state.clone(), 2_000)
-            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state.clone(), 2_000);
+            .actor_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
+            .actor_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state.clone(), 3_000)
+            .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state.clone(), 2_000)
+            .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state.clone(), 2_000);
         let err = builder.build(&reversed_groups).expect_err("spawn groups must remain in declaration order");
         assert!(
             matches!(
@@ -902,7 +902,7 @@ mod tests {
         );
 
         let missing_metadata = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 controller_state,
                 EntryCall::new("launch").args(args![11, 12, 21, 11, 12]),
@@ -910,10 +910,10 @@ mod tests {
                 controller_utxo,
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state, CovenantBinding::new(0, controller_id), 5_000)
-            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state, 2_000)
+            .actor_output("controller_app::Controller", next_controller_state, CovenantBinding::new(0, controller_id), 5_000)
+            .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state, 2_000)
             .genesis_output(0, "spawn::first_pair", ScriptPublicKey::new(0, vec![OpTrue].into()), 2_000)
-            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state, 3_000);
+            .actor_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state, 3_000);
         let err = builder.build(&missing_metadata).expect_err("spawn outputs must retain Argent actor metadata");
         assert!(
             matches!(
@@ -955,7 +955,7 @@ mod tests {
         // groups. Spawn resolution uses the explicit clause names, while each
         // launch remains a separate consensus-valid genesis group.
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "controller_app::Controller",
                 controller_state.clone(),
                 EntryCall::new("launch").args(args![11, 12, 21, 31, 32]),
@@ -963,15 +963,15 @@ mod tests {
                 controller_utxo,
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state, CovenantBinding::new(0, controller_id), 5_000)
-            .argent_genesis_output(0, "launch::extra", "controller_app::Controller", controller_state.clone(), 100)
-            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state, 2_000)
-            .argent_genesis_output(0, "launch::extra", "controller_app::Controller", controller_state, 200)
+            .actor_output("controller_app::Controller", next_controller_state, CovenantBinding::new(0, controller_id), 5_000)
+            .actor_genesis_output(0, "launch::extra", "controller_app::Controller", controller_state.clone(), 100)
+            .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state, 2_000)
+            .actor_genesis_output(0, "launch::extra", "controller_app::Controller", controller_state, 200)
             .genesis_output(0, "launch::middle", unrelated_spk, 300)
-            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state, 2_000)
-            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state, 3_000)
-            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_left_state, 2_000)
-            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_right_state, 2_000);
+            .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state, 2_000)
+            .actor_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state, 3_000)
+            .actor_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_left_state, 2_000)
+            .actor_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_right_state, 2_000);
 
         builder.build(&context).expect("independent launch groups do not participate in explicit spawn resolution");
     }
@@ -1007,7 +1007,7 @@ mod tests {
         let asset_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x77; 32]), index: 0 };
 
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Controller",
                 controller_initial.clone(),
                 EntryCall::new("swap").args(args![asset_covenant_id, next_owner_pk.clone()]),
@@ -1015,7 +1015,7 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "asset_app::Asset",
                 asset_initial.clone(),
                 EntryCall::new("transfer")
@@ -1024,8 +1024,8 @@ mod tests {
                 asset_utxo.clone(),
                 0,
             )
-            .argent_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
-            .argent_output("asset_app::Asset", asset_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
+            .actor_output("Controller", controller_next.clone(), CovenantBinding::new(0, controller_covenant_id), 4_000)
+            .actor_output("asset_app::Asset", asset_next.clone(), CovenantBinding::new(1, asset_covenant_id), 2_000);
         let transaction = builder.build(&context).expect("signed observed co-spend builds");
 
         assert_eq!(transaction.inputs.len(), 2);
@@ -1033,7 +1033,7 @@ mod tests {
         assert_eq!(transaction.outputs[1].covenant.unwrap().authorizing_input, 1);
 
         let invalid_signature = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Controller",
                 controller_initial,
                 EntryCall::new("swap").args(args![asset_covenant_id, next_owner_pk.clone()]),
@@ -1041,7 +1041,7 @@ mod tests {
                 controller_utxo,
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "asset_app::Asset",
                 asset_initial,
                 EntryCall::new("transfer").args(args![next_owner_pk.clone(), vec![0; 65]]),
@@ -1049,8 +1049,8 @@ mod tests {
                 asset_utxo,
                 0,
             )
-            .argent_output("Controller", controller_next, CovenantBinding::new(0, controller_covenant_id), 4_000)
-            .argent_output("asset_app::Asset", asset_next, CovenantBinding::new(1, asset_covenant_id), 2_000);
+            .actor_output("Controller", controller_next, CovenantBinding::new(0, controller_covenant_id), 4_000)
+            .actor_output("asset_app::Asset", asset_next, CovenantBinding::new(1, asset_covenant_id), 2_000);
         let err = builder.build(&invalid_signature).expect_err("invalid observed co-spend signature must fail");
         assert!(matches!(err, BuilderError::InputScript { input_index: 1, .. }), "unexpected error: {err}");
     }
@@ -1132,8 +1132,8 @@ mod tests {
         let entries = vec![player_a_utxo.clone(), player_b_utxo.clone()];
 
         let undeclared_delegate = TxContext::new()
-            .argent_input("Player", initial_a.clone(), EntryCall::new("retire"), outpoint_a, player_a_utxo.clone(), 0)
-            .argent_input("Player", initial_b.clone(), EntryCall::new("accept_start"), outpoint_b, player_b_utxo.clone(), 0);
+            .actor_input("Player", initial_a.clone(), EntryCall::new("retire"), outpoint_a, player_a_utxo.clone(), 0)
+            .actor_input("Player", initial_b.clone(), EntryCall::new("accept_start"), outpoint_b, player_b_utxo.clone(), 0);
         let err = builder.build(&undeclared_delegate).expect_err("standalone leader entry must reject an undeclared delegate");
         assert!(
             matches!(
@@ -1150,7 +1150,7 @@ mod tests {
         );
 
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Player",
                 initial_a.clone(),
                 EntryCall::new("start_game")
@@ -1159,7 +1159,7 @@ mod tests {
                 player_a_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "Player",
                 initial_b.clone(),
                 EntryCall::new("accept_start")
@@ -1168,9 +1168,9 @@ mod tests {
                 player_b_utxo.clone(),
                 0,
             )
-            .argent_output("Player", next_a.clone(), CovenantBinding::new(0, covenant_id), input_a_value)
-            .argent_output("Player", next_b.clone(), CovenantBinding::new(0, covenant_id), input_b_value)
-            .argent_output("StonesGame", next_game.clone(), CovenantBinding::new(0, covenant_id), game_value);
+            .actor_output("Player", next_a.clone(), CovenantBinding::new(0, covenant_id), input_a_value)
+            .actor_output("Player", next_b.clone(), CovenantBinding::new(0, covenant_id), input_b_value)
+            .actor_output("StonesGame", next_game.clone(), CovenantBinding::new(0, covenant_id), game_value);
         let tx = builder.build(&context).expect("leader and delegate inputs pass");
 
         let player_contract = artifact.sil_abi.contract("Player").expect("Player contract exists");
@@ -1208,7 +1208,7 @@ mod tests {
         );
 
         let swapped_outputs = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Player",
                 initial_a.clone(),
                 EntryCall::new("start_game")
@@ -1217,7 +1217,7 @@ mod tests {
                 player_a_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "Player",
                 initial_b.clone(),
                 EntryCall::new("accept_start")
@@ -1226,16 +1226,16 @@ mod tests {
                 player_b_utxo,
                 0,
             )
-            .argent_output("Player", next_b, CovenantBinding::new(0, covenant_id), input_b_value)
-            .argent_output("Player", next_a, CovenantBinding::new(0, covenant_id), input_a_value)
-            .argent_output("StonesGame", next_game.clone(), CovenantBinding::new(0, covenant_id), game_value);
+            .actor_output("Player", next_b, CovenantBinding::new(0, covenant_id), input_b_value)
+            .actor_output("Player", next_a, CovenantBinding::new(0, covenant_id), input_a_value)
+            .actor_output("StonesGame", next_game.clone(), CovenantBinding::new(0, covenant_id), game_value);
         assert!(builder.build(&swapped_outputs).is_err());
 
         let wrong_peer = builder
             .covenant_utxo("League", league_state(vec![0; 32], 7, 3), input_b_value, 0, false, Some(covenant_id))
             .expect("wrong-template peer utxo builds");
         let wrong_peer = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Player",
                 initial_a,
                 EntryCall::new("start_game")
@@ -1245,19 +1245,19 @@ mod tests {
                 0,
             )
             .input(outpoint_b, wrong_peer, Vec::new(), 0)
-            .argent_output(
+            .actor_output(
                 "Player",
                 player_state(owner_a_hash, player_a_id, 1, 0, 0, 0),
                 CovenantBinding::new(0, covenant_id),
                 input_a_value,
             )
-            .argent_output(
+            .actor_output(
                 "Player",
                 player_state(owner_b_hash, player_b_id, 1, 0, 0, 0),
                 CovenantBinding::new(0, covenant_id),
                 input_b_value,
             )
-            .argent_output("StonesGame", next_game, CovenantBinding::new(0, covenant_id), game_value);
+            .actor_output("StonesGame", next_game, CovenantBinding::new(0, covenant_id), game_value);
         assert!(builder.build(&wrong_peer).is_err());
     }
 
@@ -1275,8 +1275,8 @@ mod tests {
             .covenant_utxo("Player", player_initial.clone(), input_value, 0, false, Some(covenant_id))
             .expect("Player utxo builds");
         let enter_mux = TxContext::new()
-            .argent_input("Player", player_initial.clone(), "enter_mux", player_outpoint, player_utxo.clone(), 0)
-            .argent_output("Mux", mux_initial.clone(), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_input("Player", player_initial.clone(), "enter_mux", player_outpoint, player_utxo.clone(), 0)
+            .actor_output("Mux", mux_initial.clone(), CovenantBinding::new(0, covenant_id), input_value);
         let enter_mux_tx = builder.build(&enter_mux).expect("Player can enter the mux family");
 
         let player_contract = artifact.sil_abi.contract("Player").expect("Player contract exists");
@@ -1313,13 +1313,13 @@ mod tests {
         let mux_utxo =
             builder.covenant_utxo("Mux", mux_initial.clone(), input_value, 0, false, Some(covenant_id)).expect("Mux utxo builds");
         let choose_pawn = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), "choose_pawn", mux_outpoint, mux_utxo.clone(), 0)
-            .argent_output("Pawn", pawn_next.clone(), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_input("Mux", mux_initial.clone(), "choose_pawn", mux_outpoint, mux_utxo.clone(), 0)
+            .actor_output("Pawn", pawn_next.clone(), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&choose_pawn).expect("Mux can route to Pawn by table slice");
 
         let dynamic_pawn_next = board_state(7, 1);
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Mux",
                 mux_initial.clone(),
                 EntryCall::new("choose").args(args![actor("Pawn")]),
@@ -1327,12 +1327,12 @@ mod tests {
                 mux_utxo.clone(),
                 0,
             )
-            .argent_output("Pawn", dynamic_pawn_next.clone(), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Pawn", dynamic_pawn_next.clone(), CovenantBinding::new(0, covenant_id), input_value);
         let context_tx = builder.build(&context).expect("context builder resolves the dynamic route witnesses");
         assert!(context_tx.inputs[0].compute_commit.compute_budget().is_some());
 
         let dynamic_knight = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Mux",
                 mux_initial.clone(),
                 EntryCall::new("choose").args(args![actor("Knight")]),
@@ -1340,12 +1340,12 @@ mod tests {
                 mux_utxo.clone(),
                 0,
             )
-            .argent_output("Knight", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Knight", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&dynamic_knight).expect("Mux selector can choose the second table entry");
 
         let missing_selector = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), EntryCall::new("choose").args(args![0]), mux_outpoint, mux_utxo.clone(), 0)
-            .argent_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_input("Mux", mux_initial.clone(), EntryCall::new("choose").args(args![0]), mux_outpoint, mux_utxo.clone(), 0)
+            .actor_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         let missing_selector = builder.build(&missing_selector).expect_err("selector entries require an explicit template choice");
         assert!(
             matches!(missing_selector, BuilderError::MissingTemplateSelectorChoice { ref selector } if selector == "target"),
@@ -1353,7 +1353,7 @@ mod tests {
         );
 
         let invalid_selector = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Mux",
                 mux_initial.clone(),
                 EntryCall::new("choose").args(args![actor("League")]),
@@ -1361,7 +1361,7 @@ mod tests {
                 mux_utxo.clone(),
                 0,
             )
-            .argent_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         let invalid_selector = builder.build(&invalid_selector).expect_err("selector must choose one of the actor enum variants");
         assert!(
             matches!(
@@ -1373,7 +1373,7 @@ mod tests {
         );
 
         let wrong_selector = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Mux",
                 mux_initial.clone(),
                 EntryCall::new("choose").args(args![actor("Knight")]),
@@ -1381,20 +1381,20 @@ mod tests {
                 mux_utxo.clone(),
                 0,
             )
-            .argent_output("Pawn", dynamic_pawn_next, CovenantBinding::new(0, covenant_id), input_value);
+            .actor_output("Pawn", dynamic_pawn_next, CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&wrong_selector).is_err(), "selector witness must match the actor selected by table index");
 
         let const_knight = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone(), 0)
-            .argent_output("Knight", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone(), 0)
+            .actor_output("Knight", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&const_knight).expect("fixed actor enum selector can route to Knight without caller selector metadata");
 
         let const_wrong_output = TxContext::new()
-            .argent_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone(), 0)
-            .argent_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_input("Mux", mux_initial.clone(), "choose_knight_const", mux_outpoint, mux_utxo.clone(), 0)
+            .actor_output("Pawn", board_state(7, 1), CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&const_wrong_output).is_err(), "fixed actor enum selector must reject a non-Knight output");
 
-        let wrong_worker = TxContext::new().argent_input("Mux", mux_initial, "choose_pawn", mux_outpoint, mux_utxo, 0).argent_output(
+        let wrong_worker = TxContext::new().actor_input("Mux", mux_initial, "choose_pawn", mux_outpoint, mux_utxo, 0).actor_output(
             "Knight",
             pawn_next,
             CovenantBinding::new(0, covenant_id),
@@ -1530,13 +1530,13 @@ mod tests {
         let input_utxo =
             builder.covenant_utxo("Foo", initial.clone(), input_value, 0, false, Some(covenant_id)).expect("foo utxo builds");
         let context = TxContext::new()
-            .argent_input("Foo", initial.clone(), EntryCall::new("bump").args(args![5]), outpoint, input_utxo.clone(), 0)
-            .argent_output("Foo", next.clone(), CovenantBinding::new(0, covenant_id), input_value);
+            .actor_input("Foo", initial.clone(), EntryCall::new("bump").args(args![5]), outpoint, input_utxo.clone(), 0)
+            .actor_output("Foo", next.clone(), CovenantBinding::new(0, covenant_id), input_value);
         builder.build(&context).expect("same-template transition passes");
 
         let wrong_template = TxContext::new()
-            .argent_input("Foo", initial, EntryCall::new("bump").args(args![5]), outpoint, input_utxo, 0)
-            .argent_output("Bar", next, CovenantBinding::new(0, covenant_id), input_value);
+            .actor_input("Foo", initial, EntryCall::new("bump").args(args![5]), outpoint, input_utxo, 0)
+            .actor_output("Bar", next, CovenantBinding::new(0, covenant_id), input_value);
         assert!(builder.build(&wrong_template).is_err(), "same-template validation must reject a different actor template");
     }
 
@@ -1566,7 +1566,7 @@ mod tests {
             .covenant_utxo("League", league_initial.clone(), input_value, 0, false, Some(covenant_id))
             .expect("league utxo builds");
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "League",
                 league_initial.clone(),
                 EntryCall::new("register_player")
@@ -1575,8 +1575,8 @@ mod tests {
                 league_utxo.clone(),
                 0,
             )
-            .argent_output("League", league_initial.clone(), CovenantBinding::new(0, covenant_id), input_value)
-            .argent_output("Player", player_next.clone(), CovenantBinding::new(0, covenant_id), player_value);
+            .actor_output("League", league_initial.clone(), CovenantBinding::new(0, covenant_id), input_value)
+            .actor_output("Player", player_next.clone(), CovenantBinding::new(0, covenant_id), player_value);
         let tx = builder.build(&context).expect("exact continuation register_player passes");
 
         let player_template = &artifact.sil_abi.contract("Player").expect("Player contract exists").compiled.template;
@@ -1615,7 +1615,7 @@ mod tests {
 
         let changed_league_state = league_state(vec![0x56; 32], 7, 3);
         let changed_continuation = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "League",
                 league_initial,
                 EntryCall::new("register_player")
@@ -1624,8 +1624,8 @@ mod tests {
                 league_utxo,
                 0,
             )
-            .argent_output("League", changed_league_state, CovenantBinding::new(0, covenant_id), input_value)
-            .argent_output("Player", player_next, CovenantBinding::new(0, covenant_id), player_value);
+            .actor_output("League", changed_league_state, CovenantBinding::new(0, covenant_id), input_value)
+            .actor_output("Player", player_next, CovenantBinding::new(0, covenant_id), player_value);
         assert!(builder.build(&changed_continuation).is_err(), "exact continuation must reject a changed League state");
     }
 
@@ -1658,7 +1658,7 @@ mod tests {
 
         let mut explicit_observed_template_state = minter_initial.clone();
         explicit_observed_template_state.insert("gen__asset_kcc20_template".to_string(), ArtifactValue::Bytes(vec![0; 32]));
-        let explicit_hidden_state = TxContext::new().argent_output(
+        let explicit_hidden_state = TxContext::new().actor_output(
             "Minter",
             explicit_observed_template_state,
             CovenantBinding::new(0, controller_covenant_id),
@@ -1679,7 +1679,7 @@ mod tests {
             .expect("proxy utxo builds");
         let entries = vec![minter_utxo.clone(), proxy_utxo.clone()];
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Minter",
                 minter_initial.clone(),
                 EntryCall::new("mint").args_with(|tx, input_idx| {
@@ -1689,7 +1689,7 @@ mod tests {
                 minter_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "kcc20_asset::MinterProxy",
                 proxy_state.clone(),
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
@@ -1697,9 +1697,9 @@ mod tests {
                 proxy_utxo.clone(),
                 0,
             )
-            .argent_output("Minter", minter_next.clone(), CovenantBinding::new(0, controller_covenant_id), minter_value)
-            .argent_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
-            .argent_output("kcc20_asset::KCC20", recipient_state.clone(), CovenantBinding::new(1, asset_covenant_id), recipient_value);
+            .actor_output("Minter", minter_next.clone(), CovenantBinding::new(0, controller_covenant_id), minter_value)
+            .actor_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
+            .actor_output("kcc20_asset::KCC20", recipient_state.clone(), CovenantBinding::new(1, asset_covenant_id), recipient_value);
         let tx = builder.build(&context).expect("observed ICC mint passes");
 
         let minter_contract = controller_artifact.sil_abi.contract("Minter").expect("Minter contract exists");
@@ -1739,7 +1739,7 @@ mod tests {
         assert!(execute_input_with_covenants(&corrupt_hidden_tx, entries.clone(), 0).is_err());
 
         let missing_proxy = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Minter",
                 minter_initial.clone(),
                 EntryCall::new("mint").args(args![vec![0; 65], recipient_owner.clone(), minted_amount]),
@@ -1747,15 +1747,15 @@ mod tests {
                 minter_utxo.clone(),
                 0,
             )
-            .argent_output("Minter", minter_next.clone(), CovenantBinding::new(0, controller_covenant_id), minter_value)
-            .argent_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
-            .argent_output("kcc20_asset::KCC20", recipient_state.clone(), CovenantBinding::new(1, asset_covenant_id), recipient_value);
+            .actor_output("Minter", minter_next.clone(), CovenantBinding::new(0, controller_covenant_id), minter_value)
+            .actor_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
+            .actor_output("kcc20_asset::KCC20", recipient_state.clone(), CovenantBinding::new(1, asset_covenant_id), recipient_value);
         let missing_proxy_err = builder.build(&missing_proxy).expect_err("missing observed input is rejected by the runtime");
         assert!(matches!(missing_proxy_err, BuilderError::ObservedCountMismatch { side: Side::In, expected: 1, found: 0, .. }));
 
         let wrong_proxy_state = minter_proxy_state(Hash::from_bytes([0xd0; 32]));
         let wrong_proxy = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Minter",
                 minter_initial.clone(),
                 EntryCall::new("mint").args(args![vec![0; 65], recipient_owner.clone(), minted_amount]),
@@ -1763,7 +1763,7 @@ mod tests {
                 minter_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "kcc20_asset::MinterProxy",
                 wrong_proxy_state,
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
@@ -1775,7 +1775,7 @@ mod tests {
         assert!(matches!(wrong_proxy_err, BuilderError::ArgentInputScriptMismatch { input_index: 1, .. }));
 
         let wrong_recipient = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Minter",
                 minter_initial.clone(),
                 EntryCall::new("mint").args_with(|tx, input_idx| {
@@ -1785,7 +1785,7 @@ mod tests {
                 minter_utxo.clone(),
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "kcc20_asset::MinterProxy",
                 proxy_state.clone(),
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
@@ -1793,9 +1793,9 @@ mod tests {
                 proxy_utxo.clone(),
                 0,
             )
-            .argent_output("Minter", minter_next, CovenantBinding::new(0, controller_covenant_id), minter_value)
-            .argent_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
-            .argent_output(
+            .actor_output("Minter", minter_next, CovenantBinding::new(0, controller_covenant_id), minter_value)
+            .actor_output("kcc20_asset::MinterProxy", proxy_state.clone(), CovenantBinding::new(1, asset_covenant_id), proxy_value)
+            .actor_output(
                 "kcc20_asset::KCC20",
                 kcc20_state(recipient_owner.clone(), minted_amount + 1),
                 CovenantBinding::new(1, asset_covenant_id),
@@ -1809,7 +1809,7 @@ mod tests {
             .covenant_utxo("Minter", wrong_asset_minter_initial.clone(), minter_value, 0, false, Some(controller_covenant_id))
             .expect("wrong-asset minter utxo builds");
         let wrong_asset = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Minter",
                 wrong_asset_minter_initial,
                 EntryCall::new("mint").args(args![vec![0; 65], recipient_owner.clone(), minted_amount]),
@@ -1817,7 +1817,7 @@ mod tests {
                 wrong_asset_minter_utxo,
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "kcc20_asset::MinterProxy",
                 proxy_state.clone(),
                 EntryCall::new("mint").args(args![proxy_state.clone(), recipient_state.clone()]),
@@ -1825,9 +1825,9 @@ mod tests {
                 proxy_utxo,
                 0,
             )
-            .argent_output("Minter", wrong_asset_minter_next, CovenantBinding::new(0, controller_covenant_id), minter_value)
-            .argent_output("kcc20_asset::MinterProxy", proxy_state, CovenantBinding::new(1, asset_covenant_id), proxy_value)
-            .argent_output("kcc20_asset::KCC20", recipient_state, CovenantBinding::new(1, asset_covenant_id), recipient_value);
+            .actor_output("Minter", wrong_asset_minter_next, CovenantBinding::new(0, controller_covenant_id), minter_value)
+            .actor_output("kcc20_asset::MinterProxy", proxy_state, CovenantBinding::new(1, asset_covenant_id), proxy_value)
+            .actor_output("kcc20_asset::KCC20", recipient_state, CovenantBinding::new(1, asset_covenant_id), recipient_value);
         assert!(builder.build(&wrong_asset).is_err());
     }
 
@@ -1887,7 +1887,7 @@ mod tests {
             .with_app("kcc20_asset", &bad_interface_asset)
             .expect("interface mismatch is checked when the app is used");
         let bad_interface_builder = TxBuilder::from_bundle(&bad_interface_bundle).expect("builder accepts bundle shape");
-        let bad_interface_context = TxContext::new().argent_output(
+        let bad_interface_context = TxContext::new().actor_output(
             "Minter",
             minter_state(vec![0x22; 32], Hash::from_bytes([0xa5; 32]), 1, true),
             CovenantBinding::new(0, Hash::from_bytes([0xc0; 32])),
@@ -1957,8 +1957,8 @@ mod tests {
             .expect("cell UTXO builds");
 
         let context = TxContext::new()
-            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo.clone(), 0)
-            .argent_input(
+            .actor_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo.clone(), 0)
+            .actor_input(
                 "open_agent::Agent",
                 agent_initial.clone(),
                 EntryCall::new("step").args(args![agent_next.clone()]),
@@ -1966,8 +1966,8 @@ mod tests {
                 agent_utxo.clone(),
                 0,
             )
-            .argent_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value)
-            .argent_output("open_agent::Agent", agent_next.clone(), CovenantBinding::new(1, agent_covenant_id), agent_value);
+            .actor_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value)
+            .actor_output("open_agent::Agent", agent_next.clone(), CovenantBinding::new(1, agent_covenant_id), agent_value);
         let transaction = builder.build(&context).expect("context resolves and executes the open observed actor");
         assert_eq!(transaction.inputs.len(), 2);
         assert_eq!(transaction.outputs.len(), 2);
@@ -1976,8 +1976,8 @@ mod tests {
         assert!(transaction.inputs.iter().all(|input| input.compute_commit.compute_budget().is_some()));
 
         let missing_observed = TxContext::new()
-            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo, 0)
-            .argent_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value);
+            .actor_input("Cell", cell_initial.clone(), "advance", cell_outpoint, cell_utxo, 0)
+            .actor_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value);
         let missing_observed_err = builder.build(&missing_observed).expect_err("the declared observed input/output pair is required");
         assert!(
             matches!(&missing_observed_err, BuilderError::ObservedCountMismatch { observe, side, expected: 1, found: 0 }
@@ -2007,8 +2007,8 @@ mod tests {
             .covenant_utxo("open_agent::Agent", agent_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("bad-layout bundle still builds the Agent UTXO");
         let bad_layout_context = TxContext::new()
-            .argent_input("Cell", cell_initial.clone(), "advance", cell_outpoint, bad_layout_cell_utxo, 0)
-            .argent_input(
+            .actor_input("Cell", cell_initial.clone(), "advance", cell_outpoint, bad_layout_cell_utxo, 0)
+            .actor_input(
                 "open_agent::Agent",
                 agent_initial.clone(),
                 EntryCall::new("step").args(args![agent_next.clone()]),
@@ -2016,8 +2016,8 @@ mod tests {
                 bad_layout_agent_utxo,
                 0,
             )
-            .argent_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value)
-            .argent_output("open_agent::Agent", agent_next.clone(), CovenantBinding::new(1, agent_covenant_id), agent_value);
+            .actor_output("Cell", cell_next.clone(), CovenantBinding::new(0, controller_covenant_id), cell_value)
+            .actor_output("open_agent::Agent", agent_next.clone(), CovenantBinding::new(1, agent_covenant_id), agent_value);
         let bad_layout_err =
             bad_layout_builder.build(&bad_layout_context).expect_err("open observed actor state layout mismatch is rejected");
         assert!(
@@ -2049,17 +2049,10 @@ mod tests {
             .covenant_utxo("open_agent::Forager", expanded_agent_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("expanded agent utxo builds");
         let expanded_context = TxContext::new()
-            .argent_input("Cell", expanded_cell_initial, "advance", cell_outpoint, expanded_cell_utxo, 0)
-            .argent_input(
-                "open_agent::Forager",
-                expanded_agent_initial.clone(),
-                "step",
-                agent_outpoint,
-                expanded_agent_utxo.clone(),
-                0,
-            )
-            .argent_output("Cell", expanded_cell_next, CovenantBinding::new(0, controller_covenant_id), cell_value)
-            .argent_output("open_agent::Forager", expanded_agent_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
+            .actor_input("Cell", expanded_cell_initial, "advance", cell_outpoint, expanded_cell_utxo, 0)
+            .actor_input("open_agent::Forager", expanded_agent_initial.clone(), "step", agent_outpoint, expanded_agent_utxo.clone(), 0)
+            .actor_output("Cell", expanded_cell_next, CovenantBinding::new(0, controller_covenant_id), cell_value)
+            .actor_output("open_agent::Forager", expanded_agent_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
         expanded_builder.build(&expanded_context).expect("open ICC accepts an actor state that expands the observed capsule");
 
         let mut flattened_forager_state = expanded_open_agent_state(controller_covenant_id, 2, 5);
@@ -2067,7 +2060,7 @@ mod tests {
         flattened_forager_state.insert("hunger".to_string(), ArtifactValue::Int(2));
         flattened_forager_state.insert("mood".to_string(), ArtifactValue::Int(1));
         flattened_forager_state.insert("target_agent_id".to_string(), ArtifactValue::Bytes(vec![0x55; 32]));
-        let flattened_context = TxContext::new().argent_input(
+        let flattened_context = TxContext::new().actor_input(
             "open_agent::Forager",
             flattened_forager_state,
             "step",
@@ -2096,8 +2089,8 @@ mod tests {
             .covenant_utxo("open_agent::Forager", forager_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("Forager utxo builds");
         let forager_context = TxContext::new()
-            .argent_input("Cell", forager_cell_initial.clone(), "advance", cell_outpoint, forager_cell_utxo, 0)
-            .argent_input(
+            .actor_input("Cell", forager_cell_initial.clone(), "advance", cell_outpoint, forager_cell_utxo, 0)
+            .actor_input(
                 "open_agent::Forager",
                 forager_initial,
                 EntryCall::new("step").args(args![0, 0, 4]),
@@ -2105,8 +2098,8 @@ mod tests {
                 forager_utxo,
                 0,
             )
-            .argent_output("Cell", forager_cell_initial, CovenantBinding::new(0, controller_covenant_id), cell_value)
-            .argent_output("open_agent::Forager", forager_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
+            .actor_output("Cell", forager_cell_initial, CovenantBinding::new(0, controller_covenant_id), cell_value)
+            .actor_output("open_agent::Forager", forager_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
         builder.build(&forager_context).expect("Forager route executes with expanded-memory repacking");
 
         let wrong_agent_next = open_agent_state(controller_covenant_id, vec![0x77; 32], 5);
@@ -2117,8 +2110,8 @@ mod tests {
             .covenant_utxo("open_agent::Agent", agent_initial.clone(), agent_value, 0, false, Some(agent_covenant_id))
             .expect("wrong-output Agent UTXO builds");
         let wrong_context = TxContext::new()
-            .argent_input("Cell", cell_initial, "advance", cell_outpoint, wrong_cell_utxo, 0)
-            .argent_input(
+            .actor_input("Cell", cell_initial, "advance", cell_outpoint, wrong_cell_utxo, 0)
+            .actor_input(
                 "open_agent::Agent",
                 agent_initial,
                 EntryCall::new("step").args(args![wrong_agent_next.clone()]),
@@ -2126,8 +2119,8 @@ mod tests {
                 wrong_agent_utxo,
                 0,
             )
-            .argent_output("Cell", cell_next, CovenantBinding::new(0, controller_covenant_id), cell_value)
-            .argent_output("open_agent::Agent", wrong_agent_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
+            .actor_output("Cell", cell_next, CovenantBinding::new(0, controller_covenant_id), cell_value)
+            .actor_output("open_agent::Agent", wrong_agent_next, CovenantBinding::new(1, agent_covenant_id), agent_value);
         assert!(builder.build(&wrong_context).is_err(), "core physics rejects an agent output that does not spend one energy");
     }
 
@@ -2192,7 +2185,7 @@ mod tests {
             .covenant_utxo("Cell", cell_state.clone(), 2_000, 0, false, Some(controller_covenant_id))
             .expect("Cell UTXO builds");
         let context = TxContext::new()
-            .argent_input(
+            .actor_input(
                 "Cell",
                 cell_state,
                 "advance",
@@ -2200,7 +2193,7 @@ mod tests {
                 cell_utxo,
                 0,
             )
-            .argent_input(
+            .actor_input(
                 "agent_app::Agent",
                 agent_state,
                 EntryCall::new("step").args(args![next_agent_state.clone()]),
@@ -2208,8 +2201,8 @@ mod tests {
                 agent_utxo,
                 0,
             )
-            .argent_output("Cell", next_cell_state, CovenantBinding::new(0, controller_covenant_id), 2_000)
-            .argent_output("agent_app::Agent", next_agent_state, CovenantBinding::new(1, agent_covenant_id), 1_000);
+            .actor_output("Cell", next_cell_state, CovenantBinding::new(0, controller_covenant_id), 2_000)
+            .actor_output("agent_app::Agent", next_agent_state, CovenantBinding::new(1, agent_covenant_id), 1_000);
         let transaction = builder.build(&context).expect("anonymous open binding resolves and executes");
         let sigscript = &transaction.inputs[0].signature_script;
         let contract = core_artifact.sil_abi.contract("Cell").expect("Cell contract exists");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -13,6 +13,7 @@ mod tests {
         loader::load_program,
     };
     use std::{
+        cell::Cell,
         collections::BTreeMap,
         fs,
         path::PathBuf,
@@ -32,7 +33,6 @@ mod tests {
         },
     };
     use kaspa_txscript::{opcodes::codes::OpTrue, parse_script, pay_to_script_hash_signature_script_with_flags};
-    use kaspa_txscript_errors::{CovenantsError, TxScriptError};
     use secp256k1::{Keypair, Secp256k1, SecretKey};
 
     static ARTIFACT_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -659,11 +659,7 @@ mod tests {
             .covenant_utxo("controller_app::Controller", controller_state.clone(), 10_000, 0, false, Some(controller_id))
             .expect("controller UTXO builds");
 
-        let left_pair_output =
-            builder.genesis_output("pair_app::Pair", left_pair_state.clone(), 2_000).expect("left pair genesis output builds");
-        let right_pair_output =
-            builder.genesis_output("pair_app::Pair", right_pair_state.clone(), 2_000).expect("right pair genesis output builds");
-        let pair_id = covenant_id(controller_outpoint, [(1, &left_pair_output), (3, &right_pair_output)].into_iter());
+        let callback_pair_id = Cell::new(None);
         let unrelated_spk = ScriptPublicKey::new(0, vec![OpTrue].into());
         let context = TxContext::new()
             .argent_input(
@@ -674,14 +670,27 @@ mod tests {
                 controller_utxo.clone(),
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_output("pair_app::Pair", left_pair_state.clone(), CovenantBinding::new(0, pair_id), 2_000)
+            .argent_output(
+                "controller_app::Controller",
+                state_with(|state_context| {
+                    callback_pair_id.set(state_context.genesis_covenant_id(0, "spawn::new_pair"));
+                    next_controller_state.clone()
+                }),
+                CovenantBinding::new(0, controller_id),
+                5_000,
+            )
+            .argent_genesis_output(0, "spawn::new_pair", "pair_app::Pair", left_pair_state.clone(), 2_000)
             .output(unrelated_spk.clone(), None, 1_000)
-            .argent_output("pair_app::Pair", right_pair_state.clone(), CovenantBinding::new(0, pair_id), 2_000);
-        builder.build(&context).expect("generated genesis id matches rusty-kaspa");
+            .argent_genesis_output(0, "spawn::new_pair", "pair_app::Pair", right_pair_state.clone(), 2_000);
+        let transaction = builder.build(&context).expect("explicit spawn group executes");
+        let pair_id = transaction.outputs[1].covenant.expect("spawn output has a covenant binding").covenant_id;
+        let expected_pair_id =
+            covenant_id(controller_outpoint, [(1, &transaction.outputs[1]), (3, &transaction.outputs[3])].into_iter());
+        assert_eq!(pair_id, expected_pair_id);
+        assert_eq!(transaction.outputs[3].covenant, Some(CovenantBinding::new(0, pair_id)));
+        assert_eq!(callback_pair_id.get(), Some(pair_id));
 
-        let wrong_id = Hash::from_bytes([99; 32]);
-        let wrong_context = TxContext::new()
+        let unknown_spawn = TxContext::new()
             .argent_input(
                 "controller_app::Controller",
                 state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 },
@@ -691,35 +700,67 @@ mod tests {
                 0,
             )
             .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_output("pair_app::Pair", left_pair_state.clone(), CovenantBinding::new(0, wrong_id), 2_000)
-            .output(unrelated_spk.clone(), None, 1_000)
-            .argent_output("pair_app::Pair", right_pair_state.clone(), CovenantBinding::new(0, wrong_id), 2_000);
-        let err = builder.build(&wrong_context).expect_err("a non-genesis covenant id must report the consensus failure");
-        assert!(
-            matches!(
-                err,
-                BuilderError::TxScript(TxScriptError::CovenantsError(CovenantsError::WrongGenesisCovenantId(0, found)))
-                    if found == wrong_id
-            ),
-            "unexpected error: {err}"
-        );
+            .argent_genesis_output(0, "spawn::other", "pair_app::Pair", left_pair_state.clone(), 2_000)
+            .output(unrelated_spk, None, 1_000)
+            .argent_genesis_output(0, "spawn::other", "pair_app::Pair", right_pair_state.clone(), 2_000);
+        let err = builder.build(&unknown_spawn).expect_err("spawn paths must name a clause on the selected entry");
+        assert!(matches!(err, BuilderError::UnknownSpawn(0, ref spawn) if spawn == "other"), "unexpected error: {err}");
 
-        let invalid_authority = TxContext::new()
+        let incomplete_spawn = TxContext::new()
             .argent_input(
                 "controller_app::Controller",
                 state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 },
                 EntryCall::new("launch").args(args![42, 43]),
                 controller_outpoint,
+                controller_utxo.clone(),
+                0,
+            )
+            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
+            .argent_genesis_output(0, "spawn::new_pair", "pair_app::Pair", left_pair_state.clone(), 2_000);
+        let err = builder.build(&incomplete_spawn).expect_err("spawn groups must contain every declared output");
+        assert!(matches!(err, BuilderError::InvalidSpawnGroup(ref spawn, _) if spawn == "new_pair"), "unexpected error: {err}");
+
+        let missing_spawn = TxContext::new()
+            .argent_input(
+                "controller_app::Controller",
+                state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 },
+                EntryCall::new("launch").args(args![42, 43]),
+                controller_outpoint,
+                controller_utxo.clone(),
+                0,
+            )
+            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000);
+        let err = builder.build(&missing_spawn).expect_err("every spawn clause requires an explicit named genesis group");
+        assert!(matches!(err, BuilderError::MissingSpawnGroup(0, ref spawn) if spawn == "new_pair"), "unexpected error: {err}");
+
+        let wrong_actor_state = state! { pair_type: builder.actor_type_handle("pair_app::Pair", "PairState").unwrap(), launches: 0 };
+        let wrong_actor = TxContext::new()
+            .argent_input(
+                "controller_app::Controller",
+                wrong_actor_state.clone(),
+                EntryCall::new("launch").args(args![42, 43]),
+                controller_outpoint,
                 controller_utxo,
                 0,
             )
-            .argent_output("controller_app::Controller", next_controller_state, CovenantBinding::new(0, controller_id), 5_000)
-            .argent_output("pair_app::Pair", left_pair_state, CovenantBinding::new(1, pair_id), 2_000)
-            .output(unrelated_spk, None, 1_000)
-            .argent_output("pair_app::Pair", right_pair_state, CovenantBinding::new(1, pair_id), 2_000);
-        let err = builder.build(&invalid_authority).expect_err("an out-of-range authorizing input must report the consensus failure");
+            .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
+            .argent_genesis_output(0, "spawn::new_pair", "controller_app::Controller", wrong_actor_state.clone(), 2_000)
+            .argent_genesis_output(0, "spawn::new_pair", "controller_app::Controller", wrong_actor_state, 2_000);
+        let err = builder.build(&wrong_actor).expect_err("spawn output actors must match the declared actor type");
+        assert!(matches!(err, BuilderError::InvalidSpawnGroup(ref spawn, _) if spawn == "new_pair"), "unexpected error: {err}");
+
+        let funding_outpoint = TransactionOutpoint::new(TransactionId::from_bytes([0x24; 32]), 1);
+        let funding_utxo = UtxoEntry::new(2_000, ScriptPublicKey::new(0, vec![OpTrue].into()), 0, false, None);
+        let ordinary_spawn = TxContext::new().input(funding_outpoint, funding_utxo, Vec::new(), 0).argent_genesis_output(
+            0,
+            "spawn::new_pair",
+            "pair_app::Pair",
+            state! { value: 42 },
+            2_000,
+        );
+        let err = builder.build(&ordinary_spawn).expect_err("spawn paths require an Argent authorizing input");
         assert!(
-            matches!(err, BuilderError::TxScript(TxScriptError::CovenantsError(CovenantsError::AuthInputOutOfBounds(1, 1)))),
+            matches!(err, BuilderError::SpawnAuthorizingInputNotArgent(0, ref spawn) if spawn == "new_pair"),
             "unexpected error: {err}"
         );
     }
@@ -750,22 +791,8 @@ mod tests {
         let controller_utxo = builder
             .covenant_utxo("controller_app::Controller", controller_state.clone(), 10_000, 0, false, Some(controller_id))
             .expect("controller UTXO builds");
-        let first_left_output =
-            builder.genesis_output("pair_app::Pair", first_left_state.clone(), 2_000).expect("first left genesis output builds");
-        let first_right_output =
-            builder.genesis_output("pair_app::Pair", first_right_state.clone(), 2_000).expect("first right genesis output builds");
-        let second_output =
-            builder.genesis_output("pair_app::Pair", second_state.clone(), 3_000).expect("second genesis output builds");
-        let third_left_output =
-            builder.genesis_output("pair_app::Pair", third_left_state.clone(), 2_000).expect("third left genesis output builds");
-        let third_right_output =
-            builder.genesis_output("pair_app::Pair", third_right_state.clone(), 2_000).expect("third right genesis output builds");
-
         // The first group occupies global outputs 1 and 3, while the second
         // occupies output 2. Group identity, not adjacency, keeps each spawn together.
-        let first_pair_id = covenant_id(controller_outpoint, [(1, &first_left_output), (3, &first_right_output)].into_iter());
-        let second_pair_id = covenant_id(controller_outpoint, [(2, &second_output)].into_iter());
-        let third_pair_id = covenant_id(controller_outpoint, [(4, &third_left_output), (5, &third_right_output)].into_iter());
         let context = TxContext::new()
             .argent_input(
                 "controller_app::Controller",
@@ -776,12 +803,12 @@ mod tests {
                 0,
             )
             .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_output("pair_app::Pair", first_left_state.clone(), CovenantBinding::new(0, first_pair_id), 2_000)
-            .argent_output("pair_app::Pair", second_state.clone(), CovenantBinding::new(0, second_pair_id), 3_000)
-            .argent_output("pair_app::Pair", first_right_state.clone(), CovenantBinding::new(0, first_pair_id), 2_000)
-            .argent_output("pair_app::Pair", third_left_state.clone(), CovenantBinding::new(0, third_pair_id), 2_000)
-            .argent_output("pair_app::Pair", third_right_state.clone(), CovenantBinding::new(0, third_pair_id), 2_000);
-        let transaction = builder.build(&context).expect("interleaved genesis groups resolve by first output order");
+            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state.clone(), 2_000)
+            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state.clone(), 3_000)
+            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state.clone(), 2_000)
+            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_left_state.clone(), 2_000)
+            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_right_state.clone(), 2_000);
+        let transaction = builder.build(&context).expect("explicit interleaved genesis groups resolve by clause name");
 
         // Security regressions: bypass spawn resolution and invoke the generated Sil directly. The first and third clauses
         // use identical actor types, states, and values, allowing malicious indices to reuse or substitute their outputs
@@ -852,8 +879,6 @@ mod tests {
             "generated Sil must reject an incomplete witnessed genesis group"
         );
 
-        let reversed_second_pair_id = covenant_id(controller_outpoint, [(1, &second_output)].into_iter());
-        let reversed_first_pair_id = covenant_id(controller_outpoint, [(2, &first_left_output), (3, &first_right_output)].into_iter());
         let reversed_groups = TxContext::new()
             .argent_input(
                 "controller_app::Controller",
@@ -864,14 +889,14 @@ mod tests {
                 0,
             )
             .argent_output("controller_app::Controller", next_controller_state.clone(), CovenantBinding::new(0, controller_id), 5_000)
-            .argent_output("pair_app::Pair", second_state.clone(), CovenantBinding::new(0, reversed_second_pair_id), 3_000)
-            .argent_output("pair_app::Pair", first_left_state.clone(), CovenantBinding::new(0, reversed_first_pair_id), 2_000)
-            .argent_output("pair_app::Pair", first_right_state.clone(), CovenantBinding::new(0, reversed_first_pair_id), 2_000);
+            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state.clone(), 3_000)
+            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state.clone(), 2_000)
+            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state.clone(), 2_000);
         let err = builder.build(&reversed_groups).expect_err("spawn groups must remain in declaration order");
         assert!(
             matches!(
                 err,
-                BuilderError::MissingSpawnGroup { ref spawn } if spawn == "second_pair"
+                BuilderError::InvalidSpawnGroup(ref spawn, _) if spawn == "second_pair"
             ),
             "unexpected error: {err}"
         );
@@ -886,21 +911,21 @@ mod tests {
                 0,
             )
             .argent_output("controller_app::Controller", next_controller_state, CovenantBinding::new(0, controller_id), 5_000)
-            .argent_output("pair_app::Pair", first_left_state, CovenantBinding::new(0, first_pair_id), 2_000)
-            .argent_output("pair_app::Pair", second_state, CovenantBinding::new(0, second_pair_id), 3_000)
-            .output(first_right_output.script_public_key, Some(CovenantBinding::new(0, first_pair_id)), 2_000);
+            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state, 2_000)
+            .genesis_output(0, "spawn::first_pair", ScriptPublicKey::new(0, vec![OpTrue].into()), 2_000)
+            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state, 3_000);
         let err = builder.build(&missing_metadata).expect_err("spawn outputs must retain Argent actor metadata");
         assert!(
             matches!(
                 err,
-                BuilderError::MissingSpawnGroup { ref spawn } if spawn == "first_pair"
+                BuilderError::InvalidSpawnGroup(ref spawn, _) if spawn == "first_pair"
             ),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn context_matches_spawn_groups_as_an_ordered_subset() {
+    fn context_keeps_launch_groups_independent_from_explicit_spawns() {
         let source = "tests/fixtures/runtime/context_multiple_genesis_spawns/app.ag";
         let controller_artifact = selected_app_artifact(source, "ControllerApp", "context-subset-spawns-controller");
         let pair_artifact = selected_app_artifact(source, "PairApp", "context-subset-spawns-pair");
@@ -924,29 +949,11 @@ mod tests {
             .covenant_utxo("controller_app::Controller", controller_state.clone(), 10_000, 0, false, Some(controller_id))
             .expect("controller UTXO builds");
 
-        let extra_left =
-            builder.genesis_output("controller_app::Controller", controller_state.clone(), 100).expect("extra left output builds");
-        let extra_right =
-            builder.genesis_output("controller_app::Controller", controller_state.clone(), 200).expect("extra right output builds");
         let unrelated_spk = ScriptPublicKey::new(0, vec![OpTrue].into());
-        let extra_middle = TransactionOutput::new(300, unrelated_spk.clone());
-        let first_left = builder.genesis_output("pair_app::Pair", first_left_state.clone(), 2_000).expect("first left output builds");
-        let first_right =
-            builder.genesis_output("pair_app::Pair", first_right_state.clone(), 2_000).expect("first right output builds");
-        let second = builder.genesis_output("pair_app::Pair", second_state.clone(), 3_000).expect("second output builds");
-        let third_left = builder.genesis_output("pair_app::Pair", third_left_state.clone(), 2_000).expect("third left output builds");
-        let third_right =
-            builder.genesis_output("pair_app::Pair", third_right_state.clone(), 2_000).expect("third right output builds");
 
-        // Two unrelated genesis groups precede or separate the three declared groups:
-        // a same-size group of the wrong Argent actor at [1,3], and an ordinary
-        // output at [4]. The declared groups are first=[2,5], second=[6], third=[7,8].
-        let extra_first_id = covenant_id(controller_outpoint, [(1, &extra_left), (3, &extra_right)].into_iter());
-        let first_id = covenant_id(controller_outpoint, [(2, &first_left), (5, &first_right)].into_iter());
-        let extra_middle_id = covenant_id(controller_outpoint, [(4, &extra_middle)].into_iter());
-        let second_id = covenant_id(controller_outpoint, [(6, &second)].into_iter());
-        let third_id = covenant_id(controller_outpoint, [(7, &third_left), (8, &third_right)].into_iter());
-
+        // Independent launch groups precede or separate the three named spawn
+        // groups. Spawn resolution uses the explicit clause names, while each
+        // launch remains a separate consensus-valid genesis group.
         let context = TxContext::new()
             .argent_input(
                 "controller_app::Controller",
@@ -957,21 +964,16 @@ mod tests {
                 0,
             )
             .argent_output("controller_app::Controller", next_controller_state, CovenantBinding::new(0, controller_id), 5_000)
-            .argent_output(
-                "controller_app::Controller",
-                controller_state.clone(),
-                CovenantBinding::new(0, extra_first_id),
-                extra_left.value,
-            )
-            .argent_output("pair_app::Pair", first_left_state, CovenantBinding::new(0, first_id), first_left.value)
-            .argent_output("controller_app::Controller", controller_state, CovenantBinding::new(0, extra_first_id), extra_right.value)
-            .output(unrelated_spk, Some(CovenantBinding::new(0, extra_middle_id)), extra_middle.value)
-            .argent_output("pair_app::Pair", first_right_state, CovenantBinding::new(0, first_id), first_right.value)
-            .argent_output("pair_app::Pair", second_state, CovenantBinding::new(0, second_id), second.value)
-            .argent_output("pair_app::Pair", third_left_state, CovenantBinding::new(0, third_id), third_left.value)
-            .argent_output("pair_app::Pair", third_right_state, CovenantBinding::new(0, third_id), third_right.value);
+            .argent_genesis_output(0, "launch::extra", "controller_app::Controller", controller_state.clone(), 100)
+            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state, 2_000)
+            .argent_genesis_output(0, "launch::extra", "controller_app::Controller", controller_state, 200)
+            .genesis_output(0, "launch::middle", unrelated_spk, 300)
+            .argent_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_right_state, 2_000)
+            .argent_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state, 3_000)
+            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_left_state, 2_000)
+            .argent_genesis_output(0, "spawn::third_pair", "pair_app::Pair", third_right_state, 2_000);
 
-        builder.build(&context).expect("unrelated genesis groups are skipped while preserving declared spawn order");
+        builder.build(&context).expect("independent launch groups do not participate in explicit spawn resolution");
     }
 
     #[test]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,6 +21,7 @@ mod tests {
 
     use kaspa_consensus_core::{
         Hash,
+        errors::tx::PopulateGenesisCovenantsError,
         hashing::{
             covenant_id::covenant_id,
             sighash::{SigHashReusedValuesUnsync, calc_schnorr_signature_hash},
@@ -568,6 +569,65 @@ mod tests {
                     index: 1
                 } if observe == "asset" && handle == "badge"
             ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn context_launches_named_genesis_groups_from_an_ordinary_input() {
+        let source = "tests/fixtures/runtime/context_genesis_spawn/app.ag";
+        let pair_artifact = selected_app_artifact(source, "PairApp", "context-genesis-launch");
+        let builder = TxBuilder::new(&pair_artifact).expect("builder accepts pair artifact");
+
+        let funding_outpoint = TransactionOutpoint::new(TransactionId::from_bytes([0x61; 32]), 4);
+        let funding_script = ScriptPublicKey::new(0, vec![OpTrue].into());
+        let funding_utxo = UtxoEntry::new(10_000, funding_script, 0, false, None);
+        let unrelated_spk = ScriptPublicKey::new(0, vec![OpTrue].into());
+        let genesis_spk = ScriptPublicKey::new(0, vec![OpTrue].into());
+        let context = TxContext::new()
+            .input(funding_outpoint, funding_utxo, Vec::new(), 0)
+            .argent_genesis_output(0, "launch::pair", "Pair", state! { value: 7 }, 2_000)
+            .output(unrelated_spk, None, 1_000)
+            .genesis_output(0, "launch::pair", genesis_spk.clone(), 500)
+            .argent_genesis_output(0, "launch::pair", "Pair", state! { value: 8 }, 2_000)
+            .genesis_output(0, "launch::other", genesis_spk, 500);
+
+        let transaction = builder.build(&context).expect("ordinary input launches both named covenant groups");
+        let pair_id = covenant_id(
+            funding_outpoint,
+            [(0, &transaction.outputs[0]), (2, &transaction.outputs[2]), (3, &transaction.outputs[3])].into_iter(),
+        );
+        let other_id = covenant_id(funding_outpoint, [(4, &transaction.outputs[4])].into_iter());
+
+        assert_eq!(transaction.outputs[0].covenant, Some(CovenantBinding::new(0, pair_id)));
+        assert_eq!(transaction.outputs[1].covenant, None);
+        assert_eq!(transaction.outputs[2].covenant, Some(CovenantBinding::new(0, pair_id)));
+        assert_eq!(transaction.outputs[3].covenant, Some(CovenantBinding::new(0, pair_id)));
+        assert_eq!(transaction.outputs[4].covenant, Some(CovenantBinding::new(0, other_id)));
+        assert_ne!(pair_id, other_id);
+
+        let invalid_path = TxContext::new()
+            .input(
+                funding_outpoint,
+                UtxoEntry::new(3_000, ScriptPublicKey::new(0, vec![OpTrue].into()), 0, false, None),
+                Vec::new(),
+                0,
+            )
+            .argent_genesis_output(0, "pair", "Pair", state! { value: 7 }, 2_000);
+        let err = builder.build(&invalid_path).expect_err("genesis paths require the launch namespace");
+        assert!(matches!(err, BuilderError::InvalidGenesisPath(ref path) if path == "pair"), "unexpected error: {err}");
+
+        let missing_input = TxContext::new()
+            .input(
+                funding_outpoint,
+                UtxoEntry::new(3_000, ScriptPublicKey::new(0, vec![OpTrue].into()), 0, false, None),
+                Vec::new(),
+                0,
+            )
+            .argent_genesis_output(1, "launch::pair", "Pair", state! { value: 7 }, 2_000);
+        let err = builder.build(&missing_input).expect_err("launch paths must name an existing authorizing input");
+        assert!(
+            matches!(err, BuilderError::PopulateGenesisCovenants(PopulateGenesisCovenantsError::NoSuchInput(1, 1))),
             "unexpected error: {err}"
         );
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,7 +21,6 @@ mod tests {
 
     use kaspa_consensus_core::{
         Hash,
-        errors::tx::PopulateGenesisCovenantsError,
         hashing::{
             covenant_id::covenant_id,
             sighash::{SigHashReusedValuesUnsync, calc_schnorr_signature_hash},
@@ -627,7 +626,7 @@ mod tests {
             .argent_genesis_output(1, "launch::pair", "Pair", state! { value: 7 }, 2_000);
         let err = builder.build(&missing_input).expect_err("launch paths must name an existing authorizing input");
         assert!(
-            matches!(err, BuilderError::PopulateGenesisCovenants(PopulateGenesisCovenantsError::NoSuchInput(1, 1))),
+            matches!(err, BuilderError::GenesisAuthorizingInputOutOfRange { authorizing_input: 1, input_count: 1 }),
             "unexpected error: {err}"
         );
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -557,7 +557,7 @@ mod tests {
             )
             .actor_output("Controller", controller_next, CovenantBinding::new(0, controller_covenant_id), 4_000)
             .output(ordinary_badge_script, Some(CovenantBinding::new(1, asset_covenant_id)), 2_000);
-        let err = builder.build(&missing_metadata).expect_err("observed outputs must retain Argent metadata");
+        let err = builder.build(&missing_metadata).expect_err("observed outputs must retain actor metadata");
         assert!(
             matches!(
                 err,
@@ -758,9 +758,9 @@ mod tests {
             state! { value: 42 },
             2_000,
         );
-        let err = builder.build(&ordinary_spawn).expect_err("spawn paths require an Argent authorizing input");
+        let err = builder.build(&ordinary_spawn).expect_err("spawn paths require an actor authorizing input");
         assert!(
-            matches!(err, BuilderError::SpawnAuthorizingInputNotArgent(0, ref spawn) if spawn == "new_pair"),
+            matches!(err, BuilderError::SpawnAuthorizingInputNotActor(0, ref spawn) if spawn == "new_pair"),
             "unexpected error: {err}"
         );
     }
@@ -914,7 +914,7 @@ mod tests {
             .actor_genesis_output(0, "spawn::first_pair", "pair_app::Pair", first_left_state, 2_000)
             .genesis_output(0, "spawn::first_pair", ScriptPublicKey::new(0, vec![OpTrue].into()), 2_000)
             .actor_genesis_output(0, "spawn::second_pair", "pair_app::Pair", second_state, 3_000);
-        let err = builder.build(&missing_metadata).expect_err("spawn outputs must retain Argent actor metadata");
+        let err = builder.build(&missing_metadata).expect_err("spawn outputs must retain actor metadata");
         assert!(
             matches!(
                 err,
@@ -1772,7 +1772,7 @@ mod tests {
                 0,
             );
         let wrong_proxy_err = builder.build(&wrong_proxy).expect_err("observed input state must match its UTXO script");
-        assert!(matches!(wrong_proxy_err, BuilderError::ArgentInputScriptMismatch { input_index: 1, .. }));
+        assert!(matches!(wrong_proxy_err, BuilderError::ActorInputScriptMismatch { input_index: 1, .. }));
 
         let wrong_recipient = TxContext::new()
             .actor_input(


### PR DESCRIPTION
## Summary

This PR lets `TxContext` define named genesis covenant groups directly. The builder derives their covenant IDs, populates the output bindings, and exposes those IDs to deferred actor-state callbacks before assembling the transaction.

A simple independent launch now requires no manual covenant-ID calculation:

```rust
let context = TxContext::new()
    .input(funding_outpoint, funding_utxo, Vec::new(), 0)
    .actor_genesis_output(
        0,
        "launch::counter",
        "Counter",
        initial_state,
        value,
    );

let tx = builder.build(&context)?;
let counter = CovenantOutput::from_tx(&tx, 0)?;
```

`CovenantOutput` provides the resulting covenant ID, outpoint, and UTXO for subsequent transactions.

## Spawn Composition

Named `spawn::<clause>` groups connect transaction outputs to a spawn declared by the selected actor entry.

The builder resolves the spawned covenant ID before evaluating deferred continuation states. This allows the same transaction to create a new actor covenant and record its ID in another actor’s successor state:

```rust
let context = TxContext::new()
    .actor_input(
        "dexc::DexCore",
        core_state,
        "register_pair",
        core_outpoint,
        core_utxo,
        0,
    )
    .actor_output(
        "dexc::DexCore",
        state_with(|ctx| {
            let pair_id = ctx
                .genesis_covenant_id(0, "spawn::new_pair")
                .expect("passed as genesis group");

            registered_core_state(pair_id)
        }),
        core_binding,
        CORE_VALUE,
    )
    .actor_genesis_output(
        0,
        "spawn::new_pair",
        "dexp::DexPair",
        pair_state,
        PAIR_VALUE,
    );

let tx = builder.build(&context)?;
```

This keeps the full flow in one `TxContext` and one `builder.build()` call.

## Resolution

The builder:

1. Binds actor paths and validates named genesis groups.
2. Materializes the static genesis outputs needed for covenant-ID hashing.
3. Computes each group’s canonical covenant ID from its authorizing input and ordered outputs.
4. Makes those IDs available through `StateContext`.
5. Resolves deferred non-genesis actor states.
6. Builds the transaction and generated signature scripts.

Genesis actor outputs require static state because their scripts are part of their own covenant-ID preimage.

For declared spawns, the builder also verifies the group’s actor count, ordering, and concrete actor types against the artifact before constructing hidden witnesses.