### PR TITLE
Improve developer experience and add artifact inspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "argent-artifact",
  "argent-runtime",
  "blake2b_simd",
+ "colored",
  "kaspa-consensus-core",
  "kaspa-txscript",
  "kaspa-txscript-errors",
@@ -842,6 +843,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "concurrent-queue"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,13 @@ path = "src/main.rs"
 argent-artifact = { workspace = true }
 argent-runtime = { workspace = true }
 blake2b_simd = { workspace = true }
+kaspa-consensus-core = { workspace = true }
+kaspa-txscript = { workspace = true }
 serde_json = { workspace = true }
 silverscript-abi = { workspace = true }
 silverscript-lang = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-kaspa-consensus-core = { workspace = true }
-kaspa-txscript = { workspace = true }
 kaspa-txscript-errors = { workspace = true }
 secp256k1 = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ resolver = "3"
 argent-artifact = { path = "crates/argent-artifact" }
 argent-runtime = { path = "crates/argent-runtime" }
 blake2b_simd = "1.0.2"
+colored = "2.2.0"
 faster-hex = "0.10"
 kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa", tag = "v2.0.1" }
 kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa", tag = "v2.0.1" }
@@ -37,6 +38,7 @@ path = "src/main.rs"
 argent-artifact = { workspace = true }
 argent-runtime = { workspace = true }
 blake2b_simd = { workspace = true }
+colored = { workspace = true }
 kaspa-consensus-core = { workspace = true }
 kaspa-txscript = { workspace = true }
 serde_json = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Generated outputs include:
 - `manifest.json`: build metadata
 - `sil/*.sil`: generated Silverscript contracts
 
