### PR TITLE
Support dynamic byte arrays and simplify generated SIL

### DIFF
--- a/examples/build/icc_kcc20_asset/sil/KCC20.sil
+++ b/examples/build/icc_kcc20_asset/sil/KCC20.sil
@@ -15,7 +15,6 @@ contract KCC20(
     struct MinterProxyState {
         // :: generated fields
         byte[32] gen__kcc20_template;
-
         // :: user declared fields
         byte[32] controller_id;
     }
@@ -47,8 +46,6 @@ contract KCC20(
             require(false);
         }
         State next_state = {
-            // :: generated fields
-
             // :: user declared fields
             owner_identifier: new_owner_identifier,
             identifier_type: new_identifier_type,

--- a/examples/build/icc_kcc20_asset/sil/MinterProxy.sil
+++ b/examples/build/icc_kcc20_asset/sil/MinterProxy.sil
@@ -32,10 +32,6 @@ contract MinterProxy(
         byte[] gen__kcc20_prefix,
         byte[] gen__kcc20_suffix
     ) {
-        // :: witness lens
-        int gen__kcc20_prefix_len = gen__kcc20_prefix.length;
-        int gen__kcc20_suffix_len = gen__kcc20_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
         // :: output proxy: MinterProxy

--- a/examples/build/icc_kcc20_asset/sil/MinterProxy.sil
+++ b/examples/build/icc_kcc20_asset/sil/MinterProxy.sil
@@ -12,8 +12,6 @@ contract MinterProxy(
 
     // :: state layouts
     struct KCC20State {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] owner_identifier;
         byte identifier_type;

--- a/examples/build/icc_minter/sil/Minter.sil
+++ b/examples/build/icc_minter/sil/Minter.sil
@@ -18,13 +18,10 @@ contract Minter(
     struct MinterProxyState {
         // :: generated fields
         byte[32] gen__kcc20_template;
-
         // :: user declared fields
         byte[32] controller_id;
     }
     struct KCC20State {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] owner_identifier;
         byte identifier_type;
@@ -82,13 +79,10 @@ contract Minter(
         MinterProxyState next_proxy = {
             // :: generated fields
             gen__kcc20_template: gen__asset_kcc20_template,
-
             // :: user declared fields
             controller_id: OpInputCovenantId(this.activeInputIndex),
         };
         KCC20State next_recipient = {
-            // :: generated fields
-
             // :: user declared fields
             owner_identifier: recipient_owner,
             identifier_type: IDENTIFIER_PUBKEY,
@@ -115,7 +109,6 @@ contract Minter(
             // :: generated fields
             gen__asset_minter_proxy_template: gen__asset_minter_proxy_template,
             gen__asset_kcc20_template: gen__asset_kcc20_template,
-
             // :: user declared fields
             owner: owner,
             kcc20_covid: kcc20_covid,

--- a/examples/build/open_icc_agent/sil/Agent.sil
+++ b/examples/build/open_icc_agent/sil/Agent.sil
@@ -16,8 +16,6 @@ contract Agent(
 ) {
     // :: state layouts
     struct ForagerState {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] world_id;
         byte[32] agent_id;

--- a/examples/build/open_icc_agent/sil/Forager.sil
+++ b/examples/build/open_icc_agent/sil/Forager.sil
@@ -16,8 +16,6 @@ contract Forager(
 ) {
     // :: state layouts
     struct AgentCapsule {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] world_id;
         byte[32] agent_id;
@@ -78,8 +76,6 @@ contract Forager(
         require(next_energy == energy - 1);
         require(next_energy >= 0);
         State next_agent = {
-            // :: generated fields
-
             // :: user declared fields
             world_id: world_id,
             agent_id: agent_id,

--- a/examples/build/open_icc_core/sil/Cell.sil
+++ b/examples/build/open_icc_core/sil/Cell.sil
@@ -14,8 +14,6 @@ contract Cell(
 ) {
     // :: state layouts
     struct AgentCapsule {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] world_id;
         byte[32] agent_id;
@@ -80,8 +78,6 @@ contract Cell(
         require(prev_state.world_id == world_id);
         require(prev_state.capabilities_digest == occupant_caps_digest);
         AgentCapsule next_state = {
-            // :: generated fields
-
             // :: user declared fields
             world_id: prev_state.world_id,
             agent_id: prev_state.agent_id,
@@ -106,7 +102,6 @@ contract Cell(
         State next_cell = {
             // :: generated fields
             gen__cell_template: gen__cell_template,
-
             // :: user declared fields
             world_id: world_id,
             x: x,
@@ -182,8 +177,6 @@ contract Cell(
         require(target_cell.occupant_agent_type == empty_agent_type);
         require(target_cell.occupant_caps_digest == empty_caps_digest);
         AgentCapsule next_agent = {
-            // :: generated fields
-
             // :: user declared fields
             world_id: prev_state.world_id,
             agent_id: prev_state.agent_id,
@@ -199,7 +192,6 @@ contract Cell(
         State next_source = {
             // :: generated fields
             gen__cell_template: gen__cell_template,
-
             // :: user declared fields
             world_id: world_id,
             x: x,
@@ -212,7 +204,6 @@ contract Cell(
         State next_target = {
             // :: generated fields
             gen__cell_template: gen__cell_template,
-
             // :: user declared fields
             world_id: target_cell.world_id,
             x: target_cell.x,

--- a/examples/build/route_state_bodies/sil/Archive.sil
+++ b/examples/build/route_state_bodies/sil/Archive.sil
@@ -41,10 +41,6 @@ contract Archive(
         byte[] gen__pawn_suffix,
         byte[64] gen__mux_routes
     ) {
-        // :: witness lens
-        int gen__pawn_prefix_len = gen__pawn_prefix.length;
-        int gen__pawn_suffix_len = gen__pawn_suffix.length;
-
         // :: routes: route_family/BoardState/mux Pawn
         require(blake2b(gen__mux_routes) == gen__mux_routes_digest);
         byte[32] gen__pawn_template = byte[32](gen__mux_routes.slice(0, 32));

--- a/examples/build/route_state_bodies/sil/Archive.sil
+++ b/examples/build/route_state_bodies/sil/Archive.sil
@@ -14,7 +14,6 @@ contract Archive(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -23,7 +22,6 @@ contract Archive(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[64] gen__mux_routes;
-
         // :: user declared fields
         int ply;
     }
@@ -60,7 +58,6 @@ contract Archive(
             gen__archive_template: gen__archive_template,
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             ply: final_ply + 1,
         };

--- a/examples/build/route_state_bodies/sil/Knight.sil
+++ b/examples/build/route_state_bodies/sil/Knight.sil
@@ -14,7 +14,6 @@ contract Knight(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -23,7 +22,6 @@ contract Knight(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int final_ply;
     }

--- a/examples/build/route_state_bodies/sil/Lobby.sil
+++ b/examples/build/route_state_bodies/sil/Lobby.sil
@@ -14,7 +14,6 @@ contract Lobby(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[64] gen__mux_routes;
-
         // :: user declared fields
         int ply;
     }
@@ -23,7 +22,6 @@ contract Lobby(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int final_ply;
     }
@@ -59,7 +57,6 @@ contract Lobby(
             gen__archive_template: gen__archive_template,
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             ply: nonce,
         };

--- a/examples/build/route_state_bodies/sil/Lobby.sil
+++ b/examples/build/route_state_bodies/sil/Lobby.sil
@@ -41,10 +41,6 @@ contract Lobby(
         byte[] gen__mux_suffix,
         byte[64] gen__mux_routes
     ) {
-        // :: witness lens
-        int gen__mux_prefix_len = gen__mux_prefix.length;
-        int gen__mux_suffix_len = gen__mux_suffix.length;
-
         // :: routes: route_family/BoardState/mux
         require(blake2b(gen__mux_routes) == gen__mux_routes_digest);
 

--- a/examples/build/route_state_bodies/sil/Mux.sil
+++ b/examples/build/route_state_bodies/sil/Mux.sil
@@ -37,10 +37,6 @@ contract Mux(
     // :: entrypoints
     // :: leader entry (1:N)
     entrypoint function choose(int target, byte[] gen__target_prefix, byte[] gen__target_suffix) {
-        // :: witness lens
-        int gen__target_prefix_len = gen__target_prefix.length;
-        int gen__target_suffix_len = gen__target_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor
@@ -71,10 +67,6 @@ contract Mux(
 
     // :: leader entry (1:N)
     entrypoint function archive(byte[] gen__archive_prefix, byte[] gen__archive_suffix) {
-        // :: witness lens
-        int gen__archive_prefix_len = gen__archive_prefix.length;
-        int gen__archive_suffix_len = gen__archive_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Archive

--- a/examples/build/route_state_bodies/sil/Mux.sil
+++ b/examples/build/route_state_bodies/sil/Mux.sil
@@ -14,7 +14,6 @@ contract Mux(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -23,7 +22,6 @@ contract Mux(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int final_ply;
     }
@@ -52,7 +50,6 @@ contract Mux(
             gen__archive_template: gen__archive_template,
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             ply: ply + 1,
         };
@@ -87,7 +84,6 @@ contract Mux(
             gen__archive_template: gen__archive_template,
             gen__mux_template: gen__mux_template,
             gen__mux_routes_digest: blake2b(gen__mux_routes),
-
             // :: user declared fields
             final_ply: ply,
         };

--- a/examples/build/route_state_bodies/sil/Pawn.sil
+++ b/examples/build/route_state_bodies/sil/Pawn.sil
@@ -14,7 +14,6 @@ contract Pawn(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -23,7 +22,6 @@ contract Pawn(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int final_ply;
     }

--- a/examples/build/route_state_bodies/sil/Spectator.sil
+++ b/examples/build/route_state_bodies/sil/Spectator.sil
@@ -11,7 +11,6 @@ contract Spectator(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -20,7 +19,6 @@ contract Spectator(
         byte[32] gen__archive_template;
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int final_ply;
     }

--- a/examples/build/route_state_body_choice/sil/Knight.sil
+++ b/examples/build/route_state_body_choice/sil/Knight.sil
@@ -13,7 +13,6 @@ contract Knight(
         byte[32] gen__mux_template;
         byte[32] gen__spectator_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }

--- a/examples/build/route_state_body_choice/sil/Lobby.sil
+++ b/examples/build/route_state_body_choice/sil/Lobby.sil
@@ -39,12 +39,6 @@ contract Lobby(
         byte[] gen__spectator_suffix,
         byte[64] gen__mux_routes
     ) {
-        // :: witness lens
-        int gen__mux_prefix_len = gen__mux_prefix.length;
-        int gen__mux_suffix_len = gen__mux_suffix.length;
-        int gen__spectator_prefix_len = gen__spectator_prefix.length;
-        int gen__spectator_suffix_len = gen__spectator_suffix.length;
-
         // :: routes: route_family/BoardState/mux
         require(blake2b(gen__mux_routes) == gen__mux_routes_digest);
 

--- a/examples/build/route_state_body_choice/sil/Lobby.sil
+++ b/examples/build/route_state_body_choice/sil/Lobby.sil
@@ -13,7 +13,6 @@ contract Lobby(
         // :: generated fields
         byte[32] gen__mux_template;
         byte[64] gen__mux_routes;
-
         // :: user declared fields
         int ply;
     }
@@ -55,8 +54,6 @@ contract Lobby(
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         Gen__BoardStateBody next_board = {
-            // :: generated fields
-
             // :: user declared fields
             ply: nonce,
         };
@@ -74,7 +71,6 @@ contract Lobby(
                 // :: generated fields
                 gen__mux_template: gen__mux_template,
                 gen__mux_routes: gen__mux_routes,
-
                 // :: user declared fields
                 ply: next_board.ply,
             };

--- a/examples/build/route_state_body_choice/sil/Mux.sil
+++ b/examples/build/route_state_body_choice/sil/Mux.sil
@@ -13,7 +13,6 @@ contract Mux(
         byte[32] gen__mux_template;
         byte[32] gen__spectator_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -40,7 +39,6 @@ contract Mux(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             ply: ply + 1,
         };

--- a/examples/build/route_state_body_choice/sil/Mux.sil
+++ b/examples/build/route_state_body_choice/sil/Mux.sil
@@ -27,10 +27,6 @@ contract Mux(
     // :: entrypoints
     // :: leader entry (1:N)
     entrypoint function choose(int target, byte[] gen__target_prefix, byte[] gen__target_suffix) {
-        // :: witness lens
-        int gen__target_prefix_len = gen__target_prefix.length;
-        int gen__target_suffix_len = gen__target_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor

--- a/examples/build/route_state_body_choice/sil/Pawn.sil
+++ b/examples/build/route_state_body_choice/sil/Pawn.sil
@@ -13,7 +13,6 @@ contract Pawn(
         byte[32] gen__mux_template;
         byte[32] gen__spectator_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }

--- a/examples/build/route_state_body_choice/sil/Spectator.sil
+++ b/examples/build/route_state_body_choice/sil/Spectator.sil
@@ -11,7 +11,6 @@ contract Spectator(
         byte[32] gen__mux_template;
         byte[32] gen__spectator_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }

--- a/examples/build/spawns/sil/Controller.sil
+++ b/examples/build/spawns/sil/Controller.sil
@@ -8,8 +8,6 @@ contract Controller(
 ) {
     // :: state layouts
     struct PairState {
-        // :: generated fields
-
         // :: user declared fields
         int value;
     }
@@ -54,20 +52,14 @@ contract Controller(
         require(OpOutputCovenantId(gen__new_pair_left_output_idx) == pair_id);
 
         PairState left = {
-            // :: generated fields
-
             // :: user declared fields
             value: left_value,
         };
         PairState right = {
-            // :: generated fields
-
             // :: user declared fields
             value: right_value,
         };
         State next = {
-            // :: generated fields
-
             // :: user declared fields
             pair_type: pair_type,
             launches: launches + 1,

--- a/examples/build/spawns/sil/Pair.sil
+++ b/examples/build/spawns/sil/Pair.sil
@@ -7,8 +7,6 @@ contract Pair(
 ) {
     // :: state layouts
     struct ControllerState {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] pair_type;
         int launches;

--- a/examples/build/stones/sil/League.sil
+++ b/examples/build/stones/sil/League.sil
@@ -23,7 +23,6 @@ contract League(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] owner;
         byte[32] player_id;
@@ -37,7 +36,6 @@ contract League(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] player_a;
         byte[32] player_b;
@@ -50,7 +48,6 @@ contract League(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] player_a;
         byte[32] player_b;
@@ -123,7 +120,6 @@ contract League(
             gen__player_template: gen__player_template,
             gen__stones_game_template: gen__stones_game_template,
             gen__stones_settle_template: gen__stones_settle_template,
-
             // :: user declared fields
             owner: owner,
             player_id: player_id,

--- a/examples/build/stones/sil/League.sil
+++ b/examples/build/stones/sil/League.sil
@@ -101,10 +101,6 @@ contract League(
         byte[] gen__player_prefix,
         byte[] gen__player_suffix
     ) {
-        // :: witness lens
-        int gen__player_prefix_len = gen__player_prefix.length;
-        int gen__player_suffix_len = gen__player_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
         // :: output league: League

--- a/examples/build/stones/sil/Player.sil
+++ b/examples/build/stones/sil/Player.sil
@@ -109,10 +109,6 @@ contract Player(
         byte[] gen__stones_game_prefix,
         byte[] gen__stones_game_suffix
     ) {
-        // :: witness lens
-        int gen__stones_game_prefix_len = gen__stones_game_prefix.length;
-        int gen__stones_game_suffix_len = gen__stones_game_suffix.length;
-
         // :: cov inputs
         byte[32] gen__cov_id = OpInputCovenantId(this.activeInputIndex);
         require(OpCovInputCount(gen__cov_id) == 2);

--- a/examples/build/stones/sil/Player.sil
+++ b/examples/build/stones/sil/Player.sil
@@ -26,7 +26,6 @@ contract Player(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] admin;
         int default_pile;
@@ -37,7 +36,6 @@ contract Player(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] player_a;
         byte[32] player_b;
@@ -50,7 +48,6 @@ contract Player(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] player_a;
         byte[32] player_b;
@@ -150,7 +147,6 @@ contract Player(
             gen__player_template: gen__player_template,
             gen__stones_game_template: gen__stones_game_template,
             gen__stones_settle_template: gen__stones_settle_template,
-
             // :: user declared fields
             owner: owner,
             player_id: player_id,
@@ -164,7 +160,6 @@ contract Player(
             gen__player_template: gen__player_template,
             gen__stones_game_template: gen__stones_game_template,
             gen__stones_settle_template: gen__stones_settle_template,
-
             // :: user declared fields
             owner: opponent.owner,
             player_id: opponent.player_id,
@@ -178,7 +173,6 @@ contract Player(
             gen__player_template: gen__player_template,
             gen__stones_game_template: gen__stones_game_template,
             gen__stones_settle_template: gen__stones_settle_template,
-
             // :: user declared fields
             player_a: self_ref,
             player_b: opponent_ref,

--- a/examples/build/stones/sil/StonesGame.sil
+++ b/examples/build/stones/sil/StonesGame.sil
@@ -25,7 +25,6 @@ contract StonesGame(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] admin;
         int default_pile;
@@ -36,7 +35,6 @@ contract StonesGame(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] owner;
         byte[32] player_id;
@@ -50,7 +48,6 @@ contract StonesGame(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] player_a;
         byte[32] player_b;
@@ -133,7 +130,6 @@ contract StonesGame(
                 gen__player_template: gen__player_template,
                 gen__stones_game_template: gen__stones_game_template,
                 gen__stones_settle_template: gen__stones_settle_template,
-
                 // :: user declared fields
                 player_a: player_a,
                 player_b: player_b,
@@ -153,7 +149,6 @@ contract StonesGame(
                 gen__player_template: gen__player_template,
                 gen__stones_game_template: gen__stones_game_template,
                 gen__stones_settle_template: gen__stones_settle_template,
-
                 // :: user declared fields
                 player_a: player_a,
                 player_b: player_b,
@@ -194,7 +189,6 @@ contract StonesGame(
             gen__player_template: gen__player_template,
             gen__stones_game_template: gen__stones_game_template,
             gen__stones_settle_template: gen__stones_settle_template,
-
             // :: user declared fields
             player_a: player_a,
             player_b: player_b,

--- a/examples/build/stones/sil/StonesGame.sil
+++ b/examples/build/stones/sil/StonesGame.sil
@@ -105,10 +105,6 @@ contract StonesGame(
         byte[] gen__stones_settle_prefix,
         byte[] gen__stones_settle_suffix
     ) {
-        // :: witness lens
-        int gen__stones_settle_prefix_len = gen__stones_settle_prefix.length;
-        int gen__stones_settle_suffix_len = gen__stones_settle_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         // :: output next: StonesGame | StonesSettle
@@ -169,10 +165,6 @@ contract StonesGame(
         byte[] gen__stones_settle_prefix,
         byte[] gen__stones_settle_suffix
     ) {
-        // :: witness lens
-        int gen__stones_settle_prefix_len = gen__stones_settle_prefix.length;
-        int gen__stones_settle_suffix_len = gen__stones_settle_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         // :: output settle: StonesSettle

--- a/examples/build/stones/sil/StonesSettle.sil
+++ b/examples/build/stones/sil/StonesSettle.sil
@@ -23,7 +23,6 @@ contract StonesSettle(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] admin;
         int default_pile;
@@ -34,7 +33,6 @@ contract StonesSettle(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] owner;
         byte[32] player_id;
@@ -48,7 +46,6 @@ contract StonesSettle(
         byte[32] gen__player_template;
         byte[32] gen__stones_game_template;
         byte[32] gen__stones_settle_template;
-
         // :: user declared fields
         byte[32] player_a;
         byte[32] player_b;
@@ -152,7 +149,6 @@ contract StonesSettle(
             gen__player_template: gen__player_template,
             gen__stones_game_template: gen__stones_game_template,
             gen__stones_settle_template: gen__stones_settle_template,
-
             // :: user declared fields
             owner: player_a_in.owner,
             player_id: player_a_in.player_id,
@@ -166,7 +162,6 @@ contract StonesSettle(
             gen__player_template: gen__player_template,
             gen__stones_game_template: gen__stones_game_template,
             gen__stones_settle_template: gen__stones_settle_template,
-
             // :: user declared fields
             owner: player_b_in.owner,
             player_id: player_b_in.player_id,

--- a/examples/build/tickets/sil/Issuer.sil
+++ b/examples/build/tickets/sil/Issuer.sil
@@ -31,10 +31,6 @@ contract Issuer(
         byte[] gen__ticket_prefix,
         byte[] gen__ticket_suffix
     ) {
-        // :: witness lens
-        int gen__ticket_prefix_len = gen__ticket_prefix.length;
-        int gen__ticket_suffix_len = gen__ticket_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 2);
         // :: output issuer: Issuer

--- a/examples/build/tickets/sil/Issuer.sil
+++ b/examples/build/tickets/sil/Issuer.sil
@@ -9,8 +9,6 @@ contract Issuer(
 ) {
     // :: state layouts
     struct TicketState {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] owner;
         int serial;
@@ -51,14 +49,11 @@ contract Issuer(
         State next_issuer = {
             // :: generated fields
             gen__ticket_template: gen__ticket_template,
-
             // :: user declared fields
             admin: admin,
             next_serial: next_serial + 1,
         };
         TicketState new_ticket = {
-            // :: generated fields
-
             // :: user declared fields
             owner: owner,
             serial: serial,

--- a/examples/build/tickets/sil/Ticket.sil
+++ b/examples/build/tickets/sil/Ticket.sil
@@ -11,7 +11,6 @@ contract Ticket(
     struct IssuerState {
         // :: generated fields
         byte[32] gen__ticket_template;
-
         // :: user declared fields
         byte[32] admin;
         int next_serial;
@@ -36,8 +35,6 @@ contract Ticket(
         require(redeemed == 0);
         require(tx.outputs[gen__next_output_idx].value == tx.inputs[this.activeInputIndex].value);
         State redeemed_ticket = {
-            // :: generated fields
-
             // :: user declared fields
             owner: owner,
             serial: serial,

--- a/examples/build/toy_chess/sil/Knight.sil
+++ b/examples/build/toy_chess/sil/Knight.sil
@@ -14,7 +14,6 @@ contract Knight(
         byte[32] gen__mux_template;
         byte[32] gen__player_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -22,7 +21,6 @@ contract Knight(
         // :: generated fields
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -51,7 +49,6 @@ contract Knight(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             selector: selector,
             ply: ply + 1,

--- a/examples/build/toy_chess/sil/Knight.sil
+++ b/examples/build/toy_chess/sil/Knight.sil
@@ -36,10 +36,6 @@ contract Knight(
     // :: entrypoints
     // :: leader entry (1:N)
     entrypoint function back_to_mux(byte[] gen__mux_prefix, byte[] gen__mux_suffix) {
-        // :: witness lens
-        int gen__mux_prefix_len = gen__mux_prefix.length;
-        int gen__mux_suffix_len = gen__mux_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Mux

--- a/examples/build/toy_chess/sil/League.sil
+++ b/examples/build/toy_chess/sil/League.sil
@@ -13,7 +13,6 @@ contract League(
         // :: generated fields
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -21,7 +20,6 @@ contract League(
         // :: generated fields
         byte[32] gen__mux_template;
         byte[64] gen__mux_routes;
-
         // :: user declared fields
         int selector;
         int ply;
@@ -50,7 +48,6 @@ contract League(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes_digest: gen__mux_routes_digest,
-
             // :: user declared fields
             nonce: nonce + 1,
         };

--- a/examples/build/toy_chess/sil/League.sil
+++ b/examples/build/toy_chess/sil/League.sil
@@ -36,10 +36,6 @@ contract League(
     // :: entrypoints
     // :: leader entry (1:N)
     entrypoint function register(byte[] gen__player_prefix, byte[] gen__player_suffix) {
-        // :: witness lens
-        int gen__player_prefix_len = gen__player_prefix.length;
-        int gen__player_suffix_len = gen__player_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Player

--- a/examples/build/toy_chess/sil/Mux.sil
+++ b/examples/build/toy_chess/sil/Mux.sil
@@ -36,10 +36,6 @@ contract Mux(
     // :: entrypoints
     // :: leader entry (1:N)
     entrypoint function choose(int target, byte[] gen__target_prefix, byte[] gen__target_suffix) {
-        // :: witness lens
-        int gen__target_prefix_len = gen__target_prefix.length;
-        int gen__target_suffix_len = gen__target_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor
@@ -73,10 +69,6 @@ contract Mux(
 
     // :: leader entry (1:N)
     entrypoint function choose_knight_const(byte[] gen__target_prefix, byte[] gen__target_suffix) {
-        // :: witness lens
-        int gen__target_prefix_len = gen__target_prefix.length;
-        int gen__target_suffix_len = gen__target_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor
@@ -107,10 +99,6 @@ contract Mux(
 
     // :: leader entry (1:N)
     entrypoint function choose_pawn(byte[] gen__pawn_prefix, byte[] gen__pawn_suffix) {
-        // :: witness lens
-        int gen__pawn_prefix_len = gen__pawn_prefix.length;
-        int gen__pawn_suffix_len = gen__pawn_suffix.length;
-
         // :: routes: Pawn
         byte[32] gen__pawn_template = byte[32](gen__mux_routes.slice(0, 32));
 
@@ -138,10 +126,6 @@ contract Mux(
 
     // :: leader entry (1:N)
     entrypoint function choose_knight(byte[] gen__knight_prefix, byte[] gen__knight_suffix) {
-        // :: witness lens
-        int gen__knight_prefix_len = gen__knight_prefix.length;
-        int gen__knight_suffix_len = gen__knight_suffix.length;
-
         // :: routes: Knight
         byte[32] gen__knight_template = byte[32](gen__mux_routes.slice(32, 64));
 

--- a/examples/build/toy_chess/sil/Mux.sil
+++ b/examples/build/toy_chess/sil/Mux.sil
@@ -14,7 +14,6 @@ contract Mux(
         byte[32] gen__mux_template;
         byte[32] gen__player_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -22,7 +21,6 @@ contract Mux(
         // :: generated fields
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -53,7 +51,6 @@ contract Mux(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             selector: selector,
             ply: ply + 1,
@@ -88,7 +85,6 @@ contract Mux(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             selector: selector,
             ply: ply + 1,
@@ -126,7 +122,6 @@ contract Mux(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             selector: selector,
             ply: ply + 1,
@@ -158,7 +153,6 @@ contract Mux(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             selector: selector,
             ply: ply + 1,

--- a/examples/build/toy_chess/sil/Pawn.sil
+++ b/examples/build/toy_chess/sil/Pawn.sil
@@ -36,10 +36,6 @@ contract Pawn(
     // :: entrypoints
     // :: leader entry (1:N)
     entrypoint function back_to_mux(byte[] gen__mux_prefix, byte[] gen__mux_suffix) {
-        // :: witness lens
-        int gen__mux_prefix_len = gen__mux_prefix.length;
-        int gen__mux_suffix_len = gen__mux_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Mux

--- a/examples/build/toy_chess/sil/Pawn.sil
+++ b/examples/build/toy_chess/sil/Pawn.sil
@@ -14,7 +14,6 @@ contract Pawn(
         byte[32] gen__mux_template;
         byte[32] gen__player_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -22,7 +21,6 @@ contract Pawn(
         // :: generated fields
         byte[32] gen__mux_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -50,7 +48,6 @@ contract Pawn(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             selector: selector,
             ply: ply + 1,

--- a/examples/build/toy_chess/sil/Player.sil
+++ b/examples/build/toy_chess/sil/Player.sil
@@ -39,10 +39,6 @@ contract Player(
         byte[] gen__mux_suffix,
         byte[64] gen__mux_routes
     ) {
-        // :: witness lens
-        int gen__mux_prefix_len = gen__mux_prefix.length;
-        int gen__mux_suffix_len = gen__mux_suffix.length;
-
         // :: routes: route_family/BoardState/mux
         require(blake2b(gen__mux_routes) == gen__mux_routes_digest);
 

--- a/examples/build/toy_chess/sil/Player.sil
+++ b/examples/build/toy_chess/sil/Player.sil
@@ -13,7 +13,6 @@ contract Player(
         byte[32] gen__mux_template;
         byte[32] gen__player_template;
         byte[32] gen__mux_routes_digest;
-
         // :: user declared fields
         int nonce;
     }
@@ -21,7 +20,6 @@ contract Player(
         // :: generated fields
         byte[32] gen__mux_template;
         byte[64] gen__mux_routes;
-
         // :: user declared fields
         int selector;
         int ply;
@@ -56,7 +54,6 @@ contract Player(
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
-
             // :: user declared fields
             selector: nonce,
             ply: 0,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -171,8 +171,14 @@ pub struct RouteCall {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TypeRef {
     pub name: String,
-    pub array: Option<usize>,
+    pub array: Option<ArrayDim>,
     pub actor_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ArrayDim {
+    Dynamic,
+    Fixed(usize),
 }
 
 impl TypeRef {
@@ -181,7 +187,11 @@ impl TypeRef {
     }
 
     pub fn array(name: impl Into<String>, len: usize) -> Self {
-        Self { name: name.into(), array: Some(len), actor_state: None }
+        Self { name: name.into(), array: Some(ArrayDim::Fixed(len)), actor_state: None }
+    }
+
+    pub fn dynamic_array(name: impl Into<String>) -> Self {
+        Self { name: name.into(), array: Some(ArrayDim::Dynamic), actor_state: None }
     }
 
     pub fn actor_type(state: impl Into<String>) -> Self {
@@ -197,7 +207,8 @@ impl TypeRef {
             return "byte[32]".to_string();
         }
         match self.array {
-            Some(len) => format!("{}[{}]", self.name, len),
+            Some(ArrayDim::Dynamic) => format!("{}[]", self.name),
+            Some(ArrayDim::Fixed(len)) => format!("{}[{}]", self.name, len),
             None => self.name.clone(),
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -290,6 +290,57 @@ mod tests {
     }
 
     #[test]
+    fn context_executes_dynamic_byte_array_sigscript_arguments_at_varying_lengths() {
+        let artifact = inline_artifact(
+            "context-dynamic-byte-array-argument",
+            r#"
+            state BlobState {
+                int size;
+                byte[32] digest;
+            }
+
+            actor Blob owns BlobState {
+                entry store(data: byte[]) emits one Blob {
+                    BlobState next = {
+                        size: data.length,
+                        digest: blake2b(data),
+                    };
+
+                    become Blob(next);
+                }
+            }
+
+            app BlobApp {
+                actor Blob;
+            }
+            "#,
+        );
+        let builder = TxBuilder::new(&artifact).expect("builder accepts artifact");
+        let covenant_id = Hash::from_bytes([0x43; 32]);
+        let input_value = 1_000;
+
+        for (case, size) in [0usize, 1, 2, 16, 17, 75, 76, 255, 256].into_iter().enumerate() {
+            let initial = state! { size: 0, digest: vec![0; 32] };
+            let payload = vec![0; size];
+            let digest = blake2b32(&payload);
+            let input_utxo =
+                builder.covenant_utxo("Blob", initial.clone(), input_value, 0, false, Some(covenant_id)).expect("Blob UTXO builds");
+            let context = TxContext::new()
+                .actor_input(
+                    "Blob",
+                    initial,
+                    EntryCall::new("store").args(args![payload]),
+                    TransactionOutpoint::new(TransactionId::from_bytes([0x50 + case as u8; 32]), 0),
+                    input_utxo,
+                    0,
+                )
+                .actor_output("Blob", state! { size: size as i64, digest: digest }, CovenantBinding::new(0, covenant_id), input_value);
+
+            builder.build(&context).unwrap_or_else(|err| panic!("dynamic byte[] argument of length {size} failed: {err}"));
+        }
+    }
+
+    #[test]
     fn context_builds_and_verifies_signed_single_output() {
         let artifact = inline_artifact(
             "context-counter",

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -378,7 +378,9 @@ impl<'a> Model<'a> {
     fn validate_state_expansions(&self) -> Result<()> {
         for state in self.states.values() {
             for field in &state.fields {
-                if field.virtual_slot && (field.ty.name != "byte" || field.ty.array != Some(32) || field.ty.actor_state.is_some()) {
+                if field.virtual_slot
+                    && (field.ty.name != "byte" || field.ty.array != Some(ArrayDim::Fixed(32)) || field.ty.actor_state.is_some())
+                {
                     return Err(ArgentError::new(format!(
                         "state `{}` field `{}` is virtual, but virtual slots must be byte[32]",
                         state.name, field.name
@@ -426,7 +428,11 @@ impl<'a> Model<'a> {
                         state.name, expansion.base, digest.field, expansion.base
                     ))
                 })?;
-                if !field.virtual_slot || field.ty.name != "byte" || field.ty.array != Some(32) || field.ty.actor_state.is_some() {
+                if !field.virtual_slot
+                    || field.ty.name != "byte"
+                    || field.ty.array != Some(ArrayDim::Fixed(32))
+                    || field.ty.actor_state.is_some()
+                {
                     return Err(ArgentError::new(format!(
                         "state `{}` binds `{}` slot `{}`, but expanded slots must be virtual",
                         state.name, expansion.base, digest.field
@@ -2274,7 +2280,7 @@ fn packed_field_expr(ty: &TypeRef, expr: &str) -> Result<String> {
     match (ty.name.as_str(), ty.array) {
         ("int", None) => Ok(format!("byte[8]({expr})")),
         ("bool", None) | ("byte", None) => Ok(format!("byte[1]({expr})")),
-        ("byte", Some(_)) | ("pubkey", None) | (word::COVENANT_ID, None) | ("sig", None) | ("datasig", None) => {
+        ("byte", Some(ArrayDim::Fixed(_))) | ("pubkey", None) | (word::COVENANT_ID, None) | ("sig", None) | ("datasig", None) => {
             Ok(format!("byte[]({expr})"))
         }
         ("bytes", None) | ("string", None) | (_, Some(_)) => {
@@ -2292,7 +2298,7 @@ fn unpack_packed_field_expr(ty: &TypeRef, slice_expr: &str) -> Result<String> {
         ("int", None) => Ok(format!("OpBin2Num({slice_expr})")),
         ("bool", None) => Ok(format!("OpBin2Num({slice_expr}) != 0")),
         ("byte", None) => Ok(format!("byte({slice_expr})")),
-        ("byte", Some(len)) => Ok(format!("byte[{len}]({slice_expr})")),
+        ("byte", Some(ArrayDim::Fixed(len))) => Ok(format!("byte[{len}]({slice_expr})")),
         ("pubkey", None) | (word::COVENANT_ID, None) => Ok(format!("byte[32]({slice_expr})")),
         ("sig", None) => Ok(format!("byte[65]({slice_expr})")),
         ("datasig", None) => Ok(format!("byte[64]({slice_expr})")),
@@ -2310,7 +2316,7 @@ fn packed_field_len(ty: &TypeRef) -> Result<usize> {
     match (ty.name.as_str(), ty.array) {
         ("int", None) => Ok(8),
         ("bool", None) | ("byte", None) => Ok(1),
-        ("byte", Some(len)) => Ok(len),
+        ("byte", Some(ArrayDim::Fixed(len))) => Ok(len),
         ("pubkey", None) | (word::COVENANT_ID, None) => Ok(32),
         ("sig", None) => Ok(65),
         ("datasig", None) => Ok(64),
@@ -5305,12 +5311,13 @@ fn placeholder_expr_for_type<'i>(ty: &TypeRef) -> Result<SilExpr<'i>> {
         return Ok(zero_byte_array_expr(32));
     }
     match (&ty.name[..], ty.array) {
-        ("byte", Some(len)) => Ok(zero_byte_array_expr(len)),
-        (_, Some(len)) => {
+        ("byte", Some(ArrayDim::Fixed(len))) => Ok(zero_byte_array_expr(len)),
+        (_, Some(ArrayDim::Fixed(len))) => {
             let item = TypeRef::new(ty.name.clone());
             let values = (0..len).map(|_| placeholder_expr_for_type(&item)).collect::<Result<Vec<_>>>()?;
             Ok(values.into())
         }
+        (_, Some(ArrayDim::Dynamic)) => Err(ArgentError::new("dynamic arrays are not supported in actor state")),
         ("int", None) => Ok(SilExpr::int(0)),
         ("bool", None) => Ok(SilExpr::bool(false)),
         ("byte", None) => Ok(SilExpr::byte(0)),
@@ -5957,13 +5964,19 @@ fn type_artifact(ty: &TypeRef, model: &Model<'_>) -> TypeArtifact {
         TypeArtifact::FixedBytes { len: 32 }
     } else if ty.name == word::COVENANT_ID {
         match ty.array {
-            Some(len) => TypeArtifact::FixedArray { item: Box::new(TypeArtifact::FixedBytes { len: 32 }), len },
+            Some(ArrayDim::Fixed(len)) => TypeArtifact::FixedArray { item: Box::new(TypeArtifact::FixedBytes { len: 32 }), len },
+            Some(ArrayDim::Dynamic) => TypeArtifact::dynamic_array(TypeArtifact::FixedBytes { len: 32 }),
             None => TypeArtifact::FixedBytes { len: 32 },
         }
     } else if model.is_actor_enum_type(ty) {
         TypeArtifact::Int
     } else {
-        TypeArtifact::from_parts(&ty.name, ty.array)
+        match ty.array {
+            Some(ArrayDim::Dynamic) if ty.name == "byte" => TypeArtifact::Bytes,
+            Some(ArrayDim::Dynamic) => TypeArtifact::dynamic_array(TypeArtifact::from_parts(&ty.name, None)),
+            Some(ArrayDim::Fixed(len)) => TypeArtifact::from_parts(&ty.name, Some(len)),
+            None => TypeArtifact::from_parts(&ty.name, None),
+        }
     }
 }
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1950,32 +1950,6 @@ fn emit_entry(out: &mut String, actor: &ActorDecl, entry: &EntryDecl, model: &Mo
     }
     push_entry_signature(out, &entry.name, &sil_params);
 
-    let has_byte_witnesses =
-        witness_specs.templates.iter().any(|spec| spec.form == TemplateWitnessForm::Bytes) || !witness_specs.selectors.is_empty();
-    if has_byte_witnesses {
-        out.push_str("        // :: witness lens\n");
-        for spec in &witness_specs.templates {
-            if spec.form != TemplateWitnessForm::Bytes {
-                continue;
-            }
-            let prefix = hidden_witness_prefix_name(&spec.actor);
-            let suffix = hidden_witness_suffix_name(&spec.actor);
-            let prefix_len = hidden_witness_prefix_len_name(&spec.actor);
-            let suffix_len = hidden_witness_suffix_len_name(&spec.actor);
-            out.push_str(&format!("        int {prefix_len} = {prefix}.length;\n"));
-            out.push_str(&format!("        int {suffix_len} = {suffix}.length;\n"));
-        }
-        for spec in &witness_specs.selectors {
-            let prefix = hidden_template_selector_prefix_name(&spec.name);
-            let suffix = hidden_template_selector_suffix_name(&spec.name);
-            let prefix_len = hidden_template_selector_prefix_len_name(&spec.name);
-            let suffix_len = hidden_template_selector_suffix_len_name(&spec.name);
-            out.push_str(&format!("        int {prefix_len} = {prefix}.length;\n"));
-            out.push_str(&format!("        int {suffix_len} = {suffix}.length;\n"));
-        }
-        out.push('\n');
-    }
-
     if emit_entry_template_locals(out, actor, &witness_specs, model) {
         out.push('\n');
     }
@@ -6821,14 +6795,6 @@ fn hidden_template_selector_prefix_name(selector: &str) -> String {
 
 fn hidden_template_selector_suffix_name(selector: &str) -> String {
     format!("{RESERVED_GENERATED_PREFIX}{selector}_suffix")
-}
-
-fn hidden_template_selector_prefix_len_name(selector: &str) -> String {
-    format!("{RESERVED_GENERATED_PREFIX}{selector}_prefix_len")
-}
-
-fn hidden_template_selector_suffix_len_name(selector: &str) -> String {
-    format!("{RESERVED_GENERATED_PREFIX}{selector}_suffix_len")
 }
 
 fn hidden_template_selector_index_name(selector: &str) -> String {

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1851,19 +1851,27 @@ fn emit_state_layouts(
         }
         let state = model.storage_state(&state_name)?;
         out.push_str(&format!("    struct {state_name} {{\n"));
-        out.push_str("        // :: generated fields\n");
-        emit_hidden_template_fields(out, state_name.as_str(), model, 8);
-        out.push_str("\n        // :: user declared fields\n");
-        for field in &state.fields {
-            out.push_str(&format!("        {} {};\n", lower_type_ref(&field.ty, model), field.name));
+        let mut generated_fields = String::new();
+        emit_hidden_template_fields(&mut generated_fields, state_name.as_str(), model, 8);
+        if !generated_fields.is_empty() {
+            out.push_str("        // :: generated fields\n");
+            out.push_str(&generated_fields);
+        }
+        if !state.fields.is_empty() {
+            out.push_str("        // :: user declared fields\n");
+            for field in &state.fields {
+                out.push_str(&format!("        {} {};\n", lower_type_ref(&field.ty, model), field.name));
+            }
         }
         out.push_str("    }\n");
 
         if required_state_bodies.contains(&state_name) {
             out.push_str(&format!("    struct {} {{\n", hidden_state_body_type_name(&state_name)));
-            out.push_str("        // :: user declared fields\n");
-            for field in &state.fields {
-                out.push_str(&format!("        {} {};\n", lower_type_ref(&field.ty, model), field.name));
+            if !state.fields.is_empty() {
+                out.push_str("        // :: user declared fields\n");
+                for field in &state.fields {
+                    out.push_str(&format!("        {} {};\n", lower_type_ref(&field.ty, model), field.name));
+                }
             }
             out.push_str("    }\n");
         }
@@ -1893,11 +1901,17 @@ fn emit_state_layouts(
         }
         let state = model.storage_state(&actor.state)?;
         out.push_str(&format!("    struct {} {{\n", hidden_actor_state_type_name(&actor.name)));
-        out.push_str("        // :: generated fields\n");
-        emit_hidden_template_fields_for_actor(out, &actor.name, model, 8);
-        out.push_str("\n        // :: user declared fields\n");
-        for field in &state.fields {
-            out.push_str(&format!("        {} {};\n", lower_type_ref(&field.ty, model), field.name));
+        let mut generated_fields = String::new();
+        emit_hidden_template_fields_for_actor(&mut generated_fields, &actor.name, model, 8);
+        if !generated_fields.is_empty() {
+            out.push_str("        // :: generated fields\n");
+            out.push_str(&generated_fields);
+        }
+        if !state.fields.is_empty() {
+            out.push_str("        // :: user declared fields\n");
+            for field in &state.fields {
+                out.push_str(&format!("        {} {};\n", lower_type_ref(&field.ty, model), field.name));
+            }
         }
         out.push_str("    }\n");
     }
@@ -3452,12 +3466,17 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         }
         let mut out = String::new();
         out.push_str("{\n");
-        out.push_str(&format!("{field_indent}// :: generated fields\n"));
+        if !generated_fields.is_empty() {
+            out.push_str(&format!("{field_indent}// :: generated fields\n"));
+        }
         for (field, expr) in generated_fields {
             out.push_str(&format!("{field_indent}{field}: {expr},\n"));
         }
-        out.push_str(&format!("\n{field_indent}// :: user declared fields\n"));
-        for field in &self.model.storage_state(state_name)?.fields {
+        let state = self.model.storage_state(state_name)?;
+        if !state.fields.is_empty() {
+            out.push_str(&format!("{field_indent}// :: user declared fields\n"));
+        }
+        for field in &state.fields {
             let expr = if let Some(expr) = pending.remove(&field.name) {
                 expr
             } else if field.virtual_slot {
@@ -3507,11 +3526,15 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let close_indent = " ".repeat(indent);
         let mut out = String::new();
         out.push_str("{\n");
-        out.push_str(&format!("{field_indent}// :: generated fields\n"));
+        if !generated_fields.is_empty() {
+            out.push_str(&format!("{field_indent}// :: generated fields\n"));
+        }
         for (field, expr) in generated_fields {
             out.push_str(&format!("{field_indent}{field}: {expr},\n"));
         }
-        out.push_str(&format!("\n{field_indent}// :: user declared fields\n"));
+        if !storage_state.fields.is_empty() {
+            out.push_str(&format!("{field_indent}// :: user declared fields\n"));
+        }
 
         for field in &storage_state.fields {
             if let Some(digest) = expansion.digests.iter().find(|digest| digest.field == field.name) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -409,6 +409,9 @@ impl Parser {
             self.expect_symbol('>')?;
             Ok(TypeRef::actor_type(state))
         } else if self.consume_symbol('[') {
+            if self.consume_symbol(']') {
+                return Ok(TypeRef::dynamic_array(name));
+            }
             let len = self.expect_number()?.parse::<usize>().map_err(|_| self.error("invalid array length"))?;
             self.expect_symbol(']')?;
             Ok(TypeRef::array(name, len))

--- a/tests/fixtures/emit/capsule_route_context/ReserveAsset.sil
+++ b/tests/fixtures/emit/capsule_route_context/ReserveAsset.sil
@@ -57,10 +57,6 @@ contract ReserveAsset(
         byte[] gen__wallet_asset_suffix,
         byte[8] gen__policy_reserve_policy_preimage
     ) {
-        // :: witness lens
-        int gen__wallet_asset_prefix_len = gen__wallet_asset_prefix.length;
-        int gen__wallet_asset_suffix_len = gen__wallet_asset_suffix.length;
-
         // :: expanded state
         require(blake2b(gen__policy_reserve_policy_preimage) == policy);
         int gen__policy_nonce = OpBin2Num(gen__policy_reserve_policy_preimage.slice(0, 8));

--- a/tests/fixtures/emit/capsule_route_context/ReserveAsset.sil
+++ b/tests/fixtures/emit/capsule_route_context/ReserveAsset.sil
@@ -40,7 +40,6 @@ contract ReserveAsset(
             // :: generated fields
             gen__reserve_asset_template: gen__reserve_asset_template,
             gen__wallet_asset_template: gen__wallet_asset_template,
-
             // :: user declared fields
             owner_kind: owner_kind,
             owner_id: owner_id,
@@ -77,7 +76,6 @@ contract ReserveAsset(
             // :: generated fields
             gen__reserve_asset_template: gen__reserve_asset_template,
             gen__wallet_asset_template: gen__wallet_asset_template,
-
             // :: user declared fields
             owner_kind: owner_kind,
             owner_id: owner_id,

--- a/tests/fixtures/emit/input_template_route_reuse/Controller.sil
+++ b/tests/fixtures/emit/input_template_route_reuse/Controller.sil
@@ -8,8 +8,6 @@ contract Controller(
 ) {
     // :: state layouts
     struct PeerState {
-        // :: generated fields
-
         // :: user declared fields
         int count;
     }
@@ -40,8 +38,6 @@ contract Controller(
         int gen__peer_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output peer: Peer
 
         PeerState next_peer = {
-            // :: generated fields
-
             // :: user declared fields
             count: peer.count + 1,
         };

--- a/tests/fixtures/emit/observed_template_witnesses/Local.sil
+++ b/tests/fixtures/emit/observed_template_witnesses/Local.sil
@@ -8,8 +8,6 @@ contract Local(
 ) {
     // :: state layouts
     struct ForeignState {
-        // :: generated fields
-
         // :: user declared fields
         int count;
     }
@@ -43,8 +41,6 @@ contract Local(
 
         ForeignState prev = gen__asset_src_state;
         ForeignState next = {
-            // :: generated fields
-
             // :: user declared fields
             count: prev.count + 1,
         };

--- a/tests/fixtures/emit/open_observed_actor_binding/Cell.sil
+++ b/tests/fixtures/emit/open_observed_actor_binding/Cell.sil
@@ -9,8 +9,6 @@ contract Cell(
 ) {
     // :: state layouts
     struct AgentCapsule {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] controller_id;
         byte[32] caps_digest;
@@ -55,8 +53,6 @@ contract Cell(
         require(agent_type == observed_agent);
         require(prev_state.controller_id == OpInputCovenantId(this.activeInputIndex));
         AgentCapsule next_state = {
-            // :: generated fields
-
             // :: user declared fields
             controller_id: prev_state.controller_id,
             caps_digest: prev_state.caps_digest,
@@ -72,8 +68,6 @@ contract Cell(
             observed_agent
         );
         State next_cell = {
-            // :: generated fields
-
             // :: user declared fields
             agent_covid: agent_covid,
             agent_type: agent_type,

--- a/tests/fixtures/emit/open_observed_state_handle/Cell.sil
+++ b/tests/fixtures/emit/open_observed_state_handle/Cell.sil
@@ -9,8 +9,6 @@ contract Cell(
 ) {
     // :: state layouts
     struct AgentCapsule {
-        // :: generated fields
-
         // :: user declared fields
         byte[32] controller_id;
         byte[32] caps_digest;
@@ -52,8 +50,6 @@ contract Cell(
         AgentCapsule prev_state = gen__remote_agent_state;
         require(prev_state.controller_id == OpInputCovenantId(this.activeInputIndex));
         AgentCapsule next_state = {
-            // :: generated fields
-
             // :: user declared fields
             controller_id: prev_state.controller_id,
             caps_digest: prev_state.caps_digest,
@@ -69,8 +65,6 @@ contract Cell(
             agent_type
         );
         State next_cell = {
-            // :: generated fields
-
             // :: user declared fields
             agent_covid: agent_covid,
             agent_type: agent_type,

--- a/tests/fixtures/emit/state_expansion/Forager.sil
+++ b/tests/fixtures/emit/state_expansion/Forager.sil
@@ -27,8 +27,6 @@ contract Forager(
 
         require(energy > 0);
         State next_state = {
-            // :: generated fields
-
             // :: user declared fields
             strategy: blake2b(byte[8](gen__strategy_hunger + 1)),
             energy: energy - 1,

--- a/tests/fixtures/runtime/context_genesis_spawn/Controller.sil
+++ b/tests/fixtures/runtime/context_genesis_spawn/Controller.sil
@@ -8,8 +8,6 @@ contract Controller(
 ) {
     // :: state layouts
     struct PairState {
-        // :: generated fields
-
         // :: user declared fields
         int value;
     }
@@ -54,20 +52,14 @@ contract Controller(
         require(OpOutputCovenantId(gen__new_pair_left_output_idx) == pair_id);
 
         PairState left = {
-            // :: generated fields
-
             // :: user declared fields
             value: left_value,
         };
         PairState right = {
-            // :: generated fields
-
             // :: user declared fields
             value: right_value,
         };
         State next = {
-            // :: generated fields
-
             // :: user declared fields
             pair_type: pair_type,
             launches: launches + 1,

--- a/tests/fixtures/runtime/context_multiple_genesis_spawns/Controller.sil
+++ b/tests/fixtures/runtime/context_multiple_genesis_spawns/Controller.sil
@@ -8,8 +8,6 @@ contract Controller(
 ) {
     // :: state layouts
     struct PairState {
-        // :: generated fields
-
         // :: user declared fields
         int value;
     }
@@ -89,38 +87,26 @@ contract Controller(
         require(OpOutputCovenantId(gen__third_pair_left_output_idx) == third_pair_id);
 
         PairState first_left = {
-            // :: generated fields
-
             // :: user declared fields
             value: first_left_value,
         };
         PairState first_right = {
-            // :: generated fields
-
             // :: user declared fields
             value: first_right_value,
         };
         PairState second = {
-            // :: generated fields
-
             // :: user declared fields
             value: second_value,
         };
         PairState third_left = {
-            // :: generated fields
-
             // :: user declared fields
             value: third_left_value,
         };
         PairState third_right = {
-            // :: generated fields
-
             // :: user declared fields
             value: third_right_value,
         };
         State next = {
-            // :: generated fields
-
             // :: user declared fields
             pair_type: pair_type,
             launches: launches + 3,

--- a/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
+++ b/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
@@ -12,7 +12,6 @@ contract Child(
         // :: generated fields
         byte[32] gen__child_template;
         byte[32] gen__launcher_template;
-
         // :: user declared fields
         int launches;
     }
@@ -42,7 +41,6 @@ contract Child(
             // :: generated fields
             gen__child_template: gen__child_template,
             gen__launcher_template: gen__launcher_template,
-
             // :: user declared fields
             launches: 0,
         };

--- a/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
+++ b/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
@@ -29,10 +29,6 @@ contract Child(
         byte[] gen__launcher_prefix,
         byte[] gen__launcher_suffix
     ) {
-        // :: witness lens
-        int gen__launcher_prefix_len = gen__launcher_prefix.length;
-        int gen__launcher_suffix_len = gen__launcher_suffix.length;
-
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Launcher

--- a/tests/fixtures/runtime/context_static_actor_spawn/Launcher.sil
+++ b/tests/fixtures/runtime/context_static_actor_spawn/Launcher.sil
@@ -12,7 +12,6 @@ contract Launcher(
         // :: generated fields
         byte[32] gen__child_template;
         byte[32] gen__launcher_template;
-
         // :: user declared fields
         int value;
     }
@@ -53,7 +52,6 @@ contract Launcher(
             // :: generated fields
             gen__child_template: gen__child_template,
             gen__launcher_template: gen__launcher_template,
-
             // :: user declared fields
             value: value,
         };
@@ -61,7 +59,6 @@ contract Launcher(
             // :: generated fields
             gen__child_template: gen__child_template,
             gen__launcher_template: gen__launcher_template,
-
             // :: user declared fields
             launches: launches + 1,
         };


### PR DESCRIPTION
Argent now accepts SilverScript-style `byte[]` parameters and represents dynamic array dimensions explicitly. A runtime test executes varying payload lengths across push-data boundaries and verifies exact contents.

Generated SIL now omits empty field-region labels, extra spacing, and unused witness-length locals. Full Argent and playground checks pass.