+Inspect the compiled artifact without rebuilding it:
+
+```sh
+cargo run --bin argentc -- inspect examples/build/tickets
+```
+
+The report summarizes actor script, state, and template sizes, static opcode
+counts, entry arguments and generated witnesses, route metadata, and
+signature-script size estimates.
+
 Generated `.sil` files compile as ordinary Silverscript. Argent does not use
 Silverscript covenant macros.
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -955,7 +955,7 @@ impl<'a> Model<'a> {
         }
         if entry.terminal_route_sets.is_empty() {
             return Err(ArgentError::new(format!(
-                "entry `{}::{}` declares {} outputs but has no terminal `become` route",
+                "entry `{}::{}` declares {} emit outputs but has no terminal `become` route",
                 actor.name,
                 entry.name,
                 outputs.len()

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,25 +1,53 @@
 use std::fmt;
 use std::path::PathBuf;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceLocation {
+    pub line: usize,
+    pub column: usize,
+    pub byte_offset: usize,
+}
+
 #[derive(Debug)]
 pub struct ArgentError {
     pub path: Option<PathBuf>,
+    pub location: Option<SourceLocation>,
     pub message: String,
 }
 
 impl ArgentError {
     pub fn new(message: impl Into<String>) -> Self {
-        Self { path: None, message: message.into() }
+        Self { path: None, location: None, message: message.into() }
     }
 
     pub fn at(path: impl Into<PathBuf>, message: impl Into<String>) -> Self {
-        Self { path: Some(path.into()), message: message.into() }
+        Self { path: Some(path.into()), location: None, message: message.into() }
+    }
+
+    pub fn in_source(source: &str, byte_offset: usize, message: impl Into<String>) -> Self {
+        Self { path: None, location: Some(source_location(source, byte_offset)), message: message.into() }
+    }
+
+    pub fn at_source(path: impl Into<PathBuf>, source: &str, byte_offset: usize, message: impl Into<String>) -> Self {
+        Self { path: Some(path.into()), location: Some(source_location(source, byte_offset)), message: message.into() }
+    }
+
+    pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
     }
 }
 
 impl fmt::Display for ArgentError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(path) = &self.path { write!(f, "{}: {}", path.display(), self.message) } else { f.write_str(&self.message) }
+        match (&self.path, self.location) {
+            (Some(path), Some(location)) => {
+                write!(f, "{}:{}:{}: {}", path.display(), location.line, location.column, self.message)
+            }
+            (Some(path), None) => write!(f, "{}: {}", path.display(), self.message),
+            (None, Some(location)) => write!(f, "{}:{}: {}", location.line, location.column, self.message),
+            (None, None) => f.write_str(&self.message),
+        }
     }
 }
 
@@ -32,3 +60,29 @@ impl From<std::io::Error> for ArgentError {
 }
 
 pub type Result<T> = std::result::Result<T, ArgentError>;
+
+fn source_location(source: &str, byte_offset: usize) -> SourceLocation {
+    let mut byte_offset = byte_offset.min(source.len());
+    while !source.is_char_boundary(byte_offset) {
+        byte_offset -= 1;
+    }
+
+    let prefix = &source[..byte_offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let column = prefix.rsplit('\n').next().unwrap_or_default().chars().count() + 1;
+    SourceLocation { line, column, byte_offset }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ArgentError;
+
+    #[test]
+    fn displays_path_line_and_character_column() {
+        let err = ArgentError::at_source("demo.ag", "state Café {}\n/", "state Café {}\n".len(), "unexpected token");
+
+        assert_eq!(err.to_string(), "demo.ag:2:1: unexpected token");
+        let location = err.location.expect("source location");
+        assert_eq!(location.byte_offset, 15);
+    }
+}

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,0 +1,643 @@
+use std::collections::BTreeSet;
+use std::fmt::Write;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
+use kaspa_consensus_core::tx::PopulatedTransaction;
+use kaspa_txscript::parse_script;
+use kaspa_txscript::script_builder::ScriptBuilder;
+
+use crate::artifact::{
+    Artifact, CompiledTemplateArtifact, EntryArtifact, EntryKindArtifact, HiddenParamArtifact, HiddenParamPurposeArtifact,
+    HiddenParamSubjectArtifact, ParamArtifact, SilContractArtifact, SilEntryArtifact, TypeArtifact,
+};
+use crate::codec::decode_hex;
+use crate::{ArgentError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SizeEstimate {
+    pub min: usize,
+    pub max: Option<usize>,
+}
+
+impl SizeEstimate {
+    fn exact(size: usize) -> Self {
+        Self { min: size, max: Some(size) }
+    }
+
+    fn range(min: usize, max: usize) -> Self {
+        Self { min, max: Some(max) }
+    }
+
+    fn variable(min: usize) -> Self {
+        Self { min, max: None }
+    }
+
+    fn plus(self, other: Self) -> Self {
+        Self {
+            min: self.min.saturating_add(other.min),
+            max: self.max.zip(other.max).and_then(|(left, right)| left.checked_add(right)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InspectionReport {
+    pub app: String,
+    pub artifact_id: String,
+    pub actors: Vec<ActorInspection>,
+    pub route_families: usize,
+    pub route_tables: usize,
+    pub route_proofs: usize,
+    pub witness_recipes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActorInspection {
+    pub name: String,
+    pub script_bytes: usize,
+    pub state_bytes: usize,
+    pub template_bytes: usize,
+    pub opcode_count: usize,
+    pub entries: Vec<EntryInspection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryInspection {
+    pub actor: String,
+    pub name: String,
+    pub kind: EntryKindArtifact,
+    pub arguments: Vec<String>,
+    pub generated_arguments: Vec<String>,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+    pub routes: Vec<String>,
+    pub signature_script_bytes: SizeEstimate,
+}
+
+pub fn inspect_path(input: impl AsRef<Path>) -> Result<InspectionReport> {
+    let artifact_path = artifact_path(input.as_ref());
+    let json = fs::read_to_string(&artifact_path).map_err(|err| ArgentError::at(&artifact_path, err.to_string()))?;
+    let artifact =
+        serde_json::from_str::<Artifact>(&json).map_err(|err| ArgentError::at(&artifact_path, format!("invalid artifact: {err}")))?;
+    inspect_artifact(&artifact).map_err(|err| if err.path.is_none() { ArgentError::at(&artifact_path, err.message) } else { err })
+}
+
+pub fn inspect_artifact(artifact: &Artifact) -> Result<InspectionReport> {
+    artifact.check_schema_version().map_err(|err| ArgentError::new(format!("unsupported artifact: {err}")))?;
+    artifact.verify_id().map_err(|err| ArgentError::new(format!("invalid artifact identity: {err}")))?;
+    artifact.verify_template_plan().map_err(|err| ArgentError::new(format!("invalid artifact template plan: {err}")))?;
+
+    let mut actors = Vec::with_capacity(artifact.argent.actors.len());
+    for actor in &artifact.argent.actors {
+        let contract = artifact.sil_abi.contract(&actor.abi.actor).ok_or_else(|| {
+            ArgentError::new(format!("actor `{}` references missing ABI contract `{}`", actor.name, actor.abi.actor))
+        })?;
+        let script = decode_hex(&contract.compiled.script_hex)
+            .map_err(|err| ArgentError::new(format!("actor `{}` has invalid compiled script hex: {err}", actor.name)))?;
+        let template_prefix = decode_hex(&contract.compiled.template.prefix_hex)
+            .map_err(|err| ArgentError::new(format!("actor `{}` has invalid template prefix hex: {err}", actor.name)))?;
+        let template_suffix = decode_hex(&contract.compiled.template.suffix_hex)
+            .map_err(|err| ArgentError::new(format!("actor `{}` has invalid template suffix hex: {err}", actor.name)))?;
+        let opcode_count = opcode_count(&actor.name, &script)?;
+
+        let mut entries = Vec::with_capacity(actor.entries.len());
+        for entry in &actor.entries {
+            let sil_entry = contract.entry(&entry.abi.entry).ok_or_else(|| {
+                ArgentError::new(format!(
+                    "entry `{}::{}` references missing ABI entry `{}::{}`",
+                    actor.name, entry.name, entry.abi.actor, entry.abi.entry
+                ))
+            })?;
+            entries.push(inspect_entry(artifact, &actor.name, contract, entry, sil_entry, &script)?);
+        }
+
+        actors.push(ActorInspection {
+            name: actor.name.clone(),
+            script_bytes: script.len(),
+            state_bytes: contract.compiled.state_span.len,
+            template_bytes: template_prefix.len() + template_suffix.len(),
+            opcode_count,
+            entries,
+        });
+    }
+
+    let template_plan = &artifact.argent.template_plan;
+    Ok(InspectionReport {
+        app: artifact.app.clone(),
+        artifact_id: artifact.id.clone(),
+        actors,
+        route_families: template_plan.route_families.len(),
+        route_tables: template_plan.route_tables.len(),
+        route_proofs: template_plan.route_proofs.len(),
+        witness_recipes: template_plan.witness_recipes.len(),
+    })
+}
+
+pub fn render_report(report: &InspectionReport) -> String {
+    let mut out = String::new();
+    writeln!(out, "App {}", report.app).unwrap();
+    writeln!(out, "Artifact {}", report.artifact_id).unwrap();
+    out.push('\n');
+    out.push_str("Actors\n");
+
+    let actor_width = report.actors.iter().map(|actor| actor.name.len()).max().unwrap_or(5).max(5);
+    writeln!(
+        out,
+        "  {:<actor_width$}  {:>10}  {:>10}  {:>10}  {:>9}  {:>7}",
+        "Actor", "Script", "State", "Template", "Opcodes", "Entries"
+    )
+    .unwrap();
+    for actor in &report.actors {
+        writeln!(
+            out,
+            "  {:<actor_width$}  {:>8} B  {:>8} B  {:>8} B  {:>9}  {:>7}",
+            actor.name,
+            actor.script_bytes,
+            actor.state_bytes,
+            actor.template_bytes,
+            actor.opcode_count,
+            actor.entries.len()
+        )
+        .unwrap();
+    }
+
+    let entries = report.actors.iter().flat_map(|actor| &actor.entries).collect::<Vec<_>>();
+    if !entries.is_empty() {
+        out.push('\n');
+        out.push_str("Entries\n");
+        for entry in entries {
+            writeln!(out, "  {}::{} [{}]", entry.actor, entry.name, entry_kind_label(entry.kind)).unwrap();
+            writeln!(out, "    arguments: {}", list_or_none(&entry.arguments)).unwrap();
+            writeln!(out, "    generated arguments: {}", list_or_none(&entry.generated_arguments)).unwrap();
+            writeln!(out, "    inputs: {}", list_or_none(&entry.inputs)).unwrap();
+            writeln!(out, "    outputs: {}", list_or_none(&entry.outputs)).unwrap();
+            writeln!(out, "    routes: {}", list_or_none(&entry.routes)).unwrap();
+            writeln!(out, "    signature script: {}", size_estimate_label(entry.signature_script_bytes)).unwrap();
+        }
+    }
+
+    out.push('\n');
+    out.push_str("Route metadata\n");
+    writeln!(out, "  families: {}", report.route_families).unwrap();
+    writeln!(out, "  tables: {}", report.route_tables).unwrap();
+    writeln!(out, "  proofs: {}", report.route_proofs).unwrap();
+    writeln!(out, "  witness recipes: {}", report.witness_recipes).unwrap();
+    out
+}
+
+fn artifact_path(input: &Path) -> PathBuf {
+    if input.is_dir() { input.join("artifact.json") } else { input.to_path_buf() }
+}
+
+fn opcode_count(actor: &str, script: &[u8]) -> Result<usize> {
+    let mut count = 0;
+    for opcode in parse_script::<PopulatedTransaction<'_>, SigHashReusedValuesUnsync>(script) {
+        opcode.map_err(|err| ArgentError::new(format!("actor `{actor}` contains invalid compiled script: {err}")))?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+fn inspect_entry(
+    artifact: &Artifact,
+    actor: &str,
+    contract: &SilContractArtifact,
+    entry: &EntryArtifact,
+    sil_entry: &SilEntryArtifact,
+    script: &[u8],
+) -> Result<EntryInspection> {
+    let hidden_names = entry.hidden_params.iter().map(|hidden| hidden.name.as_str()).collect::<BTreeSet<_>>();
+    let arguments = sil_entry.params.iter().filter(|param| !hidden_names.contains(param.name.as_str())).map(param_label).collect();
+    let generated_arguments = entry
+        .hidden_params
+        .iter()
+        .map(|hidden| format!("{}: {} ({})", hidden.name, type_label(&hidden.ty), hidden_purpose_label(hidden.purpose)))
+        .collect();
+
+    let mut inputs = Vec::new();
+    if let Some(active) = &entry.route_plan.active_input {
+        inputs.push(format!("{}: {}", active.name, active.actor));
+    }
+    inputs.extend(entry.route_plan.consumes.iter().map(|input| format!("{}: {}", input.name, input.actor)));
+
+    let outputs = entry
+        .route_plan
+        .outputs
+        .iter()
+        .map(|output| {
+            let name = output.name.as_deref().unwrap_or("next");
+            format!("{name} -> {}", output.actors.join(" | "))
+        })
+        .collect();
+    let routes =
+        entry.routes.iter().map(|route| format!("{} -> {}", route.output.as_deref().unwrap_or("next"), route.actor)).collect();
+
+    let mut signature_script_bytes = SizeEstimate::exact(ScriptBuilder::canonical_data_size(script));
+    for param in &sil_entry.params {
+        let estimate = if let Some(hidden) = entry.hidden_params.iter().find(|hidden| hidden.name == param.name) {
+            hidden_param_size(artifact, entry, hidden)?.unwrap_or_else(|| type_size(artifact, contract, &param.ty))
+        } else {
+            type_size(artifact, contract, &param.ty)
+        };
+        signature_script_bytes = signature_script_bytes.plus(estimate);
+    }
+    if let Some(selector) = sil_entry.selector {
+        signature_script_bytes = signature_script_bytes.plus(SizeEstimate::exact(integer_size(selector)?));
+    }
+
+    Ok(EntryInspection {
+        actor: actor.to_string(),
+        name: entry.name.clone(),
+        kind: entry.kind,
+        arguments,
+        generated_arguments,
+        inputs,
+        outputs,
+        routes,
+        signature_script_bytes,
+    })
+}
+
+fn hidden_param_size(artifact: &Artifact, entry: &EntryArtifact, hidden: &HiddenParamArtifact) -> Result<Option<SizeEstimate>> {
+    match hidden.purpose {
+        HiddenParamPurposeArtifact::TemplatePrefixBytes => {
+            estimate_template_parts(artifact, entry, hidden, |template| &template.prefix_hex)
+        }
+        HiddenParamPurposeArtifact::TemplateSuffixBytes => {
+            estimate_template_parts(artifact, entry, hidden, |template| &template.suffix_hex)
+        }
+        HiddenParamPurposeArtifact::TemplatePrefixLen => {
+            estimate_template_lengths(artifact, entry, hidden, |template| &template.prefix_hex)
+        }
+        HiddenParamPurposeArtifact::TemplateSuffixLen => {
+            estimate_template_lengths(artifact, entry, hidden, |template| &template.suffix_hex)
+        }
+        HiddenParamPurposeArtifact::TemplateHash | HiddenParamPurposeArtifact::RouteTemplateLeaf => {
+            Ok(Some(SizeEstimate::exact(ScriptBuilder::canonical_data_size(&[0; 32]))))
+        }
+        HiddenParamPurposeArtifact::RouteTemplateProof => {
+            let Some(proof_id) = hidden.route_proof_id.as_deref() else {
+                return Ok(None);
+            };
+            let Some(actor) = concrete_subject_actor(&hidden.subject) else {
+                return Ok(None);
+            };
+            let Some(proof) = artifact.argent.template_plan.route_proofs.iter().find(|proof| proof.id == proof_id) else {
+                return Ok(None);
+            };
+            let Some(leaf) = proof.leaves.iter().find(|leaf| {
+                matches!(&leaf.leaf, crate::artifact::RouteTemplateLeafArtifact::Template { actor: leaf_actor, .. } if leaf_actor == actor)
+            }) else {
+                return Ok(None);
+            };
+            Ok(Some(pushed_payload_size(leaf.proof.len().saturating_mul(32))))
+        }
+        HiddenParamPurposeArtifact::RouteFamilyTable => {
+            let HiddenParamSubjectArtifact::RouteFamily { family_id } = &hidden.subject else {
+                return Ok(None);
+            };
+            let Some(family) = artifact.argent.template_plan.route_families.iter().find(|family| family.id == *family_id) else {
+                return Ok(None);
+            };
+            let Some(table) = artifact.argent.template_plan.route_tables.iter().find(|table| table.id == family.table_id) else {
+                return Ok(None);
+            };
+            Ok(Some(pushed_payload_size(table.byte_len)))
+        }
+        HiddenParamPurposeArtifact::RouteFamilyProof => {
+            let HiddenParamSubjectArtifact::RouteFamily { family_id } = &hidden.subject else {
+                return Ok(None);
+            };
+            let Some(proof_id) = hidden.route_proof_id.as_deref() else {
+                return Ok(None);
+            };
+            let Some(proof) = artifact.argent.template_plan.route_proofs.iter().find(|proof| proof.id == proof_id) else {
+                return Ok(None);
+            };
+            let Some(leaf) = proof.leaves.iter().find(|leaf| {
+                matches!(&leaf.leaf, crate::artifact::RouteTemplateLeafArtifact::RouteFamily {
+                    family_id: leaf_family,
+                    ..
+                } if leaf_family == family_id)
+            }) else {
+                return Ok(None);
+            };
+            Ok(Some(pushed_payload_size(leaf.proof.len().saturating_mul(32))))
+        }
+        HiddenParamPurposeArtifact::StateExpansionPreimage => {
+            let HiddenParamSubjectArtifact::StateExpansion { memory_state, .. } = &hidden.subject else {
+                return Ok(None);
+            };
+            let Some(state) = artifact.sil_abi.states.iter().find(|state| state.name == *memory_state) else {
+                return Ok(None);
+            };
+            let Some(payload_len) = state
+                .fields
+                .iter()
+                .try_fold(0usize, |total, field| fixed_payload_len(&field.ty).and_then(|len| total.checked_add(len)))
+            else {
+                return Ok(None);
+            };
+            Ok(Some(pushed_payload_size(payload_len)))
+        }
+        HiddenParamPurposeArtifact::SpawnOutputIndex | HiddenParamPurposeArtifact::ObservedOutputFieldValue => Ok(None),
+    }
+}
+
+fn estimate_template_parts(
+    artifact: &Artifact,
+    entry: &EntryArtifact,
+    hidden: &HiddenParamArtifact,
+    select: impl Fn(&CompiledTemplateArtifact) -> &String,
+) -> Result<Option<SizeEstimate>> {
+    let templates = hidden_templates(artifact, entry, &hidden.subject);
+    if templates.is_empty() {
+        return Ok(None);
+    }
+    let mut estimates = Vec::with_capacity(templates.len());
+    for template in templates {
+        let bytes = decode_hex(select(template))
+            .map_err(|err| ArgentError::new(format!("generated argument `{}` references invalid template hex: {err}", hidden.name)))?;
+        estimates.push(SizeEstimate::exact(ScriptBuilder::canonical_data_size(&bytes)));
+    }
+    Ok(merge_estimates(&estimates))
+}
+
+fn estimate_template_lengths(
+    artifact: &Artifact,
+    entry: &EntryArtifact,
+    hidden: &HiddenParamArtifact,
+    select: impl Fn(&CompiledTemplateArtifact) -> &String,
+) -> Result<Option<SizeEstimate>> {
+    let templates = hidden_templates(artifact, entry, &hidden.subject);
+    if templates.is_empty() {
+        return Ok(None);
+    }
+    let mut estimates = Vec::with_capacity(templates.len());
+    for template in templates {
+        let bytes = decode_hex(select(template))
+            .map_err(|err| ArgentError::new(format!("generated argument `{}` references invalid template hex: {err}", hidden.name)))?;
+        estimates.push(SizeEstimate::exact(integer_size(bytes.len() as i64)?));
+    }
+    Ok(merge_estimates(&estimates))
+}
+
+fn hidden_templates<'a>(
+    artifact: &'a Artifact,
+    entry: &EntryArtifact,
+    subject: &HiddenParamSubjectArtifact,
+) -> Vec<&'a CompiledTemplateArtifact> {
+    let actors = match subject {
+        HiddenParamSubjectArtifact::Actor { actor }
+        | HiddenParamSubjectArtifact::ObservedActor { actor, .. }
+        | HiddenParamSubjectArtifact::SpawnActor { actor, .. } => vec![actor.as_str()],
+        HiddenParamSubjectArtifact::TemplateSelector { selector } => entry
+            .template_selectors
+            .iter()
+            .find(|candidate| candidate.name == *selector)
+            .map(|selector| {
+                selector
+                    .fixed_actor
+                    .as_deref()
+                    .map_or_else(|| selector.variants.iter().map(String::as_str).collect(), |actor| vec![actor])
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    actors.into_iter().filter_map(|actor| artifact.sil_abi.contract(actor).map(|contract| &contract.compiled.template)).collect()
+}
+
+fn concrete_subject_actor(subject: &HiddenParamSubjectArtifact) -> Option<&str> {
+    match subject {
+        HiddenParamSubjectArtifact::Actor { actor }
+        | HiddenParamSubjectArtifact::ObservedActor { actor, .. }
+        | HiddenParamSubjectArtifact::SpawnActor { actor, .. } => Some(actor),
+        _ => None,
+    }
+}
+
+fn merge_estimates(estimates: &[SizeEstimate]) -> Option<SizeEstimate> {
+    let first = estimates.first()?;
+    let min = estimates.iter().map(|estimate| estimate.min).min().unwrap_or(first.min);
+    let max = estimates.iter().map(|estimate| estimate.max).collect::<Option<Vec<_>>>()?.into_iter().max();
+    Some(SizeEstimate { min, max })
+}
+
+fn type_size(artifact: &Artifact, contract: &SilContractArtifact, ty: &TypeArtifact) -> SizeEstimate {
+    match ty {
+        TypeArtifact::Int => SizeEstimate::range(1, 9),
+        TypeArtifact::Bool => SizeEstimate::exact(1),
+        TypeArtifact::Byte => SizeEstimate::range(1, 2),
+        TypeArtifact::Bytes | TypeArtifact::Text | TypeArtifact::DynamicArray { .. } => SizeEstimate::variable(1),
+        TypeArtifact::Pubkey => pushed_payload_size(32),
+        TypeArtifact::Sig => pushed_payload_size(65),
+        TypeArtifact::Datasig => pushed_payload_size(64),
+        TypeArtifact::FixedBytes { len } => pushed_payload_size(*len),
+        TypeArtifact::FixedArray { item, len } => {
+            if matches!(item.as_ref(), TypeArtifact::Struct { .. }) {
+                SizeEstimate::variable(0)
+            } else if let Some(item_len) = fixed_payload_len(item) {
+                pushed_payload_size(item_len.saturating_mul(*len))
+            } else {
+                SizeEstimate::variable(1)
+            }
+        }
+        TypeArtifact::Struct { name } => {
+            let fields = if name == "State" {
+                contract.runtime_state.fields.iter().map(|field| &field.ty).collect::<Vec<_>>()
+            } else {
+                artifact
+                    .sil_abi
+                    .states
+                    .iter()
+                    .find(|state| state.name == *name)
+                    .map(|state| state.fields.iter().map(|field| &field.ty).collect())
+                    .unwrap_or_default()
+            };
+            if fields.is_empty() {
+                SizeEstimate::variable(0)
+            } else {
+                fields.into_iter().fold(SizeEstimate::exact(0), |total, field| total.plus(type_size(artifact, contract, field)))
+            }
+        }
+    }
+}
+
+fn fixed_payload_len(ty: &TypeArtifact) -> Option<usize> {
+    match ty {
+        TypeArtifact::Int => Some(8),
+        TypeArtifact::Bool | TypeArtifact::Byte => Some(1),
+        TypeArtifact::Pubkey => Some(32),
+        TypeArtifact::Sig => Some(65),
+        TypeArtifact::Datasig => Some(64),
+        TypeArtifact::FixedBytes { len } => Some(*len),
+        TypeArtifact::FixedArray { item, len } => fixed_payload_len(item)?.checked_mul(*len),
+        TypeArtifact::Bytes | TypeArtifact::Text | TypeArtifact::DynamicArray { .. } | TypeArtifact::Struct { .. } => None,
+    }
+}
+
+fn pushed_payload_size(payload_len: usize) -> SizeEstimate {
+    if payload_len == 1 { SizeEstimate::range(1, 2) } else { SizeEstimate::exact(canonical_payload_size(payload_len)) }
+}
+
+fn canonical_payload_size(payload_len: usize) -> usize {
+    payload_len
+        + if payload_len <= 75 {
+            1
+        } else if payload_len <= u8::MAX as usize {
+            2
+        } else if payload_len <= u16::MAX as usize {
+            3
+        } else {
+            5
+        }
+}
+
+fn integer_size(value: i64) -> Result<usize> {
+    let mut builder = ScriptBuilder::new();
+    builder.add_i64(value).map_err(|err| ArgentError::new(format!("cannot size integer argument `{value}`: {err}")))?;
+    Ok(builder.script().len())
+}
+
+fn param_label(param: &ParamArtifact) -> String {
+    format!("{}: {}", param.name, type_label(&param.ty))
+}
+
+fn type_label(ty: &TypeArtifact) -> String {
+    match ty {
+        TypeArtifact::Int => "int".to_string(),
+        TypeArtifact::Bool => "bool".to_string(),
+        TypeArtifact::Byte => "byte".to_string(),
+        TypeArtifact::Bytes => "bytes".to_string(),
+        TypeArtifact::Text => "string".to_string(),
+        TypeArtifact::Pubkey => "pubkey".to_string(),
+        TypeArtifact::Sig => "sig".to_string(),
+        TypeArtifact::Datasig => "datasig".to_string(),
+        TypeArtifact::FixedBytes { len } => format!("byte[{len}]"),
+        TypeArtifact::FixedArray { item, len } => format!("{}[{len}]", type_label(item)),
+        TypeArtifact::DynamicArray { item } => format!("{}[]", type_label(item)),
+        TypeArtifact::Struct { name } => name.clone(),
+    }
+}
+
+fn hidden_purpose_label(purpose: HiddenParamPurposeArtifact) -> &'static str {
+    match purpose {
+        HiddenParamPurposeArtifact::SpawnOutputIndex => "spawn output index",
+        HiddenParamPurposeArtifact::TemplatePrefixBytes => "template prefix bytes",
+        HiddenParamPurposeArtifact::TemplateSuffixBytes => "template suffix bytes",
+        HiddenParamPurposeArtifact::TemplatePrefixLen => "template prefix length",
+        HiddenParamPurposeArtifact::TemplateSuffixLen => "template suffix length",
+        HiddenParamPurposeArtifact::TemplateHash => "template hash",
+        HiddenParamPurposeArtifact::RouteTemplateLeaf => "route template leaf",
+        HiddenParamPurposeArtifact::RouteTemplateProof => "route template proof",
+        HiddenParamPurposeArtifact::RouteFamilyTable => "route family table",
+        HiddenParamPurposeArtifact::RouteFamilyProof => "route family proof",
+        HiddenParamPurposeArtifact::StateExpansionPreimage => "state expansion preimage",
+        HiddenParamPurposeArtifact::ObservedOutputFieldValue => "observed output field",
+    }
+}
+
+fn entry_kind_label(kind: EntryKindArtifact) -> &'static str {
+    match kind {
+        EntryKindArtifact::Leader => "leader",
+        EntryKindArtifact::Delegate => "delegate",
+    }
+}
+
+fn list_or_none(values: &[String]) -> String {
+    if values.is_empty() { "none".to_string() } else { values.join(", ") }
+}
+
+fn size_estimate_label(estimate: SizeEstimate) -> String {
+    match estimate.max {
+        Some(max) if max == estimate.min => format!("{} B", estimate.min),
+        Some(max) => format!("{}-{} B", estimate.min, max),
+        None => format!(">= {} B (variable)", estimate.min),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const INSPECT_APP: &str = r#"
+state EventState {
+    int remaining;
+}
+
+state TicketState {
+    pubkey owner;
+}
+
+actor Event owns EventState {
+    entry buy(pubkey owner) emits {
+        event: Event,
+        ticket: Ticket,
+    } {
+        EventState next_event = {
+            remaining: remaining - 1,
+        };
+        TicketState ticket_state = {
+            owner: owner,
+        };
+        become {
+            event <- Event(next_event),
+            ticket <- Ticket(ticket_state),
+        };
+    }
+}
+
+actor Ticket owns TicketState {
+    entry transfer(pubkey next_owner) emits one Ticket {
+        TicketState next = {
+            owner: next_owner,
+        };
+        become Ticket(next);
+    }
+}
+
+app Show {
+    actor Event;
+    actor Ticket;
+}
+"#;
+
+    #[test]
+    fn inspects_compiled_actor_and_entry_metrics() {
+        let out_dir = std::env::temp_dir().join(format!("argent-inspect-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&out_dir);
+        crate::build_inline("inspect.ag", INSPECT_APP, &out_dir).expect("fixture compiles");
+        let report = inspect_path(&out_dir).expect("build directory inspects");
+
+        let event = report.actors.iter().find(|actor| actor.name == "Event").expect("Event report");
+        assert_eq!(event.script_bytes, event.state_bytes + event.template_bytes);
+        assert!(event.opcode_count > 0);
+        let buy = &event.entries[0];
+        assert_eq!(buy.arguments, ["owner: pubkey"]);
+        assert_eq!(buy.generated_arguments.len(), 2);
+        assert_eq!(buy.outputs, ["event -> Event", "ticket -> Ticket"]);
+        assert_eq!(buy.routes, ["event -> Event", "ticket -> Ticket"]);
+        assert!(matches!(buy.signature_script_bytes.max, Some(max) if max == buy.signature_script_bytes.min));
+
+        let rendered = render_report(&report);
+        assert!(rendered.contains("Actor"));
+        assert!(rendered.contains("Event::buy [leader]"));
+        assert!(rendered.contains("signature script:"));
+        assert!(rendered.contains("witness recipes: 2"));
+
+        let _ = std::fs::remove_dir_all(out_dir);
+    }
+
+    #[test]
+    fn reports_variable_integer_argument_size() {
+        assert_eq!(type_size_for_test(&TypeArtifact::Int), SizeEstimate::range(1, 9));
+    }
+
+    fn type_size_for_test(ty: &TypeArtifact) -> SizeEstimate {
+        let artifact = crate::compile_inline("inspect.ag", INSPECT_APP).expect("fixture compiles");
+        let contract = artifact.sil_abi.contract("Event").expect("Event contract");
+        type_size(&artifact, contract, ty)
+    }
+}

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use colored::Colorize;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::tx::PopulatedTransaction;
 use kaspa_txscript::parse_script;
@@ -137,53 +138,55 @@ pub fn inspect_artifact(artifact: &Artifact) -> Result<InspectionReport> {
 
 pub fn render_report(report: &InspectionReport) -> String {
     let mut out = String::new();
-    writeln!(out, "App {}", report.app).unwrap();
-    writeln!(out, "Artifact {}", report.artifact_id).unwrap();
+    writeln!(out, "{} {}", "App".bold(), report.app.bright_cyan().bold()).unwrap();
+    writeln!(out, "{} {}", "Artifact".bold(), report.artifact_id.dimmed()).unwrap();
     out.push('\n');
-    out.push_str("Actors\n");
+    writeln!(out, "{}", "Actors".bold().underline()).unwrap();
 
     let actor_width = report.actors.iter().map(|actor| actor.name.len()).max().unwrap_or(5).max(5);
-    writeln!(
-        out,
+    let heading = format!(
         "  {:<actor_width$}  {:>10}  {:>10}  {:>10}  {:>9}  {:>7}",
         "Actor", "Script", "State", "Template", "Opcodes", "Entries"
-    )
-    .unwrap();
+    );
+    writeln!(out, "{}", heading.dimmed()).unwrap();
     for actor in &report.actors {
-        writeln!(
-            out,
-            "  {:<actor_width$}  {:>8} B  {:>8} B  {:>8} B  {:>9}  {:>7}",
-            actor.name,
-            actor.script_bytes,
-            actor.state_bytes,
-            actor.template_bytes,
-            actor.opcode_count,
-            actor.entries.len()
-        )
-        .unwrap();
+        let name = format!("{:<actor_width$}", actor.name).bright_cyan().bold();
+        let script = format!("{:>8} B", actor.script_bytes).yellow();
+        let state = format!("{:>8} B", actor.state_bytes).yellow();
+        let template = format!("{:>8} B", actor.template_bytes).yellow();
+        let opcodes = format!("{:>9}", actor.opcode_count).yellow();
+        let entries = format!("{:>7}", actor.entries.len()).yellow();
+        writeln!(out, "  {name}  {script}  {state}  {template}  {opcodes}  {entries}").unwrap();
     }
 
     let entries = report.actors.iter().flat_map(|actor| &actor.entries).collect::<Vec<_>>();
     if !entries.is_empty() {
         out.push('\n');
-        out.push_str("Entries\n");
+        writeln!(out, "{}", "Entries".bold().underline()).unwrap();
         for entry in entries {
-            writeln!(out, "  {}::{} [{}]", entry.actor, entry.name, entry_kind_label(entry.kind)).unwrap();
-            writeln!(out, "    arguments: {}", list_or_none(&entry.arguments)).unwrap();
-            writeln!(out, "    generated arguments: {}", list_or_none(&entry.generated_arguments)).unwrap();
-            writeln!(out, "    inputs: {}", list_or_none(&entry.inputs)).unwrap();
-            writeln!(out, "    outputs: {}", list_or_none(&entry.outputs)).unwrap();
-            writeln!(out, "    routes: {}", list_or_none(&entry.routes)).unwrap();
-            writeln!(out, "    signature script: {}", size_estimate_label(entry.signature_script_bytes)).unwrap();
+            writeln!(
+                out,
+                "  {}::{} [{}]",
+                entry.actor.bright_cyan().bold(),
+                entry.name.bright_green().bold(),
+                entry_kind_label(entry.kind).dimmed()
+            )
+            .unwrap();
+            writeln!(out, "    {} {}", "arguments:".bold(), list_or_none(&entry.arguments)).unwrap();
+            writeln!(out, "    {} {}", "generated arguments:".bold(), list_or_none(&entry.generated_arguments).dimmed()).unwrap();
+            writeln!(out, "    {} {}", "inputs:".bold(), list_or_none(&entry.inputs)).unwrap();
+            writeln!(out, "    {} {}", "outputs:".bold(), list_or_none(&entry.outputs)).unwrap();
+            writeln!(out, "    {} {}", "routes:".bold(), list_or_none(&entry.routes)).unwrap();
+            writeln!(out, "    {} {}", "signature script:".bold(), styled_size_estimate(entry.signature_script_bytes)).unwrap();
         }
     }
 
     out.push('\n');
-    out.push_str("Route metadata\n");
-    writeln!(out, "  families: {}", report.route_families).unwrap();
-    writeln!(out, "  tables: {}", report.route_tables).unwrap();
-    writeln!(out, "  proofs: {}", report.route_proofs).unwrap();
-    writeln!(out, "  witness recipes: {}", report.witness_recipes).unwrap();
+    writeln!(out, "{}", "Route metadata".bold().underline()).unwrap();
+    writeln!(out, "  {} {}", "families:".bold(), report.route_families.to_string().yellow()).unwrap();
+    writeln!(out, "  {} {}", "tables:".bold(), report.route_tables.to_string().yellow()).unwrap();
+    writeln!(out, "  {} {}", "proofs:".bold(), report.route_proofs.to_string().yellow()).unwrap();
+    writeln!(out, "  {} {}", "witness recipes:".bold(), report.witness_recipes.to_string().yellow()).unwrap();
     out
 }
 
@@ -550,11 +553,11 @@ fn list_or_none(values: &[String]) -> String {
     if values.is_empty() { "none".to_string() } else { values.join(", ") }
 }
 
-fn size_estimate_label(estimate: SizeEstimate) -> String {
+fn styled_size_estimate(estimate: SizeEstimate) -> colored::ColoredString {
     match estimate.max {
-        Some(max) if max == estimate.min => format!("{} B", estimate.min),
-        Some(max) => format!("{}-{} B", estimate.min, max),
-        None => format!(">= {} B (variable)", estimate.min),
+        Some(max) if max == estimate.min => format!("{} B", estimate.min).bright_green(),
+        Some(max) => format!("{}-{} B", estimate.min, max).yellow(),
+        None => format!(">= {} B (variable)", estimate.min).yellow(),
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -67,7 +67,8 @@ impl Lexer<'_> {
                     self.push(TokenKind::Symbol(b as char), start, self.pos);
                 }
                 _ => {
-                    return Err(ArgentError::new(format!("unexpected byte {:?} at offset {}", b as char, self.pos)));
+                    let unexpected = self.source[self.pos..].chars().next().expect("lexer position is within source");
+                    return Err(self.error_at(self.pos, format!("unexpected character `{unexpected}`")));
                 }
             }
         }
@@ -98,7 +99,7 @@ impl Lexer<'_> {
                 }
                 b'\\' => {
                     self.pos += 1;
-                    let escaped = *self.bytes.get(self.pos).ok_or_else(|| ArgentError::new("unterminated string escape"))?;
+                    let escaped = *self.bytes.get(self.pos).ok_or_else(|| self.error_at(self.pos, "unterminated string escape"))?;
                     out.push(escaped as char);
                     self.pos += 1;
                 }
@@ -108,7 +109,7 @@ impl Lexer<'_> {
                 }
             }
         }
-        Err(ArgentError::new(format!("unterminated string at offset {start}")))
+        Err(self.error_at(start, "unterminated string"))
     }
 
     fn lex_number(&mut self) {
@@ -126,21 +127,19 @@ impl Lexer<'_> {
         }
         let ident = self.source[start..self.pos].to_string();
         if ident == word::LEGACY_COVENANT_ID {
-            return Err(ArgentError::new(format!(
-                "`{}` was renamed to `{}` at offset {start}",
-                word::LEGACY_COVENANT_ID,
-                word::COVENANT_ID
-            )));
+            return Err(self.error_at(start, format!("`{}` was renamed to `{}`", word::LEGACY_COVENANT_ID, word::COVENANT_ID)));
         }
         let generated_prefix =
             [RESERVED_GENERATED_PREFIX, RESERVED_GENERATED_TYPE_PREFIX].into_iter().find(|prefix| ident.starts_with(prefix));
         if let Some(generated_prefix) = generated_prefix {
-            return Err(ArgentError::new(format!(
-                "identifier `{ident}` uses reserved generated namespace `{generated_prefix}` at offset {start}"
-            )));
+            return Err(self.error_at(start, format!("identifier `{ident}` uses reserved generated namespace `{generated_prefix}`")));
         }
         self.push(TokenKind::Ident(ident), start, self.pos);
         Ok(())
+    }
+
+    fn error_at(&self, byte_offset: usize, message: impl Into<String>) -> ArgentError {
+        ArgentError::in_source(self.source, byte_offset, message)
     }
 
     fn push(&mut self, kind: TokenKind, start: usize, end: usize) {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -47,6 +47,7 @@ impl Lexer<'_> {
             match b {
                 b' ' | b'\t' | b'\r' | b'\n' => self.pos += 1,
                 b'/' if self.peek_byte(1) == Some(b'/') => self.skip_line_comment(),
+                b'/' if self.peek_byte(1) == Some(b'*') => self.skip_block_comment()?,
                 b'"' => self.lex_string()?,
                 b'0'..=b'9' => self.lex_number(),
                 b'a'..=b'z' | b'A'..=b'Z' | b'_' => self.lex_ident()?,
@@ -84,6 +85,31 @@ impl Lexer<'_> {
         while self.pos < self.bytes.len() && self.bytes[self.pos] != b'\n' {
             self.pos += 1;
         }
+    }
+
+    fn skip_block_comment(&mut self) -> Result<()> {
+        let start = self.pos;
+        self.pos += 2;
+        let mut depth = 1;
+
+        while self.pos < self.bytes.len() {
+            match (self.peek_byte(0), self.peek_byte(1)) {
+                (Some(b'/'), Some(b'*')) => {
+                    depth += 1;
+                    self.pos += 2;
+                }
+                (Some(b'*'), Some(b'/')) => {
+                    depth -= 1;
+                    self.pos += 2;
+                    if depth == 0 {
+                        return Ok(());
+                    }
+                }
+                _ => self.pos += 1,
+            }
+        }
+
+        Err(self.error_at(start, "unterminated block comment"))
     }
 
     fn lex_string(&mut self) -> Result<()> {
@@ -150,6 +176,27 @@ impl Lexer<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn skips_nested_block_comments() {
+        let tokens = lex("before /* outer /* inner */ outer */ after").expect("nested block comments must lex");
+        let identifiers = tokens
+            .iter()
+            .filter_map(|token| match &token.kind {
+                TokenKind::Ident(value) => Some(value.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(identifiers, ["before", "after"]);
+    }
+
+    #[test]
+    fn reports_unterminated_block_comment_location() {
+        let err = lex("before\n  /* never closed").expect_err("unterminated block comment must be rejected");
+
+        assert_eq!(err.to_string(), "2:3: unterminated block comment");
+    }
 
     #[test]
     fn rejects_reserved_generated_namespace_identifier() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod builder;
 pub mod codec;
 pub mod emit;
 pub mod error;
+pub mod inspect;
 mod language;
 pub mod lexer;
 pub mod loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use argent::emit::{emit_build, emit_build_app};
+use argent::inspect::{inspect_path, render_report};
 use argent::loader::load_program;
 use argent::{ArgentError, Result};
 
@@ -22,6 +23,7 @@ fn run() -> Result<()> {
     let command = args.remove(0);
     match command.as_str() {
         "build" => build(args),
+        "inspect" => inspect(args),
         _ => Err(ArgentError::new(format!("unknown command `{command}`"))),
     }
 }
@@ -60,6 +62,17 @@ fn build(args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
+fn inspect(args: Vec<String>) -> Result<()> {
+    let [input] = args.as_slice() else {
+        return Err(ArgentError::new("usage: argentc inspect <build-dir|artifact.json>"));
+    };
+    let report = inspect_path(input)?;
+    print!("{}", render_report(&report));
+    Ok(())
+}
+
 fn print_usage() {
-    eprintln!("usage: argentc build <app.ag> [--app <name>] [--out <dir>]");
+    eprintln!("usage:");
+    eprintln!("  argentc build <app.ag> [--app <name>] [--out <dir>]");
+    eprintln!("  argentc inspect <build-dir|artifact.json>");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,9 @@ use argent::loader::load_program;
 use argent::{ArgentError, Result};
 
 fn main() {
+    #[cfg(windows)]
+    let _ = colored::control::set_virtual_terminal(true);
+
     if let Err(err) = run() {
         eprintln!("argentc: {err}");
         std::process::exit(1);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -668,8 +668,8 @@ mod tests {
 
     #[test]
     fn reports_path_line_and_column_for_parse_errors() {
-        let err = parse_module(PathBuf::from("event.ag"), "state Event {\n    int remaining;\n}\n\n/* old draft */\n".to_string())
-            .expect_err("block comments are not supported");
+        let err = parse_module(PathBuf::from("event.ag"), "state Event {\n    int remaining;\n}\n\n/\n".to_string())
+            .expect_err("stray slash must not parse");
 
         assert_eq!(err.to_string(), "event.ag:5:1: expected top-level declaration, found `/`");
         assert_eq!(err.location.expect("source location").byte_offset, 36);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,7 +7,7 @@ use crate::lexer::{Token, TokenKind, lex};
 use crate::routes::analyze_routes;
 
 pub fn parse_module(path: PathBuf, source: String) -> Result<Module> {
-    let tokens = lex(&source).map_err(|err| ArgentError { path: Some(path.clone()), message: err.message })?;
+    let tokens = lex(&source).map_err(|err| err.with_path(path.clone()))?;
     Parser { path, source, tokens, pos: 0 }.parse_module()
 }
 
@@ -609,7 +609,7 @@ impl Parser {
     }
 
     fn error(&self, message: impl Into<String>) -> ArgentError {
-        ArgentError::at(&self.path, format!("{} at byte {}", message.into(), self.current().span.start))
+        ArgentError::at_source(&self.path, &self.source, self.current().span.start, message)
     }
 }
 
@@ -664,6 +664,23 @@ mod tests {
             .expect_err("name-first parameters must not parse");
 
         assert!(err.to_string().contains("expected identifier, found `:`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn reports_path_line_and_column_for_parse_errors() {
+        let err = parse_module(PathBuf::from("event.ag"), "state Event {\n    int remaining;\n}\n\n/* old draft */\n".to_string())
+            .expect_err("block comments are not supported");
+
+        assert_eq!(err.to_string(), "event.ag:5:1: expected top-level declaration, found `/`");
+        assert_eq!(err.location.expect("source location").byte_offset, 36);
+    }
+
+    #[test]
+    fn reports_path_line_and_column_for_lexer_errors() {
+        let err = parse_module(PathBuf::from("event.ag"), "state Event {}\n@\n".to_string())
+            .expect_err("unsupported character must not lex");
+
+        assert_eq!(err.to_string(), "event.ag:2:1: unexpected character `@`");
     }
 
     #[test]

--- a/vscode/argent-syntax/README.md
+++ b/vscode/argent-syntax/README.md
@@ -30,6 +30,8 @@ Features:
   the field declaration.
 - Entry and delegate bodies also offer owned-state fields in ordinary
   completion.
+- Completion inside entry and delegate bodies includes variables introduced by
+  `consumes`, `emits`, `observes`, and `spawns` clauses.
 - The editor indexer is tolerant of unfinished function and actor bodies.
 - `std::core` is indexed as an imported Argent module. Import paths and
   imported functions navigate to the compiler's standard-library source.

--- a/vscode/argent-syntax/README.md
+++ b/vscode/argent-syntax/README.md
@@ -28,6 +28,8 @@ Features:
 - `self.` completes fields from the enclosing actor's owned state (including
   inherited expanded-state fields); hover and go-to-definition resolve back to
   the field declaration.
+- Entry and delegate bodies also offer owned-state fields in ordinary
+  completion.
 - The editor indexer is tolerant of unfinished function and actor bodies.
 - `std::core` is indexed as an imported Argent module. Import paths and
   imported functions navigate to the compiler's standard-library source.

--- a/vscode/argent-syntax/extension.js
+++ b/vscode/argent-syntax/extension.js
@@ -450,7 +450,9 @@ function activate(context) {
           }
         }
         const callable = enclosingCallable(catalog, document.uri, document.offsetAt(position));
-        return [...parameterCompletionItems(callable?.parameters ?? []), ...completionItems(catalog)];
+        const actor = callable?.actor ? enclosingActor(catalog, document.uri, document.offsetAt(position)) : undefined;
+        const fields = actor ? fieldCompletionItems(fieldsForState(catalog, actor.ownedState)) : [];
+        return [...parameterCompletionItems(callable?.parameters ?? []), ...fields, ...completionItems(catalog)];
       },
     }, '.'),
     vscode.languages.registerDefinitionProvider(selector, {

--- a/vscode/argent-syntax/extension.js
+++ b/vscode/argent-syntax/extension.js
@@ -361,6 +361,15 @@ function parameterCompletionItems(parameters) {
   });
 }
 
+function clauseVariableCompletionItems(variables, callable) {
+  return variables.map((variable) => {
+    const item = new vscode.CompletionItem(variable.name, vscode.CompletionItemKind.Variable);
+    item.detail = `${variable.signature} — clause variable of ${callable}`;
+    item.sortText = `0-${variable.name}`;
+    return item;
+  });
+}
+
 function wordAt(document, position) {
   const range = document.getWordRangeAtPosition(position, /[A-Za-z_][A-Za-z0-9_]*/);
   return range ? { range, value: document.getText(range) } : undefined;
@@ -452,7 +461,12 @@ function activate(context) {
         const callable = enclosingCallable(catalog, document.uri, document.offsetAt(position));
         const actor = callable?.actor ? enclosingActor(catalog, document.uri, document.offsetAt(position)) : undefined;
         const fields = actor ? fieldCompletionItems(fieldsForState(catalog, actor.ownedState)) : [];
-        return [...parameterCompletionItems(callable?.parameters ?? []), ...fields, ...completionItems(catalog)];
+        return [
+          ...parameterCompletionItems(callable?.parameters ?? []),
+          ...clauseVariableCompletionItems(callable?.clauseVariables ?? [], callable?.name),
+          ...fields,
+          ...completionItems(catalog),
+        ];
       },
     }, '.'),
     vscode.languages.registerDefinitionProvider(selector, {

--- a/vscode/argent-syntax/language-service.js
+++ b/vscode/argent-syntax/language-service.js
@@ -441,9 +441,90 @@ function callableBody(source, tokens, start, segmentEnd) {
     }
   }
   return {
+    openIndex: lastOpen,
     bodyStart: lastOpen >= 0 ? tokens[lastOpen].end : tokens[start].end,
     bodyEnd: lastClose >= 0 ? tokens[lastClose].start : source.length,
   };
+}
+
+function callableClauseVariables(tokens, start, end) {
+  const variables = [];
+  const seen = new Set();
+  const add = (clause, nameToken) => {
+    if (!ident(nameToken) || seen.has(nameToken.value)) {
+      return;
+    }
+    seen.add(nameToken.value);
+    variables.push({
+      kind: 'clauseVariable',
+      clause,
+      name: nameToken.value,
+      signature: `${clause} ${nameToken.value}`,
+      start: nameToken.start,
+      end: nameToken.end,
+    });
+  };
+  const addNamedBlock = (clause, openIndex, closeIndex) => {
+    const blockEnd = closeIndex >= 0 && closeIndex < end ? closeIndex : end;
+    let depth = 1;
+    for (let index = openIndex + 1; index < blockEnd; index += 1) {
+      if (depth === 1 && ident(tokens[index]) && symbol(tokens[index + 1], ':')) {
+        add(clause, tokens[index]);
+      }
+      if (symbol(tokens[index], '{')) {
+        depth += 1;
+      } else if (symbol(tokens[index], '}')) {
+        depth -= 1;
+      }
+    }
+  };
+
+  let index = start;
+  while (index < end) {
+    if (ident(tokens[index], 'consumes')) {
+      const openIndex = findSymbolIndex(tokens, index + 1, '{');
+      if (openIndex >= 0 && openIndex < end) {
+        const closeIndex = matchingBraceIndex(tokens, openIndex);
+        addNamedBlock('consume', openIndex, closeIndex);
+        index = closeIndex >= 0 ? closeIndex + 1 : end;
+        continue;
+      }
+    } else if (ident(tokens[index], 'emits')) {
+      if (ident(tokens[index + 1], 'one')) {
+        add('emit', { kind: 'ident', value: 'next', start: tokens[index + 1].start, end: tokens[index + 1].end });
+      } else if (symbol(tokens[index + 1], '{')) {
+        const openIndex = index + 1;
+        const closeIndex = matchingBraceIndex(tokens, openIndex);
+        addNamedBlock('emit', openIndex, closeIndex);
+        index = closeIndex >= 0 ? closeIndex + 1 : end;
+        continue;
+      }
+    } else if (ident(tokens[index], 'observes') && ident(tokens[index + 1])) {
+      add('observe', tokens[index + 1]);
+      const openIndex = findSymbolIndex(tokens, index + 2, '{');
+      if (openIndex >= 0 && openIndex < end) {
+        const closeIndex = matchingBraceIndex(tokens, openIndex);
+        const blockEnd = closeIndex >= 0 && closeIndex < end ? closeIndex : end;
+        for (let bindingIndex = openIndex + 1; bindingIndex < blockEnd; bindingIndex += 1) {
+          if (ident(tokens[bindingIndex], 'as')) {
+            add('observed actor', tokens[bindingIndex + 1]);
+          }
+        }
+        index = closeIndex >= 0 ? closeIndex + 1 : end;
+        continue;
+      }
+    } else if (ident(tokens[index], 'spawns') && ident(tokens[index + 1])) {
+      add('spawn', tokens[index + 1]);
+      const openIndex = findSymbolIndex(tokens, index + 2, '{');
+      if (openIndex >= 0 && openIndex < end) {
+        const closeIndex = matchingBraceIndex(tokens, openIndex);
+        index = closeIndex >= 0 ? closeIndex + 1 : end;
+        continue;
+      }
+    }
+    index += 1;
+  }
+  return variables;
 }
 
 function actorMembers(source, tokens, openIndex, closeIndex) {
@@ -473,6 +554,12 @@ function actorMembers(source, tokens, openIndex, closeIndex) {
     const paramsOpen = start + 2;
     const paramsClose = matchingSymbolIndex(tokens, paramsOpen, '(', ')');
     const signatureEnd = paramsClose >= 0 ? tokens[paramsClose].end : nameToken.end;
+    const { openIndex: bodyOpenIndex, ...bodyRange } = callableBody(
+      source,
+      tokens,
+      paramsClose >= 0 ? paramsClose + 1 : start + 2,
+      segmentEnd,
+    );
     return declaration(
       keyword,
       nameToken,
@@ -481,7 +568,12 @@ function actorMembers(source, tokens, openIndex, closeIndex) {
       parameters.map((parameter) => parameter.name),
       {
         parameters,
-        ...callableBody(source, tokens, paramsClose >= 0 ? paramsClose + 1 : start + 2, segmentEnd),
+        clauseVariables: callableClauseVariables(
+          tokens,
+          paramsClose >= 0 ? paramsClose + 1 : start + 2,
+          bodyOpenIndex >= 0 ? bodyOpenIndex : segmentEnd,
+        ),
+        ...bodyRange,
       },
     );
   });

--- a/vscode/argent-syntax/language-service.test.js
+++ b/vscode/argent-syntax/language-service.test.js
@@ -295,6 +295,69 @@ actor Pair owns PairState {
   assert.ok(authorize.bodyEnd > source.indexOf('checkSig(owner_sig'));
 });
 
+test('indexes variables introduced by all callable clause forms', () => {
+  const source = `
+actor Event owns EventState {
+  entry publish()
+  observes flow by asset_id {
+    inputs {
+      payment: actor_type<AssetState> as asset_impl,
+    }
+    outputs {
+      reserve: asset_impl,
+    }
+  }
+  spawns batch by batch_id {
+    outputs {
+      child: Child,
+    }
+  }
+  consumes {
+    peer: Peer,
+  }
+  emits {
+    event: Event,
+    ticket: Ticket,
+  } {
+    require(event.value > 0);
+  }
+
+  entry keep() emits one Event {
+    require(next.value > 0);
+  }
+
+  delegate audit() consumes {
+    leader: Event,
+  } {
+    require(leader.value > 0);
+  }
+}
+`;
+
+  const actor = scanDocument(source).declarations.find((item) => item.name === 'Event');
+  const publish = actor.members.find((item) => item.name === 'publish');
+  const keep = actor.members.find((item) => item.name === 'keep');
+  const audit = actor.members.find((item) => item.name === 'audit');
+
+  assert.deepEqual(
+    publish.clauseVariables.map(({ clause, name }) => ({ clause, name })),
+    [
+      { clause: 'observe', name: 'flow' },
+      { clause: 'observed actor', name: 'asset_impl' },
+      { clause: 'spawn', name: 'batch' },
+      { clause: 'consume', name: 'peer' },
+      { clause: 'emit', name: 'event' },
+      { clause: 'emit', name: 'ticket' },
+    ],
+  );
+  assert.deepEqual(keep.clauseVariables.map(({ clause, name }) => ({ clause, name })), [
+    { clause: 'emit', name: 'next' },
+  ]);
+  assert.deepEqual(audit.clauseVariables.map(({ clause, name }) => ({ clause, name })), [
+    { clause: 'consume', name: 'leader' },
+  ]);
+});
+
 test('documents Argent-specific identity and actor-handle types', () => {
   assert.match(PRIMITIVE_DOCUMENTATION.cov_id, /^A 32-byte handle identifying a covenant instance/);
   assert.match(PRIMITIVE_DOCUMENTATION.cov_id, /target of an `observes` clause/);


### PR DESCRIPTION
## Summary

- Report lexer and parser errors with `path:line:column` source locations.
- Support nested `/* ... */` block comments.
- Clarify missing-route diagnostics for declared emit outputs.
- Improve VS Code completion inside actor callables:
  - owned-state fields;
  - variables introduced by `consumes`, `emits`, `observes`, and `spawns`.
- Add `argentc inspect <build-dir|artifact.json>` with:
  - actor script, state, and template sizes;
  - static opcode counts;
  - entry arguments and generated witnesses;
  - input, output, and route summaries;
  - signature-script size estimates;
  - route metadata totals.
- Add TTY-aware colored inspector output while preserving plain redirected output.

## Testing

- `./check.sh --full`
- `cd vscode/argent-syntax && npm test`
- `cargo run --quiet --bin argentc -- inspect examples/build/tickets`
