### PR TITLE
Make output handles and values explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ actor Ticket owns TicketState {
     entry transfer(byte[32] next_owner, sig owner_sig, pubkey owner_pk) emits next: Ticket {
         require(blake2b(owner_pk) == owner);
         require(checkSig(owner_sig, owner_pk));
+        require(next.value == self.value);
 
         TicketState new_state = {
             owner: next_owner,

--- a/README.md
+++ b/README.md
@@ -108,20 +108,20 @@ Silverscript covenant macros.
 ```rust
 state TicketState {
     byte[32] owner;
-    int value;
+    int units;
 }
 
 actor Ticket owns TicketState {
-    entry transfer(byte[32] next_owner, sig owner_sig, pubkey owner_pk) emits one Ticket {
+    entry transfer(byte[32] next_owner, sig owner_sig, pubkey owner_pk) emits next: Ticket {
         require(blake2b(owner_pk) == owner);
         require(checkSig(owner_sig, owner_pk));
 
-        TicketState next = {
+        TicketState new_state = {
             owner: next_owner,
-            value: value,
+            units: units,
         };
 
-        become Ticket(next);
+        become next <- Ticket(new_state);
     }
 }
 

--- a/crates/argent-artifact/src/lib.rs
+++ b/crates/argent-artifact/src/lib.rs
@@ -615,7 +615,6 @@ pub struct ConsumeArtifact {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum EmitArtifact {
     None,
-    One { actors: Vec<String> },
     Outputs { outputs: Vec<EmitOutputArtifact> },
 }
 
@@ -644,14 +643,14 @@ pub struct RouteInputArtifact {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RouteOutputHandleArtifact {
-    pub name: Option<String>,
+    pub name: String,
     pub auth_index: usize,
     pub actors: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RouteArtifact {
-    pub output: Option<String>,
+    pub output: String,
     pub actor: String,
     pub template_id: String,
     pub state_expr: String,

--- a/docs/argent-design.md
+++ b/docs/argent-design.md
@@ -1,14 +1,14 @@
 # Argent design notes
 
 Argent is an actor-style frontend for building multi-contract Silverscript apps
-as well-formed covenant state machines. This document captures design choices
-and the parts still under discussion.
+as well-formed covenant state machines. This document records the current
+language and compiler design.
 
 The focus is the compiler/runtime boundary: generated Silverscript, portable
 artifacts, ICC flows, route families, and the source features needed to make
 those pieces usable from Argent.
 
-## Settled for now
+## Core design
 
 - Argent emits plain Silverscript, not Silverscript covenant macros.
 - User state is declared once with `state`.
@@ -22,8 +22,7 @@ those pieces usable from Argent.
 - Prefix/suffix witnesses are generated Silverscript ABI, not Argent source
   surface.
 - Every `become` route must be allowed by the entry's `emits` declaration.
-- Covenant input/output shape is a first-class Argent concern, even while the
-  source syntax evolves.
+- Covenant input/output shape is a first-class Argent concern.
 - The main language/compiler contribution is hiding route logic, template
   propagation, and mechanical safety checks from application code.
 - Named actor flows use a leader-auth output pattern by default.
@@ -140,6 +139,12 @@ become {
 `white_out` and `black_out` refer to roles in the `emits` clause. The final
 semicolon terminates the `become` statement.
 
+A singleton route can omit the braces:
+
+```rust
+become next <- Player(next_player);
+```
+
 ### Consistency rule
 
 Declarations put the type before the declared name. Value, role, and route
@@ -172,10 +177,14 @@ self.value  // Native KAS value of the UTXO consumed by the active input.
             // Type: int.
 self.state  // Complete typed source-level state owned by the actor.
             // Type: the state named in the actor's owns clause.
-self.cov_id // Reserved.
+self.cov_id // Covenant ID carried by the active input. Type: cov_id.
+            // Lowers to OpInputCovenantId(this.activeInputIndex).
 self.type   // Reserved.
 self.ref    // Reserved.
 ```
+
+`self.cov_id` identifies the runtime covenant instance to which the active actor
+input belongs.
 
 An actor's effective top-level state cannot declare `state`, `value`, `cov_id`,
 `type`, or `ref` as a field. This rule also applies to base fields and expansion
@@ -196,8 +205,8 @@ state WalletState {
 
 ## Template hash rule
 
-Template hashes must exclude all instance state, including hidden template fields.
-The working rule is the chess rule:
+Argent uses Silverscript's template hash, which excludes all instance state,
+including compiler-owned state:
 
 ```text
 template_hash = blake2b(i64le(template_prefix.length) || template_prefix || i64le(template_suffix.length) || template_suffix)
@@ -208,9 +217,10 @@ state do not participate in their own template hash.
 
 ## Hidden ABI state
 
-Template fields are hidden ABI state, not source-level user fields.
+Template and route fields are compiler-owned ABI state, not source-level user
+fields.
 
-The compiler may add fields such as:
+The compiler adds fields such as these when an actor needs route context:
 
 ```text
 gen__player_template
@@ -218,55 +228,18 @@ gen__game_template
 gen__mux_routes_digest
 ```
 
-Ordinary transitions must preserve these exactly. Bootstrap or explicit handoff
-paths are the only places where hidden ABI state may be initialized or changed.
-
-Open questions:
-
-- Should imports name required symbols explicitly, such as
-  `import PlayerState, GameState, player_ref from "./types.ag";`?
-- Should hidden ABI fields be emitted as leading state fields, a named generated
-  struct prefix, or another ABI convention?
-- Do we need explicit source syntax for privileged bootstrap/handoff paths?
-- How should generated code prevent user code from accidentally shadowing hidden
-  field names?
-
-## Bootstrap and launch proofs
-
-The initial hidden ABI fields are correct because bootstrap constructs them
-correctly. Later transitions preserve them.
-
-The launch proof should let an auditor verify the current app from current UTXOs
-plus opened covenant-id/bootstrap preimages, without replaying all history.
-
-Open questions:
-
-- What exact launch artifact should Argent generate?
-- Is bootstrap a generated transaction builder, a manifest, a proof object, or
-  all three?
-- How do we represent one-time init paths in the source language?
-- How much launch proof checking belongs in Argent tooling vs external auditors
-  and indexers?
-- What does a minimal proof for the Stones example look like?
+The `gen__` namespace is reserved. The artifact records each generated field's
+role, and `argent-runtime` constructs its value from the template plan.
+Same-context transitions preserve these fields; routes to another actor derive
+the target actor's planned context.
 
 ## Transaction builder context
 
 Argent source should not expose prefix/suffix witnesses, route proofs, template
-preimages, or other Silverscript machinery. The `argent-runtime` crate provides
-the current artifact-level `TxBuilder`; a future generated transaction builder
-with an app context can wrap that lower-level surface and supply this material
-behind app-specific methods.
-
-Open questions:
-
-- What exactly lives in the app context?
-- Does the context own compiled template witnesses, route proof receipts,
-  route-family table preimages, launch proof data, or all of them?
-- How does the builder choose the right route preimage for a union output?
-- Should the builder expose actor-level methods, entry-level methods, or both?
-- How much validation should happen client-side before building the transaction?
-- What is the boundary between generated Argent builder code and reusable
-  Silverscript builder APIs?
+preimages, or other Silverscript machinery. The portable artifact records
+recipes for this hidden material. `argent-runtime`'s artifact-level `TxBuilder`
+combines those recipes with a `TxContext` to construct actor inputs, outputs,
+and entry arguments.
 
 ## Route commitments
 
@@ -295,77 +268,27 @@ compiler boundary. [Routing Optimization Opportunities](../src/routing/optimizat
 records known cases where the current policy produces correct but inefficient
 cuts.
 
-Open questions:
-
-- When should the planner create nested helper branches?
-- Should source code or compiler configuration provide forest hints?
-- When should the planner use a flat table instead of nested branches?
-- How should the planner improve cohort selection without weakening cut
-  equality or dependency propagation?
-
 ## Same-template shortcuts
 
-Same-template outputs should use the cheaper same-script validation path.
+Route lowering uses the strongest template identity already proved by the entry
+model:
 
-Desired lowering rule:
+- An exact self-continuation with `self.state` compares the successor output's
+  script public key with the active input's script public key.
+- A same-actor continuation with new state uses `validateOutputState`.
+- A foreign continuation can use `validateOutputStateWithInputTemplate` when a
+  bound input already proves the target template.
+- Other foreign continuations use `validateOutputStateWithTemplate` and a
+  compiler-planned template witness.
 
-```text
-become self_template_actor(next_state)
-  -> validateOutputState(output_idx, next_state)
-
-become foreign_template_actor(next_state)
-  -> validateOutputStateWithTemplate(output_idx, next_state, prefix, suffix, template_hash)
-```
-
-This should remove prefix/suffix witness parameters for outputs that continue
-the active input's template, such as `League -> League`, `Player -> Player`, or
-`StonesGame -> StonesGame`.
-
-Input reads are subtler. A consumed peer may have the same actor type as the
-active input, but covenant grouping alone does not prove that the peer input's
-redeem script is really the same template. For peer inputs, even same-actor
-inputs should keep `readInputStateWithTemplate(...)` unless another explicit
-proof establishes same-template identity.
-
-Safe default:
-
-```text
-self/current input fields:
-  use contract fields, or readInputState(this.activeInputIndex) when a State value is needed
-
-consumed peer input:
-  use readInputStateWithTemplate(peer_idx, prefix_len, suffix_len, expected_template)
-```
-
-This matches the chess `delegate_start_game` pattern: it reads another `Player`
-with `readInputStateWithTemplate` so the delegate independently proves that the
-leader input is really a Player template, not just an arbitrary input in the same
-covenant group.
-
-Open questions:
-
-- Should Argent infer same-template output shortcuts automatically? Probably yes.
-- Should source syntax expose "already proven same template" peer inputs, or keep
-  the conservative template-read default?
-- Can the transaction builder carry reusable proof metadata so same-template peer
-  inputs can opt into `readInputState(...)` safely in special cases?
+Consumed and observed inputs follow the same rule. Argent uses
+`readInputState` only when the entry model proves the current template is the
+expected template; otherwise it uses `readInputStateWithTemplate`.
 
 ## Input and output shape
 
-The source wants to say:
-
-```ag
-require cov.inputs == [self, opponent];
-```
-
-The compiler currently emits exact leader-entry covenant input counts and conservative
-delegate minimum counts. The source-level shape model can become more explicit.
-
-Covenant shape should be first-class in Argent. The source spelling is still
-open, but the shape belongs in declarations rather than unchecked user body
-text.
-
-Default actor-app lowering should use a coordinator shape:
+`consumes`, `emits`, `observes`, and `spawns` declare transaction shape. The
+compiler lowers ordinary actor coordination as follows:
 
 ```text
 leader input:    reads peer inputs through OpCovInput*
@@ -373,68 +296,42 @@ leader outputs:  validates successors through OpAuthOutput*
 delegate inputs: verify they are not leader and require OpAuthOutputCount(active) == 0
 ```
 
-This still uses covenant input grouping for many-input transitions, but it avoids
-covenant outputs for ordinary named actor flows. The practical upside is that
-`1:N` auth-output groups can coexist naturally in one transaction, while true
-`N:M` cov-output transitions remain singleton per covenant id per transaction.
+Coordinated leader entries enforce the declared covenant input count and order.
+Standalone entries that neither consume peers nor lead delegates allow
+covenant batching. Delegates enforce a conservative minimum input count because
+the leader may coordinate additional actors. Every entry enforces its exact
+authorized output count and handle order.
 
-True cov-output lowering should be reserved for explicit set-like transitions,
-if Argent supports them later.
-
-Open questions:
-
-- What is the right declaration syntax for covenant input shape?
-- Do delegate entries need a first-class notation for "same transaction, no
-  outputs from me"?
-- How should output value policies be expressed without making `become` carry
-  value rules?
-- Should `cov[n]` and `auth[n]` remain explicit indexes or become named output
-  handles?
-- Do we need any source-level escape hatch for explicit cov-output transitions?
+An `observes` clause currently describes the complete observed covenant input
+and output groups. A `spawns` clause describes an ordered genesis output group
+and verifies its derived covenant ID. Flexible clause cardinality is specified
+separately in [Entry clause ranges](entry-clause-ranges.md).
 
 ## Body lowering
 
-The current compiler lowers the Stones subset into plain Silverscript. It handles
-terminal `become`, simple locals, `if/else`, state constructors, output-handle
-values, consumed-input values, and generated route validation.
+The compiler lowers entry bodies into plain Silverscript. Targeted lowering
+handles terminal `become`, typed locals, `if/else`, state constructors,
+transaction values, consumed and observed state, actor selectors, and generated
+route validation.
 
 Argent does not yet own a full source typechecker. The compiler performs the
 analysis needed for lowering and leaves final helper/body validity to
 Silverscript where possible.
 
-Open questions:
+## Application continuation invariants
 
-- How much of Argent expression syntax should be Silverscript-like?
-- Should Argent own a real expression AST early, or keep copying Silverscript-like
-  helper code through?
-- How should state constructors lower into hidden-plus-user state structs?
-- How should union outputs be lowered when one handle can target several actors?
-- What diagnostics should users get when a route needs a missing template witness?
-- How much validation belongs in Argent before handing generated Silverscript to
-  `silverc`?
-
-## Exact continuation protection
-
-Chess-style player and league continuations show that multi-actor apps need
-actor-instance preservation discipline, not just template checks.
-
-Open questions:
-
-- Which continuation invariants should Argent infer from actor/state
-  declarations?
-- Which should remain explicit `require(...)` code?
-- Should "same actor instance, same hidden ABI state" become a reusable generated
-  pattern?
-- How should settlement actors prove they are closing exactly the intended live
-  actors?
+Argent proves the declared actor, template, route, and successor-state
+relationships. Application identity rules—such as preserving an owner, matching
+a game identifier, or closing the intended live actors—remain explicit
+`require(...)` conditions in source.
 
 ## Compiler obligations
 
-Argent-generated code must eventually enforce:
+Argent-generated code enforces the declared mechanical invariants:
 
-- exact covenant input shape where declared
+- covenant input shape according to the leader, delegate, and batching rules
 - exact authorized output shape where declared
-- hidden ABI state preservation
+- planned hidden ABI state preservation and transition
 - typed foreign input template checks
 - same-template output validation through `validateOutputState` where applicable
 - route commitment membership checks

--- a/docs/argent-design.md
+++ b/docs/argent-design.md
@@ -307,6 +307,25 @@ and output groups. A `spawns` clause describes an ordered genesis output group
 and verifies its derived covenant ID. Flexible clause cardinality is specified
 separately in [Entry clause ranges](entry-clause-ranges.md).
 
+### Output value policy
+
+Every output created by the current entry must reference its native value
+explicitly. This includes ordinary `emits` handles and group-qualified spawn
+handles:
+
+```ag
+require(next.value == self.value);
+require(children.outputs.first.value > 0);
+```
+
+An intentionally free value uses `unrestricted(handle.value)`. The declaration
+is compile-time-only and emits no Silverscript.
+
+Observed outputs are excluded: their emitting contracts own their value policy.
+The initial check is syntactic and entry-scoped. It requires each output value
+reference to appear somewhere in the entry body; it does not prove that a
+restriction is meaningful or present on every control-flow path.
+
 ## Body lowering
 
 The compiler lowers entry bodies into plain Silverscript. Targeted lowering

--- a/docs/argent-design.md
+++ b/docs/argent-design.md
@@ -103,7 +103,8 @@ are value bindings. The final semicolon terminates the declaration.
 
 The `consumes`, `emits`, `spawns`, and `observes` clauses bind role names to
 actor targets. A colon separates the role name from the actor target. Commas
-separate the role bindings.
+separate the role bindings. Output handles are always named; a singleton can
+use the unbraced `emits name: Actor` shorthand.
 
 An actor target can be a fixed actor or a dynamic actor handle. This `observes`
 clause uses a dynamic actor handle:
@@ -385,7 +386,6 @@ Open questions:
 - What is the right declaration syntax for covenant input shape?
 - Do delegate entries need a first-class notation for "same transaction, no
   outputs from me"?
-- Should output handles always be named, even for `emits one`?
 - How should output value policies be expressed without making `become` carry
   value rules?
 - Should `cov[n]` and `auth[n]` remain explicit indexes or become named output

--- a/docs/entry-clause-ranges.md
+++ b/docs/entry-clause-ranges.md
@@ -78,9 +78,6 @@ spawns batch by batch_id {
 }
 ```
 
-Keep `emits one` as a singleton form. A ranged emit must use the named block
-form because the body needs a range handle.
-
 ## Terms
 
 - A **singleton** has cardinality one.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3,27 +3,6 @@
 This file contains small follow-up items. Each item gives its area, context,
 and required work.
 
-## Replace `emits one` with a named shorthand
-
-**Area:** Entry syntax and body lowering.
-
-**Context:** `emits one` declares an unnamed output, but the entry body can read
-its value through `next.value`. The name `next` is synthesized by the compiler
-and is not visible in the entry declaration. This makes a convenient shorthand
-look like an ordinary declared binding.
-
-**Follow-up:** Replace `emits one Type` with a concise named form such as:
-
-```rust
-entry transfer(...) emits next Type {
-    become next <- Type(next_state);
-}
-```
-
-The shorthand still declares exactly one output, but its handle is explicit.
-Use the same named `become` form as an `emits` block. Remove the synthesized
-`next` binding.
-
 ## Require an output-value disposition
 
 **Area:** Entry validation and body analysis.
@@ -198,7 +177,7 @@ spawns asset by asset_id {
         proxy: self.proxy_type,
     }
 }
-emits one Minter {
+emits next: Minter {
     require(!initialized);
     require(checkSig(owner_sig, owner));
 
@@ -216,7 +195,7 @@ emits one Minter {
         amount: amount,
         initialized: true,
     };
-    become Minter(next_controller);
+    become next <- Minter(next_controller);
 }
 ```
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -182,7 +182,7 @@ emits next: Minter {
     require(checkSig(owner_sig, owner));
 
     MinterProxyState proxy_state = {
-        controller_id: self.covenant_id,
+        controller_id: self.cov_id,
     };
     require asset.outputs become {
         proxy <- self.proxy_type(proxy_state),

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3,6 +3,85 @@
 This file contains small follow-up items. Each item gives its area, context,
 and required work.
 
+## Replace `emits one` with a named shorthand
+
+**Area:** Entry syntax and body lowering.
+
+**Context:** `emits one` declares an unnamed output, but the entry body can read
+its value through `next.value`. The name `next` is synthesized by the compiler
+and is not visible in the entry declaration. This makes a convenient shorthand
+look like an ordinary declared binding.
+
+**Follow-up:** Replace `emits one Type` with a concise named form such as:
+
+```rust
+entry transfer(...) emits next Type {
+    become next <- Type(next_state);
+}
+```
+
+The shorthand still declares exactly one output, but its handle is explicit.
+Use the same named `become` form as an `emits` block. Remove the synthesized
+`next` binding.
+
+## Require an output-value disposition
+
+**Area:** Entry validation and body analysis.
+
+**Context:** An entry can validate an emitted actor's state and template while
+placing no restriction on the output's Kaspa value. Omitting a value policy is
+easy to miss during review.
+
+**Follow-up:** Require every emitted output handle to account explicitly for
+its `.value` on every terminal path. A value can be constrained by an enforced
+boolean expression or deliberately accepted with:
+
+```rust
+unrestricted(next.value);
+```
+
+Define precisely which boolean uses count. Merely computing and discarding a
+comparison must not satisfy the rule. Start with direct use in `require(...)`
+and conditions that govern a terminal path; decide separately how annotated
+helper functions can preserve the guarantee. Report the output handle and
+uncovered terminal path in diagnostics.
+
+## Infer the leader of a singleton-app delegate
+
+**Area:** Delegate modeling, covenant-input validation, and artifacts.
+
+**Context:** A delegate currently names its leader as the first `consumes`
+actor. This lets the generated prelude authenticate the leader input's
+template. In an app with only one actor, the only in-app leader template is
+already determined by the delegate actor, so requiring a source-level leader
+handle solely for that proof is redundant.
+
+**Follow-up:** Allow a delegate in a singleton-actor app to omit the leader
+from `consumes`. Infer the same actor as its leader and keep the generated
+template authentication of the concrete leader input. Require an explicit
+handle when the delegate body needs to inspect the leader's state or value.
+Record the inferred leader relationship explicitly in the artifact.
+
+## Allow open observed groups
+
+**Area:** Observe syntax, transaction-shape validation, artifacts, and runtime
+resolution.
+
+**Context:** An `observes` clause currently describes the complete observed
+input and output groups. An observer may need to authenticate and follow a
+known subset while permitting unrelated inputs or outputs in the same
+transaction.
+
+**Follow-up:** Add an explicit open-group marker to observed `inputs` and
+`outputs`. Declared handles remain authenticated and available to the body,
+while the generated checks permit additional group members.
+
+Define where extra members may occur. Restricting them to a declared rest
+position keeps handle indices derivable; allowing them anywhere requires
+explicit indices or an unambiguous matching rule. Record openness and the
+binding rule in the artifact so the runtime and transaction builder resolve
+the same handles.
+
 ## Resolve observed state read types
 
 **Area:** Compiler code generation and Silverscript type checking.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3,28 +3,6 @@
 This file contains small follow-up items. Each item gives its area, context,
 and required work.
 
-## Require an output-value disposition
-
-**Area:** Entry validation and body analysis.
-
-**Context:** An entry can validate an emitted actor's state and template while
-placing no restriction on the output's Kaspa value. Omitting a value policy is
-easy to miss during review.
-
-**Follow-up:** Require every emitted output handle to account explicitly for
-its `.value` on every terminal path. A value can be constrained by an enforced
-boolean expression or deliberately accepted with:
-
-```rust
-unrestricted(next.value);
-```
-
-Define precisely which boolean uses count. Merely computing and discarding a
-comparison must not satisfy the rule. Start with direct use in `require(...)`
-and conditions that govern a terminal path; decide separately how annotated
-helper functions can preserve the guarantee. Report the output handle and
-uncovered terminal path in diagnostics.
-
 ## Infer the leader of a singleton-app delegate
 
 **Area:** Delegate modeling, covenant-input validation, and artifacts.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -162,6 +162,7 @@ emits next: Minter {
     MinterProxyState proxy_state = {
         controller_id: self.cov_id,
     };
+    unrestricted(asset.outputs.proxy.value);
     require asset.outputs become {
         proxy <- self.proxy_type(proxy_state),
     };
@@ -173,6 +174,7 @@ emits next: Minter {
         amount: amount,
         initialized: true,
     };
+    unrestricted(next.value);
     become next <- Minter(next_controller);
 }
 ```

--- a/docs/icc-semantics.md
+++ b/docs/icc-semantics.md
@@ -227,6 +227,7 @@ emits {
         tick: tick + 1,
     };
 
+    require(cell.value == self.value);
     become cell <- Cell(next_cell);
 }
 ```

--- a/examples/build/route_state_bodies/artifact.json
+++ b/examples/build/route_state_bodies/artifact.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "id": "9c289551e4978fd8c81f23285c4d14ca2c4616329a02386bb8854331b4d141ae",
+  "id": "77ae2c55532ee5c8e01f66621b345474d495b0d700b7622712451b98a5b06d12",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -615,7 +615,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Mux"
@@ -711,14 +711,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Mux"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Mux"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Mux",
                 "template_id": "template/mux",
                 "state_expr": "next_board"
@@ -755,7 +761,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Pawn",
@@ -835,21 +841,27 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Pawn",
-                "Knight"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Pawn",
+                    "Knight"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Pawn",
                 "template_id": "template/pawn",
                 "state_expr": "next_board"
               },
               {
-                "output": null,
+                "output": "next",
                 "actor": "Knight",
                 "template_id": "template/knight",
                 "state_expr": "next_board"
@@ -877,7 +889,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Archive"
@@ -946,14 +958,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Archive"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Archive"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Archive",
                 "template_id": "template/archive",
                 "state_expr": "next_archive"
@@ -1110,7 +1128,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Pawn"
@@ -1206,14 +1224,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Pawn"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Pawn"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Pawn",
                 "template_id": "template/pawn",
                 "state_expr": "next_board"

--- a/examples/build/route_state_bodies/manifest.json
+++ b/examples/build/route_state_bodies/manifest.json
@@ -21,9 +21,9 @@
         {
           "name": "open_board",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Mux"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Mux"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Mux", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Mux", "state": "next_board" }]
         }
       ]
     },
@@ -35,16 +35,16 @@
         {
           "name": "choose",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["MoveActor"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["MoveActor"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "target", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "target", "state": "next_board" }]
         },
         {
           "name": "archive",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Archive"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Archive"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Archive", "state": "next_archive" }]
+          "routes": [{ "output": "next", "actor": "Archive", "state": "next_archive" }]
         }
       ]
     },
@@ -98,9 +98,9 @@
         {
           "name": "reopen_as_pawn",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Pawn"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Pawn"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Pawn", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Pawn", "state": "next_board" }]
         }
       ]
     }

--- a/examples/build/route_state_bodies/sil/Archive.sil
+++ b/examples/build/route_state_bodies/sil/Archive.sil
@@ -47,7 +47,7 @@ contract Archive(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Pawn
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pawn
 
         Gen__PawnState next_board = {
             // :: generated fields

--- a/examples/build/route_state_bodies/sil/Lobby.sil
+++ b/examples/build/route_state_bodies/sil/Lobby.sil
@@ -46,7 +46,7 @@ contract Lobby(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Mux
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Mux
 
         Gen__MuxState next_board = {
             // :: generated fields

--- a/examples/build/route_state_bodies/sil/Mux.sil
+++ b/examples/build/route_state_bodies/sil/Mux.sil
@@ -39,7 +39,8 @@ contract Mux(
     entrypoint function choose(int target, byte[] gen__target_prefix, byte[] gen__target_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor
+        // :: output next: MoveActor
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         State next_board = {
             // :: generated fields
@@ -69,7 +70,8 @@ contract Mux(
     entrypoint function archive(byte[] gen__archive_prefix, byte[] gen__archive_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Archive
+        // :: output next: Archive
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         Gen__ArchiveState next_archive = {
             // :: generated fields

--- a/examples/build/route_state_body_choice/artifact.json
+++ b/examples/build/route_state_body_choice/artifact.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "id": "a095cbb1ea08d7ccc1e64e02e485d1ad003c660a7462ee17f485a8f61d09b17f",
+  "id": "ed892b957437575d8db13091b7dfff73d309b3026208a2dadae06b6edf469085",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -497,7 +497,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Mux",
@@ -646,21 +646,27 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Mux",
-                "Spectator"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Mux",
+                    "Spectator"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Spectator",
                 "template_id": "template/spectator",
                 "state_expr": "next_board"
               },
               {
-                "output": null,
+                "output": "next",
                 "actor": "Mux",
                 "template_id": "template/mux",
                 "state_expr": "next_board"
@@ -697,7 +703,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Pawn",
@@ -777,21 +783,27 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Pawn",
-                "Knight"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Pawn",
+                    "Knight"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Pawn",
                 "template_id": "template/pawn",
                 "state_expr": "next_board"
               },
               {
-                "output": null,
+                "output": "next",
                 "actor": "Knight",
                 "template_id": "template/knight",
                 "state_expr": "next_board"

--- a/examples/build/route_state_body_choice/manifest.json
+++ b/examples/build/route_state_body_choice/manifest.json
@@ -20,9 +20,9 @@
         {
           "name": "open_or_watch",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Mux", "Spectator"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Mux", "Spectator"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Spectator", "state": "next_board" }, { "output": null, "actor": "Mux", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Spectator", "state": "next_board" }, { "output": "next", "actor": "Mux", "state": "next_board" }]
         }
       ]
     },
@@ -34,9 +34,9 @@
         {
           "name": "choose",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["MoveActor"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["MoveActor"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "target", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "target", "state": "next_board" }]
         }
       ]
     },

--- a/examples/build/route_state_body_choice/sil/Lobby.sil
+++ b/examples/build/route_state_body_choice/sil/Lobby.sil
@@ -44,7 +44,7 @@ contract Lobby(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one Mux | Spectator
+        // :: output next: Mux | Spectator
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         BoardState next_board = {
@@ -61,7 +61,7 @@ contract Lobby(
                 gen__spectator_template
             );
         } else {
-            Gen__MuxState gen__state_mux_gen__mux_state = {
+            Gen__MuxState gen__state_next_gen__mux_state = {
                 // :: generated fields
                 gen__mux_template: gen__mux_template,
                 gen__mux_routes: gen__mux_routes,
@@ -71,7 +71,7 @@ contract Lobby(
             // :: become Mux
             validateOutputStateWithTemplate(
                 gen__next_output_idx,
-                gen__state_mux_gen__mux_state,
+                gen__state_next_gen__mux_state,
                 gen__mux_prefix,
                 gen__mux_suffix,
                 gen__mux_template

--- a/examples/build/route_state_body_choice/sil/Mux.sil
+++ b/examples/build/route_state_body_choice/sil/Mux.sil
@@ -25,7 +25,8 @@ contract Mux(
     entrypoint function choose(int target, byte[] gen__target_prefix, byte[] gen__target_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor
+        // :: output next: MoveActor
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         State next_board = {
             // :: generated fields

--- a/examples/build/spawns/artifact.json
+++ b/examples/build/spawns/artifact.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "id": "66769ca423150857f06099ecfd9aa384437e235249914ed0f92d1e6c36bbc0c0",
+  "id": "292f839b84334db321d45b869a8510eca28ead6cc4324a16fb25239b67bdc979",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -202,7 +202,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Controller"
@@ -359,14 +359,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Controller"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Controller"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Controller",
                 "template_id": "template/controller",
                 "state_expr": "next"
@@ -403,7 +409,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Pair"
@@ -417,14 +423,20 @@
             "witnesses": [],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Pair"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Pair"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Pair",
                 "template_id": "template/pair",
                 "state_expr": "self.state"

--- a/examples/build/spawns/manifest.json
+++ b/examples/build/spawns/manifest.json
@@ -17,9 +17,9 @@
         {
           "name": "launch",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Controller"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Controller"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Controller", "state": "next" }]
+          "routes": [{ "output": "next", "actor": "Controller", "state": "next" }]
         }
       ]
     },
@@ -31,9 +31,9 @@
         {
           "name": "keep",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Pair"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Pair"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Pair", "state": "self.state" }]
+          "routes": [{ "output": "next", "actor": "Pair", "state": "self.state" }]
         }
       ]
     }

--- a/examples/build/spawns/sil/Controller.sil
+++ b/examples/build/spawns/sil/Controller.sil
@@ -30,7 +30,7 @@ contract Controller(
     ) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one Controller
+        // :: output next: Controller
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: genesis covenants

--- a/examples/build/spawns/sil/Pair.sil
+++ b/examples/build/spawns/sil/Pair.sil
@@ -22,7 +22,7 @@ contract Pair(
     entrypoint function keep() {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Pair
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pair
 
         // :: become Pair
         require(

--- a/examples/build/toy_chess/artifact.json
+++ b/examples/build/toy_chess/artifact.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "id": "96e41dcfd260de491f0cf598a4b562d3e6fd240bafad5430d8f2d5c81a78dbb0",
+  "id": "5322d689067e59520513f4b6c542484b324ae7562a513b2efd3cc26df3222c8f",
   "generator": {
     "name": "argentc",
     "version": "0.1.0"
@@ -585,7 +585,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Player"
@@ -654,14 +654,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Player"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Player"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Player",
                 "template_id": "template/player",
                 "state_expr": "next_player"
@@ -698,7 +704,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Mux"
@@ -794,14 +800,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Mux"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Mux"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Mux",
                 "template_id": "template/mux",
                 "state_expr": "next_board"
@@ -838,7 +850,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Pawn",
@@ -918,21 +930,27 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Pawn",
-                "Knight"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Pawn",
+                    "Knight"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Pawn",
                 "template_id": "template/pawn",
                 "state_expr": "next_board"
               },
               {
-                "output": null,
+                "output": "next",
                 "actor": "Knight",
                 "template_id": "template/knight",
                 "state_expr": "next_board"
@@ -960,7 +978,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Pawn",
@@ -1041,15 +1059,21 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Pawn",
-                "Knight"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Pawn",
+                    "Knight"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Knight",
                 "template_id": "template/knight",
                 "state_expr": "next_board"
@@ -1077,7 +1101,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Pawn"
@@ -1146,14 +1170,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Pawn"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Pawn"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Pawn",
                 "template_id": "template/pawn",
                 "state_expr": "next_board"
@@ -1181,7 +1211,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Knight"
@@ -1250,14 +1280,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Knight"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Knight"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Knight",
                 "template_id": "template/knight",
                 "state_expr": "next_board"
@@ -1294,7 +1330,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Mux"
@@ -1363,14 +1399,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Mux"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Mux"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Mux",
                 "template_id": "template/mux",
                 "state_expr": "next_board"
@@ -1407,7 +1449,7 @@
               "consumes": [],
               "outputs": [
                 {
-                  "name": null,
+                  "name": "next",
                   "auth_index": 0,
                   "actors": [
                     "Mux"
@@ -1476,14 +1518,20 @@
             ],
             "consumes": [],
             "emits": {
-              "kind": "one",
-              "actors": [
-                "Mux"
+              "kind": "outputs",
+              "outputs": [
+                {
+                  "name": "next",
+                  "auth_index": 0,
+                  "actors": [
+                    "Mux"
+                  ]
+                }
               ]
             },
             "routes": [
               {
-                "output": null,
+                "output": "next",
                 "actor": "Mux",
                 "template_id": "template/mux",
                 "state_expr": "next_board"

--- a/examples/build/toy_chess/manifest.json
+++ b/examples/build/toy_chess/manifest.json
@@ -20,9 +20,9 @@
         {
           "name": "register",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Player"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Player"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Player", "state": "next_player" }]
+          "routes": [{ "output": "next", "actor": "Player", "state": "next_player" }]
         }
       ]
     },
@@ -34,9 +34,9 @@
         {
           "name": "enter_mux",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Mux"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Mux"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Mux", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Mux", "state": "next_board" }]
         }
       ]
     },
@@ -48,30 +48,30 @@
         {
           "name": "choose",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["MoveActor"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["MoveActor"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "target", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "target", "state": "next_board" }]
         },
         {
           "name": "choose_knight_const",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["MoveActor"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["MoveActor"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "target", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "target", "state": "next_board" }]
         },
         {
           "name": "choose_pawn",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Pawn"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Pawn"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Pawn", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Pawn", "state": "next_board" }]
         },
         {
           "name": "choose_knight",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Knight"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Knight"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Knight", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Knight", "state": "next_board" }]
         }
       ]
     },
@@ -83,9 +83,9 @@
         {
           "name": "back_to_mux",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Mux"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Mux"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Mux", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Mux", "state": "next_board" }]
         }
       ]
     },
@@ -97,9 +97,9 @@
         {
           "name": "back_to_mux",
           "kind": "leader",
-          "emits": { "kind": "one", "actors": ["Mux"] },
+          "emits": { "kind": "outputs", "outputs": [{ "name": "next", "auth_index": 0, "actors": ["Mux"] }] },
           "consumes": [],
-          "routes": [{ "output": null, "actor": "Mux", "state": "next_board" }]
+          "routes": [{ "output": "next", "actor": "Mux", "state": "next_board" }]
         }
       ]
     }

--- a/examples/build/toy_chess/sil/Knight.sil
+++ b/examples/build/toy_chess/sil/Knight.sil
@@ -31,7 +31,7 @@ contract Knight(
     entrypoint function back_to_mux(byte[] gen__mux_prefix, byte[] gen__mux_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Mux
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Mux
 
         require(selector >= 0);
         State next_board = {

--- a/examples/build/toy_chess/sil/League.sil
+++ b/examples/build/toy_chess/sil/League.sil
@@ -39,7 +39,7 @@ contract League(
     entrypoint function register(byte[] gen__player_prefix, byte[] gen__player_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Player
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Player
 
         Gen__PlayerState next_player = {
             // :: generated fields

--- a/examples/build/toy_chess/sil/Mux.sil
+++ b/examples/build/toy_chess/sil/Mux.sil
@@ -31,7 +31,8 @@ contract Mux(
     entrypoint function choose(int target, byte[] gen__target_prefix, byte[] gen__target_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor
+        // :: output next: MoveActor
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         if (target == 1 /*KNIGHT*/) {
             require(selector >= 0);
@@ -64,7 +65,8 @@ contract Mux(
     entrypoint function choose_knight_const(byte[] gen__target_prefix, byte[] gen__target_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one MoveActor
+        // :: output next: MoveActor
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         State next_board = {
             // :: generated fields
@@ -97,7 +99,7 @@ contract Mux(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Pawn
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pawn
 
         State next_board = {
             // :: generated fields
@@ -124,7 +126,7 @@ contract Mux(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Knight
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Knight
 
         State next_board = {
             // :: generated fields

--- a/examples/build/toy_chess/sil/Pawn.sil
+++ b/examples/build/toy_chess/sil/Pawn.sil
@@ -31,7 +31,7 @@ contract Pawn(
     entrypoint function back_to_mux(byte[] gen__mux_prefix, byte[] gen__mux_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Mux
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Mux
 
         State next_board = {
             // :: generated fields

--- a/examples/build/toy_chess/sil/Player.sil
+++ b/examples/build/toy_chess/sil/Player.sil
@@ -45,7 +45,7 @@ contract Player(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Mux
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Mux
 
         Gen__MuxState next_board = {
             // :: generated fields

--- a/examples/icc/kcc20_asset.ag
+++ b/examples/icc/kcc20_asset.ag
@@ -35,6 +35,7 @@ actor KCC20 owns KCC20State {
             amount: amount,
         };
 
+        unrestricted(next.value);
         become next <- KCC20(next_state);
     }
 }
@@ -50,6 +51,8 @@ actor MinterProxy owns MinterProxyState {
         require(controller_id.co_spent());
         require(next_proxy.controller_id == controller_id);
 
+        unrestricted(proxy.value);
+        unrestricted(recipient.value);
         become {
             proxy <- MinterProxy(next_proxy),
             recipient <- KCC20(recipient),

--- a/examples/icc/minter.ag
+++ b/examples/icc/minter.ag
@@ -35,10 +35,10 @@ actor Minter owns MinterState {
         require(checkSig(owner_sig, owner));
         require(initialized);
         require(amount >= minted_amount);
-        require(prev_proxy.controller_id == self.covenant_id);
+        require(prev_proxy.controller_id == self.cov_id);
 
         MinterProxyState next_proxy = {
-            controller_id: self.covenant_id,
+            controller_id: self.cov_id,
         };
 
         KCC20State next_recipient = {

--- a/examples/icc/minter.ag
+++ b/examples/icc/minter.ag
@@ -59,6 +59,7 @@ actor Minter owns MinterState {
             initialized: initialized,
         };
 
+        unrestricted(controller.value);
         become controller <- Minter(next_controller);
     }
 }

--- a/examples/open_icc/agent.ag
+++ b/examples/open_icc/agent.ag
@@ -28,6 +28,7 @@ actor Agent owns AgentCapsule {
         require(next_agent.strategy == strategy);
         require(next_agent.generation == generation);
 
+        unrestricted(agent.value);
         become agent <- Agent(next_agent);
     }
 }
@@ -57,6 +58,7 @@ actor Forager owns ForagerState {
             generation: generation,
         };
 
+        unrestricted(agent.value);
         become agent <- Forager(next_agent);
     }
 }

--- a/examples/open_icc/core.ag
+++ b/examples/open_icc/core.ag
@@ -82,6 +82,7 @@ actor Cell owns CellState {
             occupant_caps_digest: occupant_caps_digest,
         };
 
+        unrestricted(cell.value);
         become cell <- Cell(next_cell);
     }
 
@@ -161,6 +162,8 @@ actor Cell owns CellState {
             agent <- self.occupant_agent_type(next_agent),
         };
 
+        unrestricted(source_cell.value);
+        unrestricted(target_cell.value);
         become {
             source_cell <- Cell(next_source),
             target_cell <- Cell(next_target),

--- a/examples/route_state_bodies.ag
+++ b/examples/route_state_bodies.ag
@@ -22,6 +22,7 @@ actor Lobby owns LobbyState {
             ply: nonce,
         };
 
+        unrestricted(next.value);
         become next <- Mux(next_board);
     }
 }
@@ -32,6 +33,7 @@ actor Mux owns BoardState {
             ply: ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- target(next_board);
     }
 
@@ -42,6 +44,7 @@ actor Mux owns BoardState {
             final_ply: ply,
         };
 
+        unrestricted(next.value);
         become next <- Archive(next_archive);
     }
 }
@@ -74,6 +77,7 @@ actor Archive owns ArchiveState {
             ply: final_ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- Pawn(next_board);
     }
 }

--- a/examples/route_state_bodies.ag
+++ b/examples/route_state_bodies.ag
@@ -17,32 +17,32 @@ actor enum MoveActor {
 
 // Lobby carries the packed Board family and opens it when entering Mux.
 actor Lobby owns LobbyState {
-    entry open_board() emits one Mux {
+    entry open_board() emits next: Mux {
         BoardState next_board = {
             ply: nonce,
         };
 
-        become Mux(next_board);
+        become next <- Mux(next_board);
     }
 }
 
 actor Mux owns BoardState {
-    entry choose(MoveActor target) emits one MoveActor {
+    entry choose(MoveActor target) emits next: MoveActor {
         BoardState next_board = {
             ply: ply + 1,
         };
 
-        become target(next_board);
+        become next <- target(next_board);
     }
 
     // Archive needs one packed Board-family commitment, so this transition
     // packs the open table carried by Mux.
-    entry archive() emits one Archive {
+    entry archive() emits next: Archive {
         ArchiveState next_archive = {
             final_ply: ply,
         };
 
-        become Archive(next_archive);
+        become next <- Archive(next_archive);
     }
 }
 
@@ -69,12 +69,12 @@ actor Spectator owns BoardState {
 
 // This downstream route gives Archive a packed Board-family dependency.
 actor Archive owns ArchiveState {
-    entry reopen_as_pawn() emits one Pawn {
+    entry reopen_as_pawn() emits next: Pawn {
         BoardState next_board = {
             ply: final_ply + 1,
         };
 
-        become Pawn(next_board);
+        become next <- Pawn(next_board);
     }
 }
 

--- a/examples/route_state_body_choice.ag
+++ b/examples/route_state_body_choice.ag
@@ -14,26 +14,26 @@ actor enum MoveActor {
 actor Lobby owns LobbyState {
     // `next_board` has no single generated layout until this branch chooses
     // between the open Mux cut and Spectator's empty cut.
-    entry open_or_watch(bool watch) emits one Mux | Spectator {
+    entry open_or_watch(bool watch) emits next: Mux | Spectator {
         BoardState next_board = {
             ply: nonce,
         };
 
         if (watch) {
-            become Spectator(next_board);
+            become next <- Spectator(next_board);
         } else {
-            become Mux(next_board);
+            become next <- Mux(next_board);
         }
     }
 }
 
 actor Mux owns BoardState {
-    entry choose(MoveActor target) emits one MoveActor {
+    entry choose(MoveActor target) emits next: MoveActor {
         BoardState next_board = {
             ply: ply + 1,
         };
 
-        become target(next_board);
+        become next <- target(next_board);
     }
 }
 

--- a/examples/route_state_body_choice.ag
+++ b/examples/route_state_body_choice.ag
@@ -19,6 +19,7 @@ actor Lobby owns LobbyState {
             ply: nonce,
         };
 
+        unrestricted(next.value);
         if (watch) {
             become next <- Spectator(next_board);
         } else {
@@ -33,6 +34,7 @@ actor Mux owns BoardState {
             ply: ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- target(next_board);
     }
 }

--- a/examples/spawns.ag
+++ b/examples/spawns.ag
@@ -27,16 +27,20 @@ actor Controller owns ControllerState {
             launches: launches + 1,
         };
 
+        unrestricted(new_pair.outputs.left.value);
+        unrestricted(new_pair.outputs.right.value);
         require new_pair.outputs become {
             left <- self.pair_type(left),
             right <- self.pair_type(right),
         };
+        unrestricted(next.value);
         become next <- Controller(next);
     }
 }
 
 actor Pair owns PairState {
     entry keep() emits next: Pair {
+        unrestricted(next.value);
         become next <- Pair(self.state);
     }
 }

--- a/examples/spawns.ag
+++ b/examples/spawns.ag
@@ -15,7 +15,7 @@ actor Controller owns ControllerState {
             right: self.pair_type,
         }
     }
-    emits one Controller {
+    emits next: Controller {
         PairState left = {
             amount: left_amount,
         };
@@ -31,13 +31,13 @@ actor Controller owns ControllerState {
             left <- self.pair_type(left),
             right <- self.pair_type(right),
         };
-        become Controller(next);
+        become next <- Controller(next);
     }
 }
 
 actor Pair owns PairState {
-    entry keep() emits one Pair {
-        become Pair(self.state);
+    entry keep() emits next: Pair {
+        become next <- Pair(self.state);
     }
 }
 

--- a/examples/stones/README.md
+++ b/examples/stones/README.md
@@ -65,7 +65,7 @@ Compiler features exercised today:
 - typed covenant peer reads through `readInputStateWithTemplate`
 - single-output `become`
 - multi-output atomic `become`
-- read-only output handles such as `next.value`
+- explicitly declared read-only output handles such as `next.value`
 - ordinary `require(...)` checks for output value policy
 - generated hidden template fields
 - generated successor validation through `validateOutputStateWithTemplate`

--- a/examples/toy_chess/app.ag
+++ b/examples/toy_chess/app.ag
@@ -22,6 +22,7 @@ actor League owns LeagueState {
             nonce: nonce + 1,
         };
 
+        unrestricted(next.value);
         become next <- Player(next_player);
     }
 }
@@ -33,6 +34,7 @@ actor Player owns PlayerState {
             ply: 0,
         };
 
+        unrestricted(next.value);
         become next <- Mux(next_board);
     }
 }
@@ -48,6 +50,7 @@ actor Mux owns BoardState {
             ply: ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- target(next_board);
     }
 
@@ -58,6 +61,7 @@ actor Mux owns BoardState {
         };
 
         actor_type<BoardState> target = MoveActor::Knight;
+        unrestricted(next.value);
         become next <- target(next_board);
     }
 
@@ -67,6 +71,7 @@ actor Mux owns BoardState {
             ply: ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- Pawn(next_board);
     }
 
@@ -76,6 +81,7 @@ actor Mux owns BoardState {
             ply: ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- Knight(next_board);
     }
 }
@@ -87,6 +93,7 @@ actor Pawn owns BoardState {
             ply: ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- Mux(next_board);
     }
 }
@@ -100,6 +107,7 @@ actor Knight owns BoardState {
             ply: ply + 1,
         };
 
+        unrestricted(next.value);
         become next <- Mux(next_board);
     }
 }

--- a/examples/toy_chess/app.ag
+++ b/examples/toy_chess/app.ag
@@ -17,28 +17,28 @@ actor enum MoveActor {
 }
 
 actor League owns LeagueState {
-    entry register() emits one Player {
+    entry register() emits next: Player {
         PlayerState next_player = {
             nonce: nonce + 1,
         };
 
-        become Player(next_player);
+        become next <- Player(next_player);
     }
 }
 
 actor Player owns PlayerState {
-    entry enter_mux() emits one Mux {
+    entry enter_mux() emits next: Mux {
         BoardState next_board = {
             selector: nonce,
             ply: 0,
         };
 
-        become Mux(next_board);
+        become next <- Mux(next_board);
     }
 }
 
 actor Mux owns BoardState {
-    entry choose(MoveActor target) emits one MoveActor {
+    entry choose(MoveActor target) emits next: MoveActor {
         if (target == MoveActor::Knight) {
             require(selector >= 0);
         }
@@ -48,51 +48,51 @@ actor Mux owns BoardState {
             ply: ply + 1,
         };
 
-        become target(next_board);
+        become next <- target(next_board);
     }
 
-    entry choose_knight_const() emits one MoveActor {
+    entry choose_knight_const() emits next: MoveActor {
         BoardState next_board = {
             selector: selector,
             ply: ply + 1,
         };
 
         actor_type<BoardState> target = MoveActor::Knight;
-        become target(next_board);
+        become next <- target(next_board);
     }
 
-    entry choose_pawn() emits one Pawn {
+    entry choose_pawn() emits next: Pawn {
         BoardState next_board = {
             selector: selector,
             ply: ply + 1,
         };
 
-        become Pawn(next_board);
+        become next <- Pawn(next_board);
     }
 
-    entry choose_knight() emits one Knight {
+    entry choose_knight() emits next: Knight {
         BoardState next_board = {
             selector: selector,
             ply: ply + 1,
         };
 
-        become Knight(next_board);
+        become next <- Knight(next_board);
     }
 }
 
 actor Pawn owns BoardState {
-    entry back_to_mux() emits one Mux {
+    entry back_to_mux() emits next: Mux {
         BoardState next_board = {
             selector: selector,
             ply: ply + 1,
         };
 
-        become Mux(next_board);
+        become next <- Mux(next_board);
     }
 }
 
 actor Knight owns BoardState {
-    entry back_to_mux() emits one Mux {
+    entry back_to_mux() emits next: Mux {
         require(selector >= 0);
 
         BoardState next_board = {
@@ -100,7 +100,7 @@ actor Knight owns BoardState {
             ply: ply + 1,
         };
 
-        become Mux(next_board);
+        become next <- Mux(next_board);
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -146,7 +146,6 @@ pub struct ObservedActorDecl {
 #[derive(Debug, Clone)]
 pub enum EmitSpec {
     None,
-    One { actors: Vec<String> },
     Outputs(Vec<EmitOutput>),
 }
 
@@ -165,7 +164,7 @@ pub struct AppDecl {
 
 #[derive(Debug, Clone)]
 pub struct RouteCall {
-    pub output: Option<String>,
+    pub output: String,
     pub actor: String,
     pub state: String,
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -386,13 +386,13 @@ mod tests {
             }
 
             actor Blob owns BlobState {
-                entry store(byte[] data) emits one Blob {
+                entry store(byte[] data) emits next: Blob {
                     BlobState next = {
                         size: data.length,
                         digest: blake2b(data),
                     };
 
-                    become Blob(next);
+                    become next <- Blob(next);
                 }
             }
 
@@ -438,14 +438,14 @@ mod tests {
             }
 
             actor Issuer owns IssuerState {
-                entry issue(byte[] domain, byte[32] expected) emits one Issuer {
+                entry issue(byte[] domain, byte[32] expected) emits next: Issuer {
                     byte[32] uid = invocation_uid(domain);
                     require(uid == expected);
 
                     IssuerState next = {
                         last_uid: uid,
                     };
-                    become Issuer(next);
+                    become next <- Issuer(next);
                 }
             }
 
@@ -531,7 +531,7 @@ mod tests {
             }
 
             actor Counter owns CounterState {
-                entry bump(sig owner_sig, int delta) emits one Counter {
+                entry bump(sig owner_sig, int delta) emits next: Counter {
                     require(checkSig(owner_sig, owner));
 
                     CounterState next = {
@@ -539,7 +539,7 @@ mod tests {
                         count: count + delta,
                     };
 
-                    become Counter(next);
+                    become next <- Counter(next);
                 }
             }
 
@@ -822,15 +822,15 @@ mod tests {
             }
 
             actor Foreign owns ForeignState {
-                entry hold() emits one Foreign {
-                    become Foreign(self.state);
+                entry hold() emits next: Foreign {
+                    become next <- Foreign(self.state);
                 }
 
-                entry route() emits one Target {
+                entry route() emits next: Target {
                     TargetState next = {
                         units: 0,
                     };
-                    become Target(next);
+                    become next <- Target(next);
                 }
             }
 
@@ -844,7 +844,7 @@ mod tests {
                         next: Foreign,
                     }
                 }
-                emits one Local {
+                emits next: Local {
                     ForeignState next_foreign = remote.inputs.src.state;
                     require remote.outputs become {
                         next <- Foreign(next_foreign),
@@ -854,7 +854,7 @@ mod tests {
                         foreign_id: foreign_id,
                         steps: steps + 1,
                     };
-                    become Local(next_local);
+                    become next <- Local(next_local);
                 }
             }
 
@@ -1601,8 +1601,8 @@ mod tests {
         assert_eq!(entry.route_plan.consumes[0].actor, "Player");
         assert_eq!(entry.route_plan.consumes[0].cov_index, Some(1));
         assert_eq!(
-            entry.route_plan.outputs.iter().map(|output| (output.name.as_deref(), output.auth_index)).collect::<Vec<_>>(),
-            vec![(Some("self_out"), 0), (Some("opponent_out"), 1), (Some("game"), 2)]
+            entry.route_plan.outputs.iter().map(|output| (output.name.as_str(), output.auth_index)).collect::<Vec<_>>(),
+            vec![("self_out", 0), ("opponent_out", 1), ("game", 2)]
         );
         assert_eq!(
             entry
@@ -1951,12 +1951,12 @@ mod tests {
             }
 
             actor Mux owns BoardState {
-                entry choose(MoveActor target) emits one MoveActor {
+                entry choose(MoveActor target) emits next: MoveActor {
                     BoardState next = {
                         ply: ply + 1,
                     };
 
-                    become target(next);
+                    become next <- target(next);
                 }
             }
 
@@ -2152,11 +2152,11 @@ mod tests {
             }
 
             actor Foo owns FooState {
-                entry bump(int amount) emits one Foo {
+                entry bump(int amount) emits next: Foo {
                     State next_state = {
                         count: count + amount,
                     };
-                    become Foo(next_state);
+                    become next <- Foo(next_state);
                 }
             }
 
@@ -3055,9 +3055,9 @@ mod tests {
             }
 
             actor Agent owns AgentCapsule {
-                entry step(AgentCapsule next_state) emits one Agent {
+                entry step(AgentCapsule next_state) emits next: Agent {
                     require(controller_id.co_spent());
-                    become Agent(next_state);
+                    become next <- Agent(next_state);
                 }
             }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -387,6 +387,7 @@ mod tests {
 
             actor Blob owns BlobState {
                 entry store(byte[] data) emits next: Blob {
+                    unrestricted(next.value);
                     BlobState next = {
                         size: data.length,
                         digest: blake2b(data),
@@ -439,6 +440,7 @@ mod tests {
 
             actor Issuer owns IssuerState {
                 entry issue(byte[] domain, byte[32] expected) emits next: Issuer {
+                    unrestricted(next.value);
                     byte[32] uid = invocation_uid(domain);
                     require(uid == expected);
 
@@ -532,6 +534,7 @@ mod tests {
 
             actor Counter owns CounterState {
                 entry bump(sig owner_sig, int delta) emits next: Counter {
+                    unrestricted(next.value);
                     require(checkSig(owner_sig, owner));
 
                     CounterState next = {
@@ -608,6 +611,8 @@ mod tests {
                     left_out: Left,
                     peer_out: Right,
                 } {
+                    unrestricted(left_out.value);
+                    unrestricted(peer_out.value);
                     BoxState next_left = { units: units - amount, };
                     BoxState next_peer = { units: peer.units + amount, };
 
@@ -823,10 +828,12 @@ mod tests {
 
             actor Foreign owns ForeignState {
                 entry hold() emits next: Foreign {
+                    unrestricted(next.value);
                     become next <- Foreign(self.state);
                 }
 
                 entry route() emits next: Target {
+                    unrestricted(next.value);
                     TargetState next = {
                         units: 0,
                     };
@@ -845,6 +852,7 @@ mod tests {
                     }
                 }
                 emits next: Local {
+                    unrestricted(next.value);
                     ForeignState next_foreign = remote.inputs.src.state;
                     require remote.outputs become {
                         next <- Foreign(next_foreign),
@@ -1952,6 +1960,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry choose(MoveActor target) emits next: MoveActor {
+                    unrestricted(next.value);
                     BoardState next = {
                         ply: ply + 1,
                     };
@@ -2153,6 +2162,7 @@ mod tests {
 
             actor Foo owns FooState {
                 entry bump(int amount) emits next: Foo {
+                    unrestricted(next.value);
                     State next_state = {
                         count: count + amount,
                     };
@@ -3056,6 +3066,7 @@ mod tests {
 
             actor Agent owns AgentCapsule {
                 entry step(AgentCapsule next_state) emits next: Agent {
+                    unrestricted(next.value);
                     require(controller_id.co_spent());
                     become next <- Agent(next_state);
                 }
@@ -3192,6 +3203,7 @@ mod tests {
                 entry step() emits {
                     agent: Forager,
                 } {
+                    unrestricted(agent.value);
                     require(controller_id.co_spent());
 
                     ForagerState next_agent = {

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -2934,8 +2934,15 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         assert_eq!(word::SELF, "self");
         assert_eq!(word::VALUE, "value");
         assert_eq!(word::COVENANT_ID, "cov_id");
-        let mut out = expr.replace("self.value", "tx.inputs[this.activeInputIndex].value");
-        out = out.replace("self.cov_id", "OpInputCovenantId(this.activeInputIndex)");
+        let mut out = replace_exact_identifier(expr, "self.value", "tx.inputs[this.activeInputIndex].value");
+        out = replace_exact_identifier(&out, "self.cov_id", "OpInputCovenantId(this.activeInputIndex)");
+        // TODO: Replace the raw qualified-reference substitutions below with a
+        // token-aware rewriter shared with `count_qualified_ref`. Each source
+        // should match an exact identifier-and-dot token path rooted at the
+        // expression level (in particular, not after another `.`), without
+        // matching longer identifiers or prefix-related fields. Replacements
+        // should be selected from the original token spans in one pass so that
+        // generated text is never reconsidered by a later substitution.
         for spec in state_expansion_witness_specs_for_actor(self.actor, self.model) {
             for field in &self.model.state(&spec.memory_state)?.fields {
                 let local = hidden_state_expansion_field_name(&spec, &field.name);
@@ -5673,6 +5680,27 @@ fn parse_call_statement<'a>(statement: &'a str, callee: &str) -> Option<&'a str>
     tail.strip_prefix('(')?.strip_suffix(')').map(str::trim)
 }
 
+/// Replace an exact identifier reference without matching within a longer identifier.
+fn replace_exact_identifier(input: &str, source: &str, replacement: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0;
+    let bytes = input.as_bytes();
+    let identifier_char = |byte: &u8| byte.is_ascii_alphanumeric() || *byte == b'_';
+    for (start, _) in input.match_indices(source) {
+        let end = start + source.len();
+        let continues_previous = start.checked_sub(1).and_then(|previous| bytes.get(previous)).is_some_and(identifier_char);
+        let continues_next = bytes.get(end).is_some_and(identifier_char);
+        if continues_previous || continues_next {
+            continue;
+        }
+        out.push_str(&input[cursor..start]);
+        out.push_str(replacement);
+        cursor = end;
+    }
+    out.push_str(&input[cursor..]);
+    out
+}
+
 fn count_qualified_ref(tokens: &[Token], source: &str) -> usize {
     let segments = source.split('.').collect::<Vec<_>>();
     let token_count = segments.len() * 2 - 1;
@@ -7486,6 +7514,47 @@ mod tests {
             sil.contains("require(OpInputCovenantId(this.activeInputIndex) == OpInputCovenantId(this.activeInputIndex));"),
             "{sil}"
         );
+    }
+
+    #[test]
+    fn self_member_prefixes_remain_state_field_refs() {
+        let source = r#"
+            state FooState {
+                int value_note;
+                int cov_id_note;
+            }
+            state PeerState {}
+
+            actor Foo owns FooState {
+                entry step()
+                consumes {
+                    foo_self: Peer,
+                }
+                emits next: Foo {
+                    unrestricted(next.value);
+                    require(self.value_note == value_note);
+                    require(self.cov_id_note == cov_id_note);
+                    require(foo_self.value >= 0);
+                    become next <- Foo(self.state);
+                }
+            }
+
+            actor Peer owns PeerState {}
+
+            app Test {
+                actor Foo;
+                actor Peer;
+            }
+        "#;
+        let path = PathBuf::from("test.ag");
+        let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
+        let program = Program { root: path, modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+        let sil = emit_actor(model.actor("Foo").expect("actor exists"), &model).expect("actor emits");
+
+        assert!(sil.contains("require(value_note == value_note);"), "{sil}");
+        assert!(sil.contains("require(cov_id_note == cov_id_note);"), "{sil}");
+        assert!(sil.contains("require(tx.inputs[gen__foo_self_input_idx].value >= 0);"), "{sil}");
     }
 
     #[test]

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -414,9 +414,7 @@ impl<'a> Model<'a> {
                     }
                 }
                 for route in &entry.routes {
-                    if let Some(output) = &route.output {
-                        reject_reserved_identifier(&format!("entry `{}::{}` route output handle", actor.name, entry.name), output)?;
-                    }
+                    reject_reserved_identifier(&format!("entry `{}::{}` route output handle", actor.name, entry.name), &route.output)?;
                 }
             }
         }
@@ -464,14 +462,6 @@ impl<'a> Model<'a> {
 
         match &entry.emits {
             EmitSpec::None => {}
-            EmitSpec::One { actors } => {
-                for target in self.expand_actor_refs(actors) {
-                    self.require_template_actor(
-                        &target,
-                        format!("entry `{}::{}` emits unknown actor `{target}`", actor.name, entry.name),
-                    )?;
-                }
-            }
             EmitSpec::Outputs(outputs) => {
                 let mut names = BTreeSet::new();
                 let mut auth_indices = BTreeSet::new();
@@ -745,36 +735,12 @@ impl<'a> Model<'a> {
                 "entry `{}::{}` has a `become` route to `{}`, but declares `emits none`",
                 actor.name, entry.name, route.actor
             ))),
-            EmitSpec::One { actors } => {
-                if let Some(output) = &route.output {
-                    return Err(ArgentError::new(format!(
-                        "entry `{}::{}` names output `{output}`, but `emits one` uses an unnamed output",
-                        actor.name, entry.name
-                    )));
-                }
-                let allowed = self.expand_actor_refs(actors);
-                let targets = self.route_targets(actor, entry, route)?;
-                if targets.iter().all(|target| allowed.iter().any(|allowed| allowed == target)) {
-                    Ok(())
-                } else {
-                    Err(ArgentError::new(format!(
-                        "entry `{}::{}` routes to `{}`, but `emits one` allows only {}",
-                        actor.name,
-                        entry.name,
-                        route.actor,
-                        actors.join(" | ")
-                    )))
-                }
-            }
             EmitSpec::Outputs(outputs) => {
-                let output_name = route.output.as_ref().ok_or_else(|| {
+                let output = outputs.iter().find(|output| output.name == route.output).ok_or_else(|| {
                     ArgentError::new(format!(
-                        "entry `{}::{}` routes to `{}` without an output handle, but declares named outputs",
-                        actor.name, entry.name, route.actor
+                        "entry `{}::{}` routes through unknown output `{}`",
+                        actor.name, entry.name, route.output
                     ))
-                })?;
-                let output = outputs.iter().find(|output| &output.name == output_name).ok_or_else(|| {
-                    ArgentError::new(format!("entry `{}::{}` routes through unknown output `{output_name}`", actor.name, entry.name))
                 })?;
                 let allowed = self.expand_actor_refs(&output.actors);
                 let targets = self.route_targets(actor, entry, route)?;
@@ -797,28 +763,8 @@ impl<'a> Model<'a> {
     fn validate_route_coverage(&self, actor: &ActorDecl, entry: &EntryDecl) -> Result<()> {
         match &entry.emits {
             EmitSpec::None => Ok(()),
-            EmitSpec::One { .. } => self.validate_single_output_coverage(actor, entry),
             EmitSpec::Outputs(outputs) => self.validate_named_output_coverage(actor, entry, outputs),
         }
-    }
-
-    fn validate_single_output_coverage(&self, actor: &ActorDecl, entry: &EntryDecl) -> Result<()> {
-        if entry.terminal_route_sets.is_empty() {
-            return Err(ArgentError::new(format!(
-                "entry `{}::{}` declares `emits one` but has no terminal `become` route",
-                actor.name, entry.name
-            )));
-        }
-
-        for (path_idx, routes) in entry.terminal_route_sets.iter().enumerate() {
-            if routes.len() != 1 || routes[0].output.is_some() {
-                return Err(ArgentError::new(format!(
-                    "entry `{}::{}` terminal path {} must validate exactly one unnamed output for `emits one`",
-                    actor.name, entry.name, path_idx
-                )));
-            }
-        }
-        Ok(())
     }
 
     fn validate_named_output_coverage(&self, actor: &ActorDecl, entry: &EntryDecl, outputs: &[EmitOutput]) -> Result<()> {
@@ -838,12 +784,7 @@ impl<'a> Model<'a> {
         for (path_idx, routes) in entry.terminal_route_sets.iter().enumerate() {
             let mut seen = BTreeSet::new();
             for route in routes {
-                let output = route.output.as_deref().ok_or_else(|| {
-                    ArgentError::new(format!(
-                        "entry `{}::{}` terminal path {} has an unnamed route but declares named outputs",
-                        actor.name, entry.name, path_idx
-                    ))
-                })?;
+                let output = route.output.as_str();
                 if !declared.contains(output) {
                     continue;
                 }
@@ -1359,15 +1300,6 @@ fn emit_entry(out: &mut String, actor: &ActorDecl, entry: &EntryDecl, model: &Mo
     out.push_str(&format!("        require(OpAuthOutputCount(this.activeInputIndex) == {auth_output_count});\n"));
     match &entry.emits {
         EmitSpec::None => {}
-        EmitSpec::One { actors } => {
-            let output_idx = hidden_next_output_idx_name();
-            push_generated_statement_with_comment(
-                out,
-                8,
-                &format!("int {output_idx} = OpAuthOutputIdx(this.activeInputIndex, 0)"),
-                &format!("emits one {}", actors.join(" | ")),
-            );
-        }
         EmitSpec::Outputs(outputs) => {
             for output in outputs {
                 let output_idx = hidden_output_idx_name(&output.name);
@@ -1390,7 +1322,6 @@ fn emit_entry(out: &mut String, actor: &ActorDecl, entry: &EntryDecl, model: &Mo
 fn emitted_auth_output_count(emits: &EmitSpec) -> usize {
     match emits {
         EmitSpec::None => 0,
-        EmitSpec::One { .. } => 1,
         EmitSpec::Outputs(outputs) => outputs.len(),
     }
 }
@@ -1826,9 +1757,6 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let mut output_names = BTreeSet::new();
         match &entry.emits {
             EmitSpec::None => {}
-            EmitSpec::One { .. } => {
-                output_names.insert("next".to_string());
-            }
             EmitSpec::Outputs(outputs) => {
                 output_names.extend(outputs.iter().map(|output| output.name.clone()));
             }
@@ -2002,13 +1930,16 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         lowered_ty: &str,
     ) -> Result<Option<String>> {
         // A route-neutral state object used only by one concrete route can
-        // receive that target layout at its declaration point. Counting exact
-        // identifier tokens keeps the optimization deliberately local: any
-        // read, rewrite, or second route preserves the route-neutral body.
+        // receive that target layout at its declaration point. Output handles
+        // are not state-local uses, even when both have the same source name.
+        // Any other read, rewrite, or second route preserves the route-neutral
+        // body.
+        let route_handle_uses = self.entry.routes.iter().filter(|route| route.output == name).count();
         if self.conditional_depth != 0
             || lowered_ty != source_ty
             || split_state_object_literal(expr).is_none()
-            || self.tokens.iter().filter(|token| matches!(&token.kind, TokenKind::Ident(ident) if ident == name)).count() != 2
+            || self.tokens.iter().filter(|token| matches!(&token.kind, TokenKind::Ident(ident) if ident == name)).count()
+                != 2 + route_handle_uses
         {
             return Ok(None);
         }
@@ -2134,13 +2065,11 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     }
 
     fn parse_become_route(&mut self) -> Result<RouteCall> {
-        let start = self.current().span.start;
-        let first = self.expect_any_ident()?;
-        let (output, actor) = if self.consume_left_arrow() {
-            (Some(first), self.take_route_actor_expr()?)
-        } else {
-            (None, self.take_route_actor_expr_from(start)?)
-        };
+        let output = self.expect_any_ident()?;
+        if !self.consume_left_arrow() {
+            return Err(self.error("every `become` route must name its output with `output <- Actor(state)`"));
+        }
+        let actor = self.take_route_actor_expr()?;
         self.expect_symbol('(')?;
         let state = self.take_balanced_expr('(', ')')?;
         Ok(RouteCall { output, actor, state })
@@ -2209,20 +2138,13 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         group: &CovenantGroup<'a>,
         routes: Vec<RouteCall>,
     ) -> Result<()> {
-        let outputs_by_name = group
-            .outputs()
-            .iter()
-            .map(|output| (output.handle().expect("external covenant outputs are named"), output))
-            .collect::<BTreeMap<_, _>>();
+        let outputs_by_name = group.outputs().iter().map(|output| (output.handle(), output)).collect::<BTreeMap<_, _>>();
         let group_name = group.name().expect("current covenant is not lowered through an external output clause");
         let group_label = if group.observe().is_some() { "observe" } else { "spawn" };
-        let route_label = if group.observe().is_some() { "observed" } else { "spawned" };
         let mut seen = BTreeSet::new();
 
         for route in routes {
-            let Some(handle) = route.output.as_deref() else {
-                return Err(self.error(format!("{route_label} output route to `{}` is missing an output handle", route.actor)));
-            };
+            let handle = route.output.as_str();
             let Some(output) = outputs_by_name.get(handle).copied() else {
                 return Err(self.error(format!("{group_label} `{group_name}` has no output `{handle}`")));
             };
@@ -2241,7 +2163,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         }
 
         for output in group.outputs() {
-            let handle = output.handle().expect("external covenant outputs are named");
+            let handle = output.handle();
             if !seen.contains(handle) {
                 return Err(self.error(format!("{group_label} `{group_name}` does not validate output `{handle}`")));
             }
@@ -2518,7 +2440,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             return self.lower_selector_route(out, indent, route);
         }
         self.model.actor_state(&route.actor)?;
-        let output_idx = route.output.as_ref().map_or_else(hidden_next_output_idx_name, |output| hidden_output_idx_name(output));
+        let output_idx = hidden_output_idx_name(&route.output);
         let validation = route_validation_kind(self.actor, &route);
 
         if validation == RouteValidationKind::ExactScriptPublicKey {
@@ -2601,7 +2523,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             .get(&route.actor)
             .ok_or_else(|| ArgentError::new(format!("unknown actor handle `{}`", route.actor)))?
             .clone();
-        let output_idx = route.output.as_ref().map_or_else(hidden_next_output_idx_name, |output| hidden_output_idx_name(output));
+        let output_idx = hidden_output_idx_name(&route.output);
         let layout_actor = selector.variants.first().expect("validated actor selector has at least one variant");
         let transition = self
             .model
@@ -3208,8 +3130,7 @@ fn push_generated_statement_with_comment(out: &mut String, indent: usize, statem
 }
 
 fn generated_state_name(route: &RouteCall, state_ty: &str) -> String {
-    let base = route.output.as_deref().unwrap_or(route.actor.as_str());
-    format!("{RESERVED_GENERATED_PREFIX}state_{}_{}", to_snake(base), to_snake(state_ty))
+    format!("{RESERVED_GENERATED_PREFIX}state_{}_{}", to_snake(&route.output), to_snake(state_ty))
 }
 
 fn split_state_constructor(expr: &str) -> Option<(&str, &str)> {
@@ -4272,11 +4193,9 @@ fn emit_manifest(program: &Program, model: &Model<'_>) -> String {
                 if route_idx > 0 {
                     out.push_str(", ");
                 }
-                let output =
-                    route.output.as_ref().map(|output| format!("\"{}\"", json_escape(output))).unwrap_or_else(|| "null".to_string());
                 out.push_str(&format!(
-                    "{{ \"output\": {}, \"actor\": \"{}\", \"state\": \"{}\" }}",
-                    output,
+                    "{{ \"output\": \"{}\", \"actor\": \"{}\", \"state\": \"{}\" }}",
+                    json_escape(&route.output),
                     json_escape(&route.actor),
                     json_escape(&compact_expr(&route.state))
                 ));
@@ -5496,7 +5415,7 @@ fn route_output_handles(entry: &EntryModel<'_>) -> Vec<RouteOutputHandleArtifact
         .outputs()
         .iter()
         .map(|output| RouteOutputHandleArtifact {
-            name: output.handle().map(str::to_string),
+            name: output.handle().to_string(),
             auth_index: output.index(),
             actors: output.target().actors().map(str::to_string).collect(),
         })
@@ -5519,28 +5438,18 @@ fn sil_entry_artifact(actor: &ActorDecl, entry_index: usize, entry: &EntryDecl, 
 fn emit_spec_artifact(entry: &EntryModel<'_>) -> EmitArtifact {
     match &entry.source().emits {
         EmitSpec::None => EmitArtifact::None,
-        EmitSpec::One { .. } => {
-            let [output] = entry.current().outputs() else {
-                unreachable!("emits one has one modeled output");
-            };
-            let InteractionSource::CurrentOutput { declaration, output: None } = output.source() else {
-                unreachable!("emits one retains its emit spec");
-            };
-            debug_assert!(matches!(declaration, EmitSpec::One { .. }));
-            EmitArtifact::One { actors: output.target().actors().map(str::to_string).collect() }
-        }
         EmitSpec::Outputs(_) => EmitArtifact::Outputs {
             outputs: entry
                 .current()
                 .outputs()
                 .iter()
                 .map(|interaction| {
-                    let InteractionSource::CurrentOutput { declaration, output: Some(_) } = interaction.source() else {
+                    let InteractionSource::CurrentOutput(output) = interaction.source() else {
                         unreachable!("named emits output retains its source");
                     };
-                    debug_assert!(matches!(declaration, EmitSpec::Outputs(_)));
+                    debug_assert_eq!(interaction.handle(), output.name);
                     EmitOutputArtifact {
-                        name: interaction.handle().expect("named output has a modeled handle").to_string(),
+                        name: interaction.handle().to_string(),
                         auth_index: interaction.index(),
                         actors: interaction.target().actors().map(str::to_string).collect(),
                     }
@@ -5808,16 +5717,6 @@ fn lower_actor_enum_literals(expr: &str, model: &Model<'_>) -> Result<String> {
 fn emit_emit_spec_json(out: &mut String, emits: &EmitSpec) {
     match emits {
         EmitSpec::None => out.push_str("{ \"kind\": \"none\" }"),
-        EmitSpec::One { actors } => {
-            out.push_str("{ \"kind\": \"one\", \"actors\": [");
-            for (idx, actor) in actors.iter().enumerate() {
-                if idx > 0 {
-                    out.push_str(", ");
-                }
-                out.push_str(&format!("\"{}\"", json_escape(actor)));
-            }
-            out.push_str("] }");
-        }
         EmitSpec::Outputs(outputs) => {
             out.push_str("{ \"kind\": \"outputs\", \"outputs\": [");
             for (output_idx, output) in outputs.iter().enumerate() {
@@ -6512,10 +6411,6 @@ fn hidden_input_idx_name(input: &str) -> String {
     format!("{RESERVED_GENERATED_PREFIX}{input}_input_idx")
 }
 
-fn hidden_next_output_idx_name() -> String {
-    format!("{RESERVED_GENERATED_PREFIX}next_output_idx")
-}
-
 fn hidden_output_idx_name(output: &str) -> String {
     format!("{RESERVED_GENERATED_PREFIX}{output}_output_idx")
 }
@@ -6619,7 +6514,7 @@ mod tests {
     fn rejects_route_outside_named_output_union() {
         let mut program = test_program();
         program.modules[0].actors[0].entries[0].routes =
-            vec![RouteCall { output: Some("next".to_string()), actor: "Game".to_string(), state: "next_game".to_string() }];
+            vec![RouteCall { output: "next".to_string(), actor: "Game".to_string(), state: "next_game".to_string() }];
 
         let err = Model::from_program(&program).expect_err("route must be rejected");
         assert!(err.to_string().contains("routes output `next` to `Game`"), "unexpected error: {err}");
@@ -6633,7 +6528,7 @@ mod tests {
             actors: vec!["Player".to_string(), "Game".to_string()],
             auth_index: 0,
         }]);
-        let route = RouteCall { output: Some("next".to_string()), actor: "Game".to_string(), state: "next_game".to_string() };
+        let route = RouteCall { output: "next".to_string(), actor: "Game".to_string(), state: "next_game".to_string() };
         program.modules[0].actors[0].entries[0].routes = vec![route.clone()];
         program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![route]];
 
@@ -6655,11 +6550,11 @@ mod tests {
             }
 
             actor Source owns SourceState {
-                entry choose_a() emits one A | B {
+                entry choose_a() emits next: A | B {
                     TargetState next = {
                         nonce: nonce,
                     };
-                    become A(next);
+                    become next <- A(next);
                 }
             }
 
@@ -6727,7 +6622,7 @@ mod tests {
             EmitOutput { name: "a".to_string(), actors: vec!["Player".to_string()], auth_index: 0 },
             EmitOutput { name: "b".to_string(), actors: vec!["Player".to_string()], auth_index: 1 },
         ]);
-        let route = RouteCall { output: Some("a".to_string()), actor: "Player".to_string(), state: "next_a".to_string() };
+        let route = RouteCall { output: "a".to_string(), actor: "Player".to_string(), state: "next_a".to_string() };
         program.modules[0].actors[0].entries[0].routes = vec![route.clone()];
         program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![route]];
 
@@ -6797,8 +6692,8 @@ mod tests {
     #[test]
     fn rejects_duplicate_named_output_coverage() {
         let mut program = test_program();
-        let first = RouteCall { output: Some("next".to_string()), actor: "Player".to_string(), state: "next_player".to_string() };
-        let second = RouteCall { output: Some("next".to_string()), actor: "Player".to_string(), state: "other_player".to_string() };
+        let first = RouteCall { output: "next".to_string(), actor: "Player".to_string(), state: "next_player".to_string() };
+        let second = RouteCall { output: "next".to_string(), actor: "Player".to_string(), state: "other_player".to_string() };
         program.modules[0].actors[0].entries[0].routes = vec![first.clone(), second.clone()];
         program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![first, second]];
 
@@ -6813,7 +6708,7 @@ mod tests {
         program.modules[0].actors[0].entries[0].consumes.push(ConsumeDecl { name: "leader".to_string(), actor: "Player".to_string() });
         program.modules[0].actors[0].entries[0].emits = EmitSpec::None;
         program.modules[0].actors[0].entries[0].routes =
-            vec![RouteCall { output: Some("next".to_string()), actor: "Player".to_string(), state: "next_player".to_string() }];
+            vec![RouteCall { output: "next".to_string(), actor: "Player".to_string(), state: "next_player".to_string() }];
 
         let err = Model::from_program(&program).expect_err("delegate become must be rejected");
         assert!(err.to_string().contains("cannot use `become`"), "unexpected error: {err}");
@@ -6857,15 +6752,15 @@ mod tests {
             }
 
             actor Leader owns LeaderState {
-                entry standalone() emits one Leader {
-                    become Leader(self.state);
+                entry standalone() emits next: Leader {
+                    become next <- Leader(self.state);
                 }
 
                 entry coordinated() consumes {
                     worker: Worker,
-                } emits one Leader {
+                } emits next: Leader {
                     require(worker.value >= 0);
-                    become Leader(self.state);
+                    become next <- Leader(self.state);
                 }
             }
 
@@ -6878,8 +6773,8 @@ mod tests {
             }
 
             actor Unrelated owns UnrelatedState {
-                entry standalone() emits one Unrelated {
-                    become Unrelated(self.state);
+                entry standalone() emits next: Unrelated {
+                    become next <- Unrelated(self.state);
                 }
             }
 
@@ -7089,7 +6984,7 @@ mod tests {
         let mut program = test_program();
         program.modules[0].actors[0].entries[0].emits =
             EmitSpec::Outputs(vec![EmitOutput { name: "gen__next".to_string(), actors: vec!["Player".to_string()], auth_index: 0 }]);
-        let route = RouteCall { output: Some("gen__next".to_string()), actor: "Player".to_string(), state: "next_player".to_string() };
+        let route = RouteCall { output: "gen__next".to_string(), actor: "Player".to_string(), state: "next_player".to_string() };
         program.modules[0].actors[0].entries[0].routes = vec![route.clone()];
         program.modules[0].actors[0].entries[0].terminal_route_sets = vec![vec![route]];
 
@@ -7140,9 +7035,9 @@ mod tests {
             state FooState {}
 
             actor Foo owns FooState {
-                entry step() emits one Foo {
+                entry step() emits next: Foo {
                     require(next.value == self.value);
-                    become Foo(self.state);
+                    become next <- Foo(self.state);
                 }
             }
 
@@ -7184,11 +7079,11 @@ mod tests {
             }
 
             actor Foo owns FooState {
-                entry bump(int amount) emits one Foo {
+                entry bump(int amount) emits next: Foo {
                     State next_state = {
                         count: count + amount,
                     };
-                    become Foo(next_state);
+                    become next <- Foo(next_state);
                 }
             }
 
@@ -7236,20 +7131,20 @@ mod tests {
             }
 
             actor Source owns SourceState {
-                entry finish() emits one Terminal {
+                entry finish() emits next: Terminal {
                     TerminalState next = {
                         count: count + 1,
                     };
-                    become Terminal(next);
+                    become next <- Terminal(next);
                 }
             }
 
             actor Terminal owns TerminalState {
-                entry step() emits one Terminal {
+                entry step() emits next: Terminal {
                     TerminalState next = {
                         count: count + 1,
                     };
-                    become Terminal(next);
+                    become next <- Terminal(next);
                 }
             }
 
@@ -7304,9 +7199,9 @@ mod tests {
             }
 
             actor Foo owns FooState {
-                entry step(int amount) emits one Foo {
+                entry step(int amount) emits next: Foo {
                     require(next.value == self.value);
-                    become Foo(self.state);
+                    become next <- Foo(self.state);
                 }
             }
 
@@ -7396,7 +7291,8 @@ mod tests {
         assert_eq!(entry.abi.entry, "step");
         assert!(entry.hidden_params.is_empty(), "exact same-state continuation should not expose template witnesses");
         assert!(entry.witnesses.is_empty(), "exact same-state continuation should not expose route witnesses");
-        assert!(matches!(entry.emits, EmitArtifact::One { .. }));
+        assert!(matches!(&entry.emits, EmitArtifact::Outputs { outputs } if outputs.len() == 1 && outputs[0].name == "next"));
+        assert_eq!(entry.routes[0].output, "next");
         assert_eq!(entry.routes[0].actor, "Foo");
         assert_eq!(entry.routes[0].state_expr, "self.state");
         assert_eq!(
@@ -7404,7 +7300,7 @@ mod tests {
             Some(("Foo", Some(0)))
         );
         assert_eq!(entry.route_plan.outputs[0].auth_index, 0);
-        assert_eq!(entry.route_plan.outputs[0].name, None);
+        assert_eq!(entry.route_plan.outputs[0].name, "next");
 
         let sil_entry = sil_contract.entry(&entry.abi.entry).expect("outer entry should point at Sil ABI entry");
         assert_eq!(sil_entry.selector, None);
@@ -7442,8 +7338,8 @@ mod tests {
             }
 
             actor Holder owns HolderState {
-                entry hold() emits one Holder {
-                    become Holder(self.state);
+                entry hold() emits next: Holder {
+                    become next <- Holder(self.state);
                 }
             }
 
@@ -7648,14 +7544,14 @@ mod tests {
             }
 
             actor Forager owns ForagerState {
-                entry step() emits one Forager {
+                entry step() emits next: Forager {
                     ForagerState next_state = {
                         strategy: {
                             hunger: strategy.hunger + 1,
                         },
                     };
 
-                    become Forager(next_state);
+                    become next <- Forager(next_state);
                 }
             }
 
@@ -8375,12 +8271,12 @@ mod tests {
                 consumes {
                     other: Counter,
                 }
-                emits one Counter {
+                emits next: Counter {
                     CounterState next = {
                         count: count + other.count,
                     };
 
-                    become Counter(next);
+                    become next <- Counter(next);
                 }
             }
 
@@ -8447,15 +8343,15 @@ mod tests {
             state TargetState {}
 
             actor Current owns SharedState {
-                entry step() emits one Current {
-                    become Current(self.state);
+                entry step() emits next: Current {
+                    become next <- Current(self.state);
                 }
             }
 
             actor Outside owns SharedState {
-                entry step() emits one Target {
+                entry step() emits next: Target {
                     TargetState next = {};
-                    become Target(next);
+                    become next <- Target(next);
                 }
             }
 
@@ -8873,56 +8769,56 @@ mod tests {
             }
 
             actor Source owns SourceState {
-                entry start() emits one HubA {
+                entry start() emits next: HubA {
                     SharedState next = { amount: amount + 1 };
-                    become HubA(next);
+                    become next <- HubA(next);
                 }
             }
 
             actor HubA owns SharedState {
-                entry advance() emits one A1 {
+                entry advance() emits next: A1 {
                     SharedState next = { amount: amount + 1 };
-                    become A1(next);
+                    become next <- A1(next);
                 }
             }
 
             actor A1 owns SharedState {
-                entry advance() emits one A2 {
+                entry advance() emits next: A2 {
                     SharedState next = { amount: amount + 1 };
-                    become A2(next);
+                    become next <- A2(next);
                 }
             }
 
             actor A2 owns SharedState {
-                entry cross() emits one HubB {
+                entry cross() emits next: HubB {
                     SharedState next = { amount: amount + 1 };
-                    become HubB(next);
+                    become next <- HubB(next);
                 }
             }
 
             actor HubB owns SharedState {
-                entry advance() emits one B1 {
+                entry advance() emits next: B1 {
                     SharedState next = { amount: amount + 1 };
-                    become B1(next);
+                    become next <- B1(next);
                 }
 
-                entry rewind() emits one A1 {
+                entry rewind() emits next: A1 {
                     SharedState next = { amount: amount + 1 };
-                    become A1(next);
+                    become next <- A1(next);
                 }
             }
 
             actor B1 owns SharedState {
-                entry advance() emits one B2 {
+                entry advance() emits next: B2 {
                     SharedState next = { amount: amount + 1 };
-                    become B2(next);
+                    become next <- B2(next);
                 }
             }
 
             actor B2 owns SharedState {
-                entry finish() emits one Tail {
+                entry finish() emits next: Tail {
                     TailState next = { amount: amount + 1 };
-                    become Tail(next);
+                    become next <- Tail(next);
                 }
             }
 
@@ -9053,22 +8949,22 @@ mod tests {
             }
 
             actor A owns SharedState {
-                entry leave() emits one Middle {
+                entry leave() emits next: Middle {
                     MiddleState next_middle = {
                         amount: amount,
                     };
-                    become Middle(next_middle);
+                    become next <- Middle(next_middle);
                 }
             }
 
             actor B owns SharedState {}
 
             actor Middle owns MiddleState {
-                entry leave() emits one Tail {
+                entry leave() emits next: Tail {
                     TailState next_tail = {
                         amount: amount,
                     };
-                    become Tail(next_tail);
+                    become next <- Tail(next_tail);
                 }
             }
 
@@ -9157,29 +9053,29 @@ mod tests {
             }
 
             actor Source owns SourceState {
-                entry send() emits one A {
+                entry send() emits next: A {
                     SharedState next = {
                         amount: amount,
                     };
-                    become A(next);
+                    become next <- A(next);
                 }
             }
 
             actor A owns SharedState {
-                entry leave() emits one TailA {
+                entry leave() emits next: TailA {
                     TailAState next = {
                         amount: amount,
                     };
-                    become TailA(next);
+                    become next <- TailA(next);
                 }
             }
 
             actor B owns SharedState {
-                entry leave() emits one TailB {
+                entry leave() emits next: TailB {
                     TailBState next = {
                         amount: amount,
                     };
-                    become TailB(next);
+                    become next <- TailB(next);
                 }
             }
 
@@ -9307,7 +9203,7 @@ mod tests {
                         mux: Mux,
                     }
                 }
-                emits one Observer {
+                emits next: Observer {
                     BoardState board = { turn: 0 };
                     require game.outputs become {
                         mux <- Mux(board),
@@ -9316,28 +9212,28 @@ mod tests {
                         game_id: game_id,
                         steps: steps + 1,
                     };
-                    become Observer(next);
+                    become next <- Observer(next);
                 }
             }
 
             actor Mux owns BoardState {
-                entry move() emits one Pawn {
+                entry move() emits next: Pawn {
                     BoardState next = { turn: turn + 1 };
-                    become Pawn(next);
+                    become next <- Pawn(next);
                 }
             }
 
             actor Pawn owns BoardState {
-                entry finish() emits one Mux {
+                entry finish() emits next: Mux {
                     BoardState next = { turn: turn + 1 };
-                    become Mux(next);
+                    become next <- Mux(next);
                 }
             }
 
             actor Knight owns BoardState {
-                entry finish() emits one Mux {
+                entry finish() emits next: Mux {
                     BoardState next = { turn: turn + 1 };
-                    become Mux(next);
+                    become next <- Mux(next);
                 }
             }
 
@@ -9381,9 +9277,9 @@ mod tests {
             }
 
             actor Foreign owns ForeignState {
-                entry route() emits one Target {
+                entry route() emits next: Target {
                     TargetState next = { amount: amount };
-                    become Target(next);
+                    become next <- Target(next);
                 }
             }
 
@@ -9530,9 +9426,9 @@ mod tests {
                         source: Foreign,
                     }
                 }
-                emits one Foreign {
+                emits next: Foreign {
                     ForeignState next = remote.inputs.source.state;
-                    become Foreign(next);
+                    become next <- Foreign(next);
                 }
             }
 
@@ -9587,20 +9483,20 @@ mod tests {
             }
 
             actor Source owns SourceState {
-                entry enter_pawn() emits one Pawn {
+                entry enter_pawn() emits next: Pawn {
                     BoardState next = {
                         ply: nonce,
                     };
-                    become Pawn(next);
+                    become next <- Pawn(next);
                 }
             }
 
             actor Mux owns BoardState {
-                entry choose(MoveActor target) emits one MoveActor {
+                entry choose(MoveActor target) emits next: MoveActor {
                     BoardState next = {
                         ply: ply + 1,
                     };
-                    become target(next);
+                    become next <- target(next);
                 }
             }
 
@@ -9619,22 +9515,22 @@ mod tests {
             actor Consumer owns ConsumerState {
                 entry verify() consumes {
                     pawn: Pawn,
-                } emits one Archive {
+                } emits next: Archive {
                     require(pawn.ply >= 0);
 
                     ArchiveState next = {
                         nonce: nonce + 1,
                     };
-                    become Archive(next);
+                    become next <- Archive(next);
                 }
             }
 
             actor Archive owns ArchiveState {
-                entry reopen() emits one Pawn {
+                entry reopen() emits next: Pawn {
                     BoardState next = {
                         ply: nonce,
                     };
-                    become Pawn(next);
+                    become next <- Pawn(next);
                 }
             }
 
@@ -9684,11 +9580,11 @@ mod tests {
         let source = toy_chess_source().replace(
             "            actor Mux owns BoardState {\n",
             r#"            actor Mux owns BoardState {
-                entry return_to_player() emits one Player {
+                entry return_to_player() emits next: Player {
                     PlayerState next_player = {
                         nonce: ply,
                     };
-                    become Player(next_player);
+                    become next <- Player(next_player);
                 }
 
 "#,
@@ -9736,7 +9632,7 @@ mod tests {
 
         assert!(choice_sil.contains("struct BoardState {"), "{choice_sil}");
         assert!(choice_sil.contains("BoardState next_board = {"), "{choice_sil}");
-        assert!(choice_sil.contains("Gen__MuxState gen__state_mux_gen__mux_state = {"), "{choice_sil}");
+        assert!(choice_sil.contains("Gen__MuxState gen__state_next_gen__mux_state = {"), "{choice_sil}");
         assert!(
             choice_sil
                 .contains("validateOutputStateWithTemplate(\n                gen__next_output_idx,\n                next_board,"),
@@ -9980,45 +9876,45 @@ mod tests {
             }
 
             actor Mux owns BoardState {
-                entry choose(MoveActor target) emits one MoveActor {
+                entry choose(MoveActor target) emits next: MoveActor {
                     BoardState next_board = {
                         ply: ply + 1,
                     };
-                    become target(next_board);
+                    become next <- target(next_board);
                 }
 
-                entry finish() emits one Receipt {
+                entry finish() emits next: Receipt {
                     ReceiptState receipt = {
                         final_ply: ply,
                     };
-                    become Receipt(receipt);
+                    become next <- Receipt(receipt);
                 }
             }
 
             actor Pawn owns BoardState {
-                entry back_to_mux() emits one Mux {
+                entry back_to_mux() emits next: Mux {
                     BoardState next_board = {
                         ply: ply + 1,
                     };
-                    become Mux(next_board);
+                    become next <- Mux(next_board);
                 }
             }
 
             actor Knight owns BoardState {
-                entry back_to_mux() emits one Mux {
+                entry back_to_mux() emits next: Mux {
                     BoardState next_board = {
                         ply: ply + 1,
                     };
-                    become Mux(next_board);
+                    become next <- Mux(next_board);
                 }
             }
 
             actor Receipt owns ReceiptState {
-                entry resume() emits one Mux {
+                entry resume() emits next: Mux {
                     BoardState next_board = {
                         ply: final_ply + 1,
                     };
-                    become Mux(next_board);
+                    become next <- Mux(next_board);
                 }
             }
 
@@ -10099,13 +9995,13 @@ mod tests {
             }
 
             actor Mux owns BoardState {
-                entry choose_knight_const() emits one MoveActor {
+                entry choose_knight_const() emits next: MoveActor {
                     BoardState next_board = {
                         ply: ply + 1,
                     };
 
                     actor_type<BoardState> target = MoveActor::Knight;
-                    become target(next_board);
+                    become next <- target(next_board);
                 }
             }
 
@@ -10194,20 +10090,20 @@ mod tests {
             }
 
             actor Mux owns BoardState {
-                entry choose_first(FirstMove target) emits one FirstMove {
+                entry choose_first(FirstMove target) emits next: FirstMove {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become target(next_board);
+                    become next <- target(next_board);
                 }
 
-                entry choose_second(SecondMove target) emits one SecondMove {
+                entry choose_second(SecondMove target) emits next: SecondMove {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become target(next_board);
+                    become next <- target(next_board);
                 }
             }
 
@@ -10242,20 +10138,20 @@ mod tests {
             }
 
             actor Mux owns BoardState {
-                entry choose(MoveActor target) emits one MoveActor {
+                entry choose(MoveActor target) emits next: MoveActor {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become target(next_board);
+                    become next <- target(next_board);
                 }
 
-                entry visit_bishop() emits one Bishop {
+                entry visit_bishop() emits next: Bishop {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become Bishop(next_board);
+                    become next <- Bishop(next_board);
                 }
             }
 
@@ -10301,11 +10197,11 @@ mod tests {
             }
 
             actor Challenge owns SharedState {
-                entry choose(NextActor target) emits one NextActor {
+                entry choose(NextActor target) emits next: NextActor {
                     SharedState next = {
                         amount: amount + 1,
                     };
-                    become target(next);
+                    become next <- target(next);
                 }
             }
 
@@ -10361,22 +10257,22 @@ mod tests {
             }
 
             actor A owns BoardState {
-                entry to_b() emits one B {
+                entry to_b() emits next: B {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become B(next);
+                    become next <- B(next);
                 }
             }
 
             actor B owns BoardState {
-                entry to_a() emits one A {
+                entry to_a() emits next: A {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become A(next);
+                    become next <- A(next);
                 }
             }
 
@@ -10415,62 +10311,62 @@ mod tests {
             }
 
             actor A owns BoardState {
-                entry to_b() emits one B {
+                entry to_b() emits next: B {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become B(next);
+                    become next <- B(next);
                 }
             }
 
             actor B owns BoardState {
-                entry to_c() emits one C {
+                entry to_c() emits next: C {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become C(next);
+                    become next <- C(next);
                 }
             }
 
             actor C owns BoardState {
-                entry to_a() emits one A {
+                entry to_a() emits next: A {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become A(next);
+                    become next <- A(next);
                 }
             }
 
             actor D owns BoardState {
-                entry to_e() emits one E {
+                entry to_e() emits next: E {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become E(next);
+                    become next <- E(next);
                 }
             }
 
             actor E owns BoardState {
-                entry to_f() emits one F {
+                entry to_f() emits next: F {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become F(next);
+                    become next <- F(next);
                 }
             }
 
             actor F owns BoardState {
-                entry to_d() emits one D {
+                entry to_d() emits next: D {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become D(next);
+                    become next <- D(next);
                 }
             }
 
@@ -10576,42 +10472,42 @@ mod tests {
             }
 
             actor PlayerA owns PlayerState {
-                entry enter_a() emits one HubA {
+                entry enter_a() emits next: HubA {
                     BoardState next = {
                         n: n,
                     };
 
-                    become HubA(next);
+                    become next <- HubA(next);
                 }
             }
 
             actor PlayerB owns PlayerState {
-                entry enter_b() emits one HubB {
+                entry enter_b() emits next: HubB {
                     BoardState next = {
                         n: n,
                     };
 
-                    become HubB(next);
+                    become next <- HubB(next);
                 }
             }
 
             actor HubB owns BoardState {
-                entry to_leaf() emits one Leaf {
+                entry to_leaf() emits next: Leaf {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become Leaf(next);
+                    become next <- Leaf(next);
                 }
             }
 
             actor HubA owns BoardState {
-                entry to_leaf() emits one Leaf {
+                entry to_leaf() emits next: Leaf {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become Leaf(next);
+                    become next <- Leaf(next);
                 }
             }
 
@@ -10663,62 +10559,62 @@ mod tests {
             }
 
             actor PlayerA owns PlayerState {
-                entry enter_a() emits one HubA {
+                entry enter_a() emits next: HubA {
                     BoardState next = {
                         n: n,
                     };
 
-                    become HubA(next);
+                    become next <- HubA(next);
                 }
             }
 
             actor PlayerB owns PlayerState {
-                entry enter_b() emits one HubB {
+                entry enter_b() emits next: HubB {
                     BoardState next = {
                         n: n,
                     };
 
-                    become HubB(next);
+                    become next <- HubB(next);
                 }
             }
 
             actor HubB owns BoardState {
-                entry to_leaf_a() emits one LeafA {
+                entry to_leaf_a() emits next: LeafA {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become LeafA(next);
+                    become next <- LeafA(next);
                 }
             }
 
             actor HubA owns BoardState {
-                entry to_leaf_b() emits one LeafB {
+                entry to_leaf_b() emits next: LeafB {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become LeafB(next);
+                    become next <- LeafB(next);
                 }
             }
 
             actor LeafA owns BoardState {
-                entry to_a() emits one HubA {
+                entry to_a() emits next: HubA {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become HubA(next);
+                    become next <- HubA(next);
                 }
             }
 
             actor LeafB owns BoardState {
-                entry to_b() emits one HubB {
+                entry to_b() emits next: HubB {
                     BoardState next = {
                         n: n + 1,
                     };
 
-                    become HubB(next);
+                    become next <- HubB(next);
                 }
             }
 
@@ -10943,7 +10839,7 @@ mod tests {
                         pair: self_pair_type,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     PairState stored_pair = { value: 1 };
                     PairState argument_pair = { value: 2 };
                     require stored.outputs become {
@@ -10952,7 +10848,7 @@ mod tests {
                     require argument.outputs become {
                         pair <- self_pair_type(argument_pair),
                     };
-                    become Launcher(self.state);
+                    become next <- Launcher(self.state);
                 }
             }
 
@@ -10996,12 +10892,12 @@ mod tests {
                         pair: self.first_type,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     PairState pair = { value: 1 };
                     require child.outputs become {
                         pair <- self.first_type(pair),
                     };
-                    become Launcher(self.state);
+                    become next <- Launcher(self.state);
                 }
 
                 entry launch_second()
@@ -11010,12 +10906,12 @@ mod tests {
                         pair: self.second_type,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     PairState pair = { value: 2 };
                     require child.outputs become {
                         pair <- self.second_type(pair),
                     };
-                    become Launcher(self.state);
+                    become next <- Launcher(self.state);
                 }
             }
 
@@ -11066,7 +10962,7 @@ mod tests {
                         pair: self.pair_type,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     PairState pair = { value: 1 };
                     require first.outputs become {
                         pair <- self.pair_type(pair),
@@ -11074,7 +10970,7 @@ mod tests {
                     require second.outputs become {
                         pair <- self.pair_type(pair),
                     };
-                    become Launcher(self.state);
+                    become next <- Launcher(self.state);
                 }
             }
 
@@ -11111,13 +11007,13 @@ mod tests {
                         child: Child,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     ChildState child_state = { amount: 1 };
                     LauncherState next = { launches: launches + 1 };
                     require child_group.outputs become {
                         child <- Child(child_state),
                     };
-                    become Launcher(next);
+                    become next <- Launcher(next);
                 }
             }
 
@@ -11160,7 +11056,7 @@ mod tests {
                         sibling: Child,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     ChildState child_state = { amount: amount };
                     ChildState sibling_state = { amount: amount + 1 };
                     LauncherState next = { launches: launches + 1 };
@@ -11168,16 +11064,16 @@ mod tests {
                         child <- Child(child_state),
                         sibling <- Child(sibling_state),
                     };
-                    become Launcher(next);
+                    become next <- Launcher(next);
                 }
             }
 
             // The spawned actor itself needs Launcher's template for its
             // normal successor, exercising the spawned template closure.
             actor Child owns ChildState {
-                entry return_to_launcher() emits one Launcher {
+                entry return_to_launcher() emits next: Launcher {
                     LauncherState next = { launches: 0 };
-                    become Launcher(next);
+                    become next <- Launcher(next);
                 }
             }
 
@@ -11279,13 +11175,13 @@ mod tests {
                         child: Node,
                     }
                 }
-                emits one Node {
+                emits next: Node {
                     NodeState child = { amount: next_amount };
                     NodeState next = { amount: next_amount + 1 };
                     require child_group.outputs become {
                         child <- Node(child),
                     };
-                    become Node(next);
+                    become next <- Node(next);
                 }
             }
 
@@ -11329,34 +11225,34 @@ mod tests {
                         mux: Mux,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     BoardState board = { turn: 0 };
                     LauncherState next = { launches: launches + 1 };
                     require game.outputs become {
                         mux <- Mux(board),
                     };
-                    become Launcher(next);
+                    become next <- Launcher(next);
                 }
             }
 
             actor Mux owns BoardState {
-                entry move() emits one Pawn {
+                entry move() emits next: Pawn {
                     BoardState next = { turn: turn + 1 };
-                    become Pawn(next);
+                    become next <- Pawn(next);
                 }
             }
 
             actor Pawn owns BoardState {
-                entry finish() emits one Mux {
+                entry finish() emits next: Mux {
                     BoardState next = { turn: turn + 1 };
-                    become Mux(next);
+                    become next <- Mux(next);
                 }
             }
 
             actor Knight owns BoardState {
-                entry finish() emits one Mux {
+                entry finish() emits next: Mux {
                     BoardState next = { turn: turn + 1 };
-                    become Mux(next);
+                    become next <- Mux(next);
                 }
             }
 
@@ -11399,9 +11295,9 @@ mod tests {
                         next_pair: self.pair_type,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     require(1 == 1);
-                    become Launcher(self.state);
+                    become next <- Launcher(self.state);
                 }
             }
 
@@ -11432,9 +11328,9 @@ mod tests {
                         next_pair: self.pair_type,
                     }
                 }
-                emits one Launcher {
+                emits next: Launcher {
                     require(1 == 1);
-                    become Launcher(self.state);
+                    become next <- Launcher(self.state);
                 }
             }
 
@@ -11515,26 +11411,26 @@ mod tests {
             }
 
             actor League owns LeagueState {
-                entry register() emits one Player {
+                entry register() emits next: Player {
                     PlayerState next_player = {
                         nonce: nonce,
                     };
-                    become Player(next_player);
+                    become next <- Player(next_player);
                 }
             }
 
             actor Player owns PlayerState {
-                entry enter_mux() emits one Mux {
+                entry enter_mux() emits next: Mux {
                     BoardState next_board = {
                         selector: nonce,
                         ply: 0,
                     };
-                    become Mux(next_board);
+                    become next <- Mux(next_board);
                 }
             }
 
             actor Mux owns BoardState {
-                entry choose(MoveActor target) emits one MoveActor {
+                entry choose(MoveActor target) emits next: MoveActor {
                     if (target == MoveActor::Knight) {
                         require(selector >= 0);
                     }
@@ -11544,55 +11440,55 @@ mod tests {
                         ply: ply + 1,
                     };
 
-                    become target(next_board);
+                    become next <- target(next_board);
                 }
 
-                entry choose_knight_const() emits one MoveActor {
+                entry choose_knight_const() emits next: MoveActor {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
 
                     actor_type<BoardState> target = MoveActor::Knight;
-                    become target(next_board);
+                    become next <- target(next_board);
                 }
 
-                entry choose_pawn() emits one Pawn {
+                entry choose_pawn() emits next: Pawn {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become Pawn(next_board);
+                    become next <- Pawn(next_board);
                 }
 
-                entry choose_knight() emits one Knight {
+                entry choose_knight() emits next: Knight {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become Knight(next_board);
+                    become next <- Knight(next_board);
                 }
             }
 
             actor Pawn owns BoardState {
-                entry back_to_mux() emits one Mux {
+                entry back_to_mux() emits next: Mux {
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become Mux(next_board);
+                    become next <- Mux(next_board);
                 }
             }
 
             actor Knight owns BoardState {
-                entry back_to_mux() emits one Mux {
+                entry back_to_mux() emits next: Mux {
                     require(selector >= 0);
 
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
                     };
-                    become Mux(next_board);
+                    become next <- Mux(next_board);
                 }
             }
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -351,7 +351,7 @@ impl<'a> Model<'a> {
             reject_reserved_identifier("constant", &konst.name)?;
         }
         for function in &self.functions {
-            reject_reserved_identifier("function", &function.name)?;
+            reject_reserved_function_identifier(&function.name)?;
             for param in &function.params {
                 reject_reserved_identifier(&format!("function `{}` parameter", function.name), &param.name)?;
             }
@@ -5854,6 +5854,16 @@ fn to_upper_camel(input: &str) -> String {
         .collect()
 }
 
+fn reject_reserved_function_identifier(name: &str) -> Result<()> {
+    if name == word::UNRESTRICTED {
+        return Err(ArgentError::new(format!(
+            "function identifier `{}` is reserved for output-value declarations",
+            word::UNRESTRICTED
+        )));
+    }
+    reject_reserved_identifier("function", name)
+}
+
 fn reject_reserved_identifier(context: &str, name: &str) -> Result<()> {
     let generated_prefix =
         [RESERVED_GENERATED_PREFIX, RESERVED_GENERATED_TYPE_PREFIX].into_iter().find(|prefix| name.starts_with(prefix));
@@ -6959,6 +6969,23 @@ mod tests {
 
         let err = Model::from_program(&program).expect_err("duplicate function declaration must be rejected");
         assert_duplicate_top_level_error(&err, "fn", "helper");
+    }
+
+    #[test]
+    fn rejects_function_named_unrestricted() {
+        let mut program = test_program();
+        program.modules[0].functions.push(FunctionDecl {
+            name: word::UNRESTRICTED.to_string(),
+            params: Vec::new(),
+            return_ty: TypeRef::new("int"),
+            body: "0".to_string(),
+        });
+
+        let err = Model::from_program(&program).expect_err("the output-value declaration must not be shadowed");
+        assert!(
+            err.to_string().contains("function identifier `unrestricted` is reserved for output-value declarations"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -2868,8 +2868,11 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     }
 
     fn lower_refs(&self, expr: &str) -> Result<String> {
+        assert_eq!(word::SELF, "self");
+        assert_eq!(word::VALUE, "value");
+        assert_eq!(word::COVENANT_ID, "cov_id");
         let mut out = expr.replace("self.value", "tx.inputs[this.activeInputIndex].value");
-        out = out.replace("self.covenant_id", "OpInputCovenantId(this.activeInputIndex)");
+        out = out.replace("self.cov_id", "OpInputCovenantId(this.activeInputIndex)");
         for spec in state_expansion_witness_specs_for_actor(self.actor, self.model) {
             for field in &self.model.state(&spec.memory_state)?.fields {
                 let local = hidden_state_expansion_field_name(&spec, &field.name);
@@ -7067,6 +7070,34 @@ mod tests {
         assert!(!sil.contains("byte[] gen__foo_prefix"), "{sil}");
         assert!(!sil.contains("gen__state_foo_state"), "{sil}");
         assert!(!sil.contains("__argent_"), "{sil}");
+    }
+
+    #[test]
+    fn self_cov_id_lowers_to_the_active_input_covenant_id() {
+        let source = r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry step() emits next: Foo {
+                    require(self.cov_id == self.cov_id);
+                    become next <- Foo(self.state);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+        "#;
+        let path = PathBuf::from("test.ag");
+        let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
+        let program = Program { root: path, modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+        let sil = emit_actor(model.actor("Foo").expect("actor exists"), &model).expect("actor emits");
+
+        assert!(
+            sil.contains("require(OpInputCovenantId(this.activeInputIndex) == OpInputCovenantId(this.activeInputIndex));"),
+            "{sil}"
+        );
     }
 
     #[test]

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1687,11 +1687,17 @@ struct BodyLowerer<'a, 'm> {
     materialized_selectors: BTreeSet<String>,
     materialized_route_locals: BTreeMap<String, String>,
     input_names: BTreeSet<String>,
-    output_names: BTreeSet<String>,
+    output_values: Vec<OutputValueRef>,
     observed_input_state_refs: Vec<(String, String)>,
     observed_output_fields: Vec<ObservedOutputFieldWitnessSpec>,
     validated_spawns: BTreeSet<String>,
     conditional_depth: usize,
+}
+
+#[derive(Debug)]
+struct OutputValueRef {
+    source: String,
+    lowered: String,
 }
 
 impl<'a, 'm> BodyLowerer<'a, 'm> {
@@ -1754,13 +1760,27 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             }
         }
 
-        let mut output_names = BTreeSet::new();
+        let mut output_values = Vec::new();
         match &entry.emits {
             EmitSpec::None => {}
             EmitSpec::Outputs(outputs) => {
-                output_names.extend(outputs.iter().map(|output| output.name.clone()));
+                output_values.extend(outputs.iter().map(|output| OutputValueRef {
+                    source: format!("{}.{}", output.name, word::VALUE),
+                    lowered: format!("tx.outputs[{}].value", hidden_output_idx_name(&output.name)),
+                }));
             }
         }
+        // This entry creates spawned outputs, so it owns their value policy.
+        // Observed outputs remain the responsibility of their emitting contracts.
+        for spawn in &entry.spawns {
+            output_values.extend(spawn.outputs.iter().map(|output| OutputValueRef {
+                source: format!("{}.{}.{}.{}", spawn.name, word::OUTPUTS, output.name, word::VALUE),
+                lowered: format!("tx.outputs[{}].value", hidden_spawn_output_idx_name(&spawn.name, &output.name)),
+            }));
+        }
+        // A qualified spawn reference can contain an ordinary emit reference as
+        // a suffix. Lower and recognize the most specific spelling first.
+        output_values.sort_by(|left, right| right.source.len().cmp(&left.source.len()).then_with(|| left.source.cmp(&right.source)));
 
         let observed_input_state_refs = entry
             .observes
@@ -1791,7 +1811,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             materialized_selectors: BTreeSet::new(),
             materialized_route_locals: BTreeMap::new(),
             input_names,
-            output_names,
+            output_values,
             observed_input_state_refs,
             observed_output_fields,
             validated_spawns: BTreeSet::new(),
@@ -1812,7 +1832,27 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
                 );
             }
         }
+        self.validate_output_value_refs()?;
         Ok(LoweredEntryBody { sil: out })
+    }
+
+    fn validate_output_value_refs(&self) -> Result<()> {
+        let missing = self
+            .output_values
+            .iter()
+            .filter(|value| count_qualified_ref(&self.tokens, &value.source) == 0)
+            .map(|value| value.source.as_str())
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            return Ok(());
+        }
+        let missing_values = missing.iter().map(|value| format!("`{value}`")).collect::<Vec<_>>().join(", ");
+        let declarations = missing.iter().map(|value| format!("`{}({value});`", word::UNRESTRICTED)).collect::<Vec<_>>().join(", ");
+        let noun = if missing.len() == 1 { "output value" } else { "output values" };
+        Err(self.error(format!(
+            "entry `{}::{}` must reference {noun} {missing_values}; if intentionally unrestricted, add {declarations}",
+            self.actor.name, self.entry.name,
+        )))
     }
 
     fn lower_statements(&mut self, out: &mut String, indent: usize, end: Option<char>) -> Result<()> {
@@ -1909,6 +1949,11 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             return Ok(());
         }
 
+        if let Some(value) = parse_unrestricted_output_value(&statement) {
+            self.validate_unrestricted_output_value(value)?;
+            return Ok(());
+        }
+
         if let Some(require_expr) = parse_require_statement(&statement) {
             for covenant_id in co_spent_covenant_ids(require_expr, &self.source_types)? {
                 push_indent(out, indent);
@@ -1922,6 +1967,17 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         Ok(())
     }
 
+    fn validate_unrestricted_output_value(&self, value: &str) -> Result<()> {
+        let value = value.trim();
+        if !self.output_values.iter().any(|output| output.source == value) {
+            return Err(self.error(format!(
+                "`{}(...)` expects exactly one current emit or spawn output value; `{value}` is not one",
+                word::UNRESTRICTED,
+            )));
+        }
+        Ok(())
+    }
+
     fn single_route_target_for_state_local(
         &self,
         source_ty: &str,
@@ -1931,15 +1987,22 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     ) -> Result<Option<String>> {
         // A route-neutral state object used only by one concrete route can
         // receive that target layout at its declaration point. Output handles
-        // are not state-local uses, even when both have the same source name.
-        // Any other read, rewrite, or second route preserves the route-neutral
-        // body.
+        // and their value references are not state-local uses, even when they
+        // have the same source name. Any other read, rewrite, or second route
+        // preserves the route-neutral body.
         let route_handle_uses = self.entry.routes.iter().filter(|route| route.output == name).count();
+        let output_value_ident_uses = self
+            .output_values
+            .iter()
+            .map(|output| {
+                count_qualified_ref(&self.tokens, &output.source) * output.source.split('.').filter(|segment| *segment == name).count()
+            })
+            .sum::<usize>();
         if self.conditional_depth != 0
             || lowered_ty != source_ty
             || split_state_object_literal(expr).is_none()
             || self.tokens.iter().filter(|token| matches!(&token.kind, TokenKind::Ident(ident) if ident == name)).count()
-                != 2 + route_handle_uses
+                != 2 + route_handle_uses + output_value_ident_uses
         {
             return Ok(None);
         }
@@ -2887,11 +2950,11 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         for (source, lowered) in &self.observed_input_state_refs {
             out = out.replace(source, lowered);
         }
+        for output in &self.output_values {
+            out = out.replace(&output.source, &output.lowered);
+        }
         for name in &self.input_names {
             out = out.replace(&format!("{name}.value"), &format!("tx.inputs[{}].value", hidden_input_idx_name(name)));
-        }
-        for name in &self.output_names {
-            out = out.replace(&format!("{name}.value"), &format!("tx.outputs[{}].value", hidden_output_idx_name(name)));
         }
         lower_actor_enum_literals(&out, self.model)
     }
@@ -5598,9 +5661,32 @@ fn co_spent_covenant_ids(expr: &str, source_types: &BTreeMap<String, String>) ->
 }
 
 fn parse_require_statement(statement: &str) -> Option<&str> {
-    let statement = statement.trim();
-    let inner = statement.strip_prefix(&format!("{}(", word::REQUIRE))?.strip_suffix(')')?;
-    Some(inner)
+    parse_call_statement(statement, word::REQUIRE)
+}
+
+fn parse_unrestricted_output_value(statement: &str) -> Option<&str> {
+    parse_call_statement(statement, word::UNRESTRICTED)
+}
+
+fn parse_call_statement<'a>(statement: &'a str, callee: &str) -> Option<&'a str> {
+    let tail = statement.trim().strip_prefix(callee)?;
+    tail.strip_prefix('(')?.strip_suffix(')').map(str::trim)
+}
+
+fn count_qualified_ref(tokens: &[Token], source: &str) -> usize {
+    let segments = source.split('.').collect::<Vec<_>>();
+    let token_count = segments.len() * 2 - 1;
+    tokens
+        .windows(token_count)
+        .enumerate()
+        .filter(|(start, window)| {
+            (*start == 0 || !matches!(&tokens[*start - 1].kind, TokenKind::Symbol('.')))
+                && segments.iter().enumerate().all(|(idx, segment)| {
+                    matches!(&window[idx * 2].kind, TokenKind::Ident(actual) if actual == segment)
+                        && (idx + 1 == segments.len() || matches!(&window[idx * 2 + 1].kind, TokenKind::Symbol('.')))
+                })
+        })
+        .count()
 }
 
 fn parse_co_spent_call(
@@ -6554,6 +6640,7 @@ mod tests {
 
             actor Source owns SourceState {
                 entry choose_a() emits next: A | B {
+                    unrestricted(next.value);
                     TargetState next = {
                         nonce: nonce,
                     };
@@ -6645,6 +6732,8 @@ mod tests {
                     a: Foo,
                     b: Foo,
                 } {
+                    unrestricted(a.value);
+                    unrestricted(b.value);
                     become a <- Foo(next_a);
                 }
             }
@@ -6674,6 +6763,7 @@ mod tests {
                 entry bump() emits {
                     next: Foo at auth[0],
                 } {
+                    unrestricted(next.value);
                     FooState next_state = {
                         amount: amount + 1,
                     };
@@ -6756,12 +6846,14 @@ mod tests {
 
             actor Leader owns LeaderState {
                 entry standalone() emits next: Leader {
+                    unrestricted(next.value);
                     become next <- Leader(self.state);
                 }
 
                 entry coordinated() consumes {
                     worker: Worker,
                 } emits next: Leader {
+                    unrestricted(next.value);
                     require(worker.value >= 0);
                     become next <- Leader(self.state);
                 }
@@ -6777,6 +6869,7 @@ mod tests {
 
             actor Unrelated owns UnrelatedState {
                 entry standalone() emits next: Unrelated {
+                    unrestricted(next.value);
                     become next <- Unrelated(self.state);
                 }
             }
@@ -7073,12 +7166,280 @@ mod tests {
     }
 
     #[test]
+    fn rejects_emit_output_without_value_policy() {
+        let err = emit_inline_error(
+            r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry step() emits next: Foo {
+                    become next <- Foo(self.state);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+            "#,
+        );
+
+        let message = err.to_string();
+        assert!(message.contains("must reference output value `next.value`"), "unexpected error: {err}");
+        assert!(message.contains("if intentionally unrestricted, add `unrestricted(next.value);`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn commented_output_value_does_not_satisfy_the_reference_check() {
+        let err = emit_inline_error(
+            r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry step() emits next: Foo {
+                    require(1 == 1 /* next.value */);
+                    become next <- Foo(self.state);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+            "#,
+        );
+
+        assert!(err.to_string().contains("must reference output value `next.value`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn output_value_reference_anywhere_in_the_entry_satisfies_the_check() {
+        let source = r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry step() emits next: Foo {
+                    int output_value = next.value;
+                    become next <- Foo(self.state);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+        "#;
+        let path = PathBuf::from("test.ag");
+        let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
+        let program = Program { root: path, modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+        let sil = emit_actor(model.actor("Foo").expect("actor exists"), &model).expect("actor emits");
+
+        assert!(sil.contains("int output_value = tx.outputs[gen__next_output_idx].value;"), "{sil}");
+    }
+
+    #[test]
+    fn unrestricted_output_value_policy_is_compile_time_only() {
+        let source = r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry allow() emits next: Foo {
+                    unrestricted(next.value);
+                    become next <- Foo(self.state);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+        "#;
+        let path = PathBuf::from("test.ag");
+        let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
+        let program = Program { root: path, modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+        let sil = emit_actor(model.actor("Foo").expect("actor exists"), &model).expect("actor emits");
+
+        assert!(!sil.contains(word::UNRESTRICTED), "{sil}");
+    }
+
+    #[test]
+    fn unrestricted_output_value_policy_requires_a_current_output_handle() {
+        let err = emit_inline_error(
+            r#"
+            state FooState {}
+
+            actor Foo owns FooState {
+                entry step() emits next: Foo {
+                    unrestricted(self.value);
+                    become next <- Foo(self.state);
+                }
+            }
+
+            app Test {
+                actor Foo;
+            }
+            "#,
+        );
+
+        assert!(
+            err.to_string()
+                .contains("`unrestricted(...)` expects exactly one current emit or spawn output value; `self.value` is not one"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn spawn_output_value_can_be_constrained_by_qualified_handle() {
+        let source = r#"
+            state LauncherState {}
+            state ChildState {}
+
+            actor Launcher owns LauncherState {
+                entry launch()
+                spawns children by children_id {
+                    outputs {
+                        child: Child,
+                    }
+                }
+                emits next: Launcher {
+                    unrestricted(next.value);
+                    require(children.outputs.child.value > 0);
+                    require children.outputs become {
+                        child <- Child(ChildState {}),
+                    };
+                    become next <- Launcher(self.state);
+                }
+            }
+
+            actor Child owns ChildState {}
+
+            app Test {
+                actor Launcher;
+                actor Child;
+            }
+        "#;
+        let path = PathBuf::from("test.ag");
+        let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
+        let program = Program { root: path, modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+        let sil = emit_actor(model.actor("Launcher").expect("actor exists"), &model).expect("actor emits");
+
+        assert!(sil.contains("require(tx.outputs[gen__children_child_output_idx].value > 0);"), "{sil}");
+    }
+
+    #[test]
+    fn rejects_spawn_output_without_value_policy() {
+        let err = emit_inline_error(
+            r#"
+            state LauncherState {}
+            state ChildState {}
+
+            actor Launcher owns LauncherState {
+                entry launch()
+                spawns children by children_id {
+                    outputs {
+                        child: Child,
+                    }
+                }
+                emits next: Launcher {
+                    unrestricted(next.value);
+                    require children.outputs become {
+                        child <- Child(ChildState {}),
+                    };
+                    become next <- Launcher(self.state);
+                }
+            }
+
+            actor Child owns ChildState {}
+
+            app Test {
+                actor Launcher;
+                actor Child;
+            }
+            "#,
+        );
+
+        assert!(err.to_string().contains("must reference output value `children.outputs.child.value`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn qualified_spawn_value_does_not_cover_same_named_emit_value() {
+        let err = emit_inline_error(
+            r#"
+            state LauncherState {}
+            state ChildState {}
+
+            actor Launcher owns LauncherState {
+                entry launch()
+                spawns children by children_id {
+                    outputs {
+                        child: Child,
+                    }
+                }
+                emits child: Launcher {
+                    require(children.outputs.child.value > 0);
+                    require children.outputs become {
+                        child <- Child(ChildState {}),
+                    };
+                    become child <- Launcher(self.state);
+                }
+            }
+
+            actor Child owns ChildState {}
+
+            app Test {
+                actor Launcher;
+                actor Child;
+            }
+            "#,
+        );
+
+        let message = err.to_string();
+        assert!(message.contains("must reference output value `child.value`"), "unexpected error: {err}");
+        assert!(!message.contains("`children.outputs.child.value`,"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn observed_output_value_is_the_emitter_contracts_responsibility() {
+        let source = r#"
+            state ObserverState {}
+            state AssetState {}
+
+            actor Observer owns ObserverState {
+                entry follow(cov_id remote_id)
+                observes remote by remote_id {
+                    outputs {
+                        asset: Asset,
+                    }
+                }
+                emits none {
+                    require remote.outputs become {
+                        asset <- Asset(AssetState {}),
+                    };
+                }
+            }
+
+            actor Asset owns AssetState {}
+
+            app Test {
+                actor Observer;
+                actor Asset;
+            }
+        "#;
+        let path = PathBuf::from("test.ag");
+        let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
+        let program = Program { root: path, modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+
+        emit_actor(model.actor("Observer").expect("actor exists"), &model).expect("observed output needs no local value policy");
+    }
+
+    #[test]
     fn self_cov_id_lowers_to_the_active_input_covenant_id() {
         let source = r#"
             state FooState {}
 
             actor Foo owns FooState {
                 entry step() emits next: Foo {
+                    unrestricted(next.value);
                     require(self.cov_id == self.cov_id);
                     become next <- Foo(self.state);
                 }
@@ -7111,6 +7472,7 @@ mod tests {
 
             actor Foo owns FooState {
                 entry bump(int amount) emits next: Foo {
+                    unrestricted(next.value);
                     State next_state = {
                         count: count + amount,
                     };
@@ -7163,6 +7525,7 @@ mod tests {
 
             actor Source owns SourceState {
                 entry finish() emits next: Terminal {
+                    unrestricted(next.value);
                     TerminalState next = {
                         count: count + 1,
                     };
@@ -7172,6 +7535,7 @@ mod tests {
 
             actor Terminal owns TerminalState {
                 entry step() emits next: Terminal {
+                    unrestricted(next.value);
                     TerminalState next = {
                         count: count + 1,
                     };
@@ -7370,6 +7734,7 @@ mod tests {
 
             actor Holder owns HolderState {
                 entry hold() emits next: Holder {
+                    unrestricted(next.value);
                     become next <- Holder(self.state);
                 }
             }
@@ -7576,6 +7941,7 @@ mod tests {
 
             actor Forager owns ForagerState {
                 entry step() emits next: Forager {
+                    unrestricted(next.value);
                     ForagerState next_state = {
                         strategy: {
                             hunger: strategy.hunger + 1,
@@ -7661,6 +8027,7 @@ mod tests {
                 emits {
                     controller: Minter,
                 } {
+                    unrestricted(controller.value);
                     MinterState next_minter = {
                         kcc20_covid: kcc20_covid,
                         amount: amount - minted_amount,
@@ -7920,6 +8287,7 @@ mod tests {
                     }
                 }
                 emits none {
+                    unrestricted(pair.outputs.next_pair.value);
                     require(1 == 1);
                 }
             }
@@ -8303,6 +8671,7 @@ mod tests {
                     other: Counter,
                 }
                 emits next: Counter {
+                    unrestricted(next.value);
                     CounterState next = {
                         count: count + other.count,
                     };
@@ -8375,12 +8744,14 @@ mod tests {
 
             actor Current owns SharedState {
                 entry step() emits next: Current {
+                    unrestricted(next.value);
                     become next <- Current(self.state);
                 }
             }
 
             actor Outside owns SharedState {
                 entry step() emits next: Target {
+                    unrestricted(next.value);
                     TargetState next = {};
                     become next <- Target(next);
                 }
@@ -8801,6 +9172,7 @@ mod tests {
 
             actor Source owns SourceState {
                 entry start() emits next: HubA {
+                    unrestricted(next.value);
                     SharedState next = { amount: amount + 1 };
                     become next <- HubA(next);
                 }
@@ -8808,6 +9180,7 @@ mod tests {
 
             actor HubA owns SharedState {
                 entry advance() emits next: A1 {
+                    unrestricted(next.value);
                     SharedState next = { amount: amount + 1 };
                     become next <- A1(next);
                 }
@@ -8815,6 +9188,7 @@ mod tests {
 
             actor A1 owns SharedState {
                 entry advance() emits next: A2 {
+                    unrestricted(next.value);
                     SharedState next = { amount: amount + 1 };
                     become next <- A2(next);
                 }
@@ -8822,6 +9196,7 @@ mod tests {
 
             actor A2 owns SharedState {
                 entry cross() emits next: HubB {
+                    unrestricted(next.value);
                     SharedState next = { amount: amount + 1 };
                     become next <- HubB(next);
                 }
@@ -8829,11 +9204,13 @@ mod tests {
 
             actor HubB owns SharedState {
                 entry advance() emits next: B1 {
+                    unrestricted(next.value);
                     SharedState next = { amount: amount + 1 };
                     become next <- B1(next);
                 }
 
                 entry rewind() emits next: A1 {
+                    unrestricted(next.value);
                     SharedState next = { amount: amount + 1 };
                     become next <- A1(next);
                 }
@@ -8841,6 +9218,7 @@ mod tests {
 
             actor B1 owns SharedState {
                 entry advance() emits next: B2 {
+                    unrestricted(next.value);
                     SharedState next = { amount: amount + 1 };
                     become next <- B2(next);
                 }
@@ -8848,6 +9226,7 @@ mod tests {
 
             actor B2 owns SharedState {
                 entry finish() emits next: Tail {
+                    unrestricted(next.value);
                     TailState next = { amount: amount + 1 };
                     become next <- Tail(next);
                 }
@@ -8981,6 +9360,7 @@ mod tests {
 
             actor A owns SharedState {
                 entry leave() emits next: Middle {
+                    unrestricted(next.value);
                     MiddleState next_middle = {
                         amount: amount,
                     };
@@ -8992,6 +9372,7 @@ mod tests {
 
             actor Middle owns MiddleState {
                 entry leave() emits next: Tail {
+                    unrestricted(next.value);
                     TailState next_tail = {
                         amount: amount,
                     };
@@ -9085,6 +9466,7 @@ mod tests {
 
             actor Source owns SourceState {
                 entry send() emits next: A {
+                    unrestricted(next.value);
                     SharedState next = {
                         amount: amount,
                     };
@@ -9094,6 +9476,7 @@ mod tests {
 
             actor A owns SharedState {
                 entry leave() emits next: TailA {
+                    unrestricted(next.value);
                     TailAState next = {
                         amount: amount,
                     };
@@ -9103,6 +9486,7 @@ mod tests {
 
             actor B owns SharedState {
                 entry leave() emits next: TailB {
+                    unrestricted(next.value);
                     TailBState next = {
                         amount: amount,
                     };
@@ -9235,6 +9619,7 @@ mod tests {
                     }
                 }
                 emits next: Observer {
+                    unrestricted(next.value);
                     BoardState board = { turn: 0 };
                     require game.outputs become {
                         mux <- Mux(board),
@@ -9249,6 +9634,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry move() emits next: Pawn {
+                    unrestricted(next.value);
                     BoardState next = { turn: turn + 1 };
                     become next <- Pawn(next);
                 }
@@ -9256,6 +9642,7 @@ mod tests {
 
             actor Pawn owns BoardState {
                 entry finish() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next = { turn: turn + 1 };
                     become next <- Mux(next);
                 }
@@ -9263,6 +9650,7 @@ mod tests {
 
             actor Knight owns BoardState {
                 entry finish() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next = { turn: turn + 1 };
                     become next <- Mux(next);
                 }
@@ -9309,6 +9697,7 @@ mod tests {
 
             actor Foreign owns ForeignState {
                 entry route() emits next: Target {
+                    unrestricted(next.value);
                     TargetState next = { amount: amount };
                     become next <- Target(next);
                 }
@@ -9458,6 +9847,7 @@ mod tests {
                     }
                 }
                 emits next: Foreign {
+                    unrestricted(next.value);
                     ForeignState next = remote.inputs.source.state;
                     become next <- Foreign(next);
                 }
@@ -9515,6 +9905,7 @@ mod tests {
 
             actor Source owns SourceState {
                 entry enter_pawn() emits next: Pawn {
+                    unrestricted(next.value);
                     BoardState next = {
                         ply: nonce,
                     };
@@ -9524,6 +9915,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry choose(MoveActor target) emits next: MoveActor {
+                    unrestricted(next.value);
                     BoardState next = {
                         ply: ply + 1,
                     };
@@ -9547,6 +9939,7 @@ mod tests {
                 entry verify() consumes {
                     pawn: Pawn,
                 } emits next: Archive {
+                    unrestricted(next.value);
                     require(pawn.ply >= 0);
 
                     ArchiveState next = {
@@ -9558,6 +9951,7 @@ mod tests {
 
             actor Archive owns ArchiveState {
                 entry reopen() emits next: Pawn {
+                    unrestricted(next.value);
                     BoardState next = {
                         ply: nonce,
                     };
@@ -9612,6 +10006,7 @@ mod tests {
             "            actor Mux owns BoardState {\n",
             r#"            actor Mux owns BoardState {
                 entry return_to_player() emits next: Player {
+                    unrestricted(next.value);
                     PlayerState next_player = {
                         nonce: ply,
                     };
@@ -9908,6 +10303,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry choose(MoveActor target) emits next: MoveActor {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         ply: ply + 1,
                     };
@@ -9915,6 +10311,7 @@ mod tests {
                 }
 
                 entry finish() emits next: Receipt {
+                    unrestricted(next.value);
                     ReceiptState receipt = {
                         final_ply: ply,
                     };
@@ -9924,6 +10321,7 @@ mod tests {
 
             actor Pawn owns BoardState {
                 entry back_to_mux() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         ply: ply + 1,
                     };
@@ -9933,6 +10331,7 @@ mod tests {
 
             actor Knight owns BoardState {
                 entry back_to_mux() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         ply: ply + 1,
                     };
@@ -9942,6 +10341,7 @@ mod tests {
 
             actor Receipt owns ReceiptState {
                 entry resume() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         ply: final_ply + 1,
                     };
@@ -10027,6 +10427,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry choose_knight_const() emits next: MoveActor {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         ply: ply + 1,
                     };
@@ -10122,6 +10523,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry choose_first(FirstMove target) emits next: FirstMove {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -10130,6 +10532,7 @@ mod tests {
                 }
 
                 entry choose_second(SecondMove target) emits next: SecondMove {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -10170,6 +10573,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry choose(MoveActor target) emits next: MoveActor {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -10178,6 +10582,7 @@ mod tests {
                 }
 
                 entry visit_bishop() emits next: Bishop {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -10229,6 +10634,7 @@ mod tests {
 
             actor Challenge owns SharedState {
                 entry choose(NextActor target) emits next: NextActor {
+                    unrestricted(next.value);
                     SharedState next = {
                         amount: amount + 1,
                     };
@@ -10289,6 +10695,7 @@ mod tests {
 
             actor A owns BoardState {
                 entry to_b() emits next: B {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10299,6 +10706,7 @@ mod tests {
 
             actor B owns BoardState {
                 entry to_a() emits next: A {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10343,6 +10751,7 @@ mod tests {
 
             actor A owns BoardState {
                 entry to_b() emits next: B {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10353,6 +10762,7 @@ mod tests {
 
             actor B owns BoardState {
                 entry to_c() emits next: C {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10363,6 +10773,7 @@ mod tests {
 
             actor C owns BoardState {
                 entry to_a() emits next: A {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10373,6 +10784,7 @@ mod tests {
 
             actor D owns BoardState {
                 entry to_e() emits next: E {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10383,6 +10795,7 @@ mod tests {
 
             actor E owns BoardState {
                 entry to_f() emits next: F {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10393,6 +10806,7 @@ mod tests {
 
             actor F owns BoardState {
                 entry to_d() emits next: D {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10504,6 +10918,7 @@ mod tests {
 
             actor PlayerA owns PlayerState {
                 entry enter_a() emits next: HubA {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n,
                     };
@@ -10514,6 +10929,7 @@ mod tests {
 
             actor PlayerB owns PlayerState {
                 entry enter_b() emits next: HubB {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n,
                     };
@@ -10524,6 +10940,7 @@ mod tests {
 
             actor HubB owns BoardState {
                 entry to_leaf() emits next: Leaf {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10534,6 +10951,7 @@ mod tests {
 
             actor HubA owns BoardState {
                 entry to_leaf() emits next: Leaf {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10591,6 +11009,7 @@ mod tests {
 
             actor PlayerA owns PlayerState {
                 entry enter_a() emits next: HubA {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n,
                     };
@@ -10601,6 +11020,7 @@ mod tests {
 
             actor PlayerB owns PlayerState {
                 entry enter_b() emits next: HubB {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n,
                     };
@@ -10611,6 +11031,7 @@ mod tests {
 
             actor HubB owns BoardState {
                 entry to_leaf_a() emits next: LeafA {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10621,6 +11042,7 @@ mod tests {
 
             actor HubA owns BoardState {
                 entry to_leaf_b() emits next: LeafB {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10631,6 +11053,7 @@ mod tests {
 
             actor LeafA owns BoardState {
                 entry to_a() emits next: HubA {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10641,6 +11064,7 @@ mod tests {
 
             actor LeafB owns BoardState {
                 entry to_b() emits next: HubB {
+                    unrestricted(next.value);
                     BoardState next = {
                         n: n + 1,
                     };
@@ -10871,6 +11295,9 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(stored.outputs.pair.value);
+                    unrestricted(argument.outputs.pair.value);
+                    unrestricted(next.value);
                     PairState stored_pair = { value: 1 };
                     PairState argument_pair = { value: 2 };
                     require stored.outputs become {
@@ -10924,6 +11351,8 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(child.outputs.pair.value);
+                    unrestricted(next.value);
                     PairState pair = { value: 1 };
                     require child.outputs become {
                         pair <- self.first_type(pair),
@@ -10938,6 +11367,8 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(child.outputs.pair.value);
+                    unrestricted(next.value);
                     PairState pair = { value: 2 };
                     require child.outputs become {
                         pair <- self.second_type(pair),
@@ -10994,6 +11425,9 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(first.outputs.pair.value);
+                    unrestricted(second.outputs.pair.value);
+                    unrestricted(next.value);
                     PairState pair = { value: 1 };
                     require first.outputs become {
                         pair <- self.pair_type(pair),
@@ -11039,6 +11473,8 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(child_group.outputs.child.value);
+                    unrestricted(next.value);
                     ChildState child_state = { amount: 1 };
                     LauncherState next = { launches: launches + 1 };
                     require child_group.outputs become {
@@ -11088,6 +11524,9 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(child_group.outputs.child.value);
+                    unrestricted(child_group.outputs.sibling.value);
+                    unrestricted(next.value);
                     ChildState child_state = { amount: amount };
                     ChildState sibling_state = { amount: amount + 1 };
                     LauncherState next = { launches: launches + 1 };
@@ -11103,6 +11542,7 @@ mod tests {
             // normal successor, exercising the spawned template closure.
             actor Child owns ChildState {
                 entry return_to_launcher() emits next: Launcher {
+                    unrestricted(next.value);
                     LauncherState next = { launches: 0 };
                     become next <- Launcher(next);
                 }
@@ -11207,6 +11647,8 @@ mod tests {
                     }
                 }
                 emits next: Node {
+                    unrestricted(child_group.outputs.child.value);
+                    unrestricted(next.value);
                     NodeState child = { amount: next_amount };
                     NodeState next = { amount: next_amount + 1 };
                     require child_group.outputs become {
@@ -11257,6 +11699,8 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(game.outputs.mux.value);
+                    unrestricted(next.value);
                     BoardState board = { turn: 0 };
                     LauncherState next = { launches: launches + 1 };
                     require game.outputs become {
@@ -11268,6 +11712,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry move() emits next: Pawn {
+                    unrestricted(next.value);
                     BoardState next = { turn: turn + 1 };
                     become next <- Pawn(next);
                 }
@@ -11275,6 +11720,7 @@ mod tests {
 
             actor Pawn owns BoardState {
                 entry finish() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next = { turn: turn + 1 };
                     become next <- Mux(next);
                 }
@@ -11282,6 +11728,7 @@ mod tests {
 
             actor Knight owns BoardState {
                 entry finish() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next = { turn: turn + 1 };
                     become next <- Mux(next);
                 }
@@ -11327,6 +11774,8 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(pair.outputs.next_pair.value);
+                    unrestricted(next.value);
                     require(1 == 1);
                     become next <- Launcher(self.state);
                 }
@@ -11360,6 +11809,8 @@ mod tests {
                     }
                 }
                 emits next: Launcher {
+                    unrestricted(pair.outputs.next_pair.value);
+                    unrestricted(next.value);
                     require(1 == 1);
                     become next <- Launcher(self.state);
                 }
@@ -11443,6 +11894,7 @@ mod tests {
 
             actor League owns LeagueState {
                 entry register() emits next: Player {
+                    unrestricted(next.value);
                     PlayerState next_player = {
                         nonce: nonce,
                     };
@@ -11452,6 +11904,7 @@ mod tests {
 
             actor Player owns PlayerState {
                 entry enter_mux() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: nonce,
                         ply: 0,
@@ -11462,6 +11915,7 @@ mod tests {
 
             actor Mux owns BoardState {
                 entry choose(MoveActor target) emits next: MoveActor {
+                    unrestricted(next.value);
                     if (target == MoveActor::Knight) {
                         require(selector >= 0);
                     }
@@ -11475,6 +11929,7 @@ mod tests {
                 }
 
                 entry choose_knight_const() emits next: MoveActor {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -11485,6 +11940,7 @@ mod tests {
                 }
 
                 entry choose_pawn() emits next: Pawn {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -11493,6 +11949,7 @@ mod tests {
                 }
 
                 entry choose_knight() emits next: Knight {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -11503,6 +11960,7 @@ mod tests {
 
             actor Pawn owns BoardState {
                 entry back_to_mux() emits next: Mux {
+                    unrestricted(next.value);
                     BoardState next_board = {
                         selector: selector,
                         ply: ply + 1,
@@ -11513,6 +11971,7 @@ mod tests {
 
             actor Knight owns BoardState {
                 entry back_to_mux() emits next: Mux {
+                    unrestricted(next.value);
                     require(selector >= 0);
 
                     BoardState next_board = {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -576,6 +576,8 @@ actor Event owns EventState {
         event: Event,
         ticket: Ticket,
     } {
+        unrestricted(event.value);
+        unrestricted(ticket.value);
         EventState next_event = {
             remaining: remaining - 1,
         };
@@ -591,6 +593,7 @@ actor Event owns EventState {
 
 actor Ticket owns TicketState {
     entry transfer(pubkey next_owner) emits next: Ticket {
+        unrestricted(next.value);
         TicketState next = {
             owner: next_owner,
         };

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -222,17 +222,8 @@ fn inspect_entry(
     }
     inputs.extend(entry.route_plan.consumes.iter().map(|input| format!("{}: {}", input.name, input.actor)));
 
-    let outputs = entry
-        .route_plan
-        .outputs
-        .iter()
-        .map(|output| {
-            let name = output.name.as_deref().unwrap_or("next");
-            format!("{name} -> {}", output.actors.join(" | "))
-        })
-        .collect();
-    let routes =
-        entry.routes.iter().map(|route| format!("{} -> {}", route.output.as_deref().unwrap_or("next"), route.actor)).collect();
+    let outputs = entry.route_plan.outputs.iter().map(|output| format!("{} -> {}", output.name, output.actors.join(" | "))).collect();
+    let routes = entry.routes.iter().map(|route| format!("{} -> {}", route.output, route.actor)).collect();
 
     let mut signature_script_bytes = SizeEstimate::exact(ScriptBuilder::canonical_data_size(script));
     for param in &sil_entry.params {
@@ -599,11 +590,11 @@ actor Event owns EventState {
 }
 
 actor Ticket owns TicketState {
-    entry transfer(pubkey next_owner) emits one Ticket {
+    entry transfer(pubkey next_owner) emits next: Ticket {
         TicketState next = {
             owner: next_owner,
         };
-        become Ticket(next);
+        become next <- Ticket(next);
     }
 }
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -30,9 +30,10 @@ pub(crate) mod word {
     pub const OUTPUTS: &str = "outputs";
     pub const OWNS: &str = "owns";
     pub const REQUIRE: &str = "require";
-    pub const RESERVED_SELF_MEMBERS: [&str; 5] = [STATE, "value", COVENANT_ID, "type", "ref"];
+    pub const RESERVED_SELF_MEMBERS: [&str; 5] = [STATE, VALUE, COVENANT_ID, "type", "ref"];
     pub const SELF: &str = "self";
     pub const SPAWNS: &str = "spawns";
     pub const STATE: &str = "state";
+    pub const VALUE: &str = "value";
     pub const VIRTUAL: &str = "virtual";
 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -34,6 +34,7 @@ pub(crate) mod word {
     pub const SELF: &str = "self";
     pub const SPAWNS: &str = "spawns";
     pub const STATE: &str = "state";
+    pub const UNRESTRICTED: &str = "unrestricted";
     pub const VALUE: &str = "value";
     pub const VIRTUAL: &str = "virtual";
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ state CounterState {
 
 actor Counter owns CounterState {
     entry bump(int delta) emits next: Counter {
+        unrestricted(next.value);
         CounterState next = {
             count: count + delta,
         };
@@ -203,6 +204,7 @@ state IssuerState {
 
 actor Issuer owns IssuerState {
     entry issue(byte[] domain) emits next: Issuer {
+        unrestricted(next.value);
         byte[32] uid = invocation_uid(domain);
         require(uid == invocation_uid(domain));
 
@@ -225,6 +227,7 @@ state LeftState {
 
 actor Left owns LeftState {
     entry bump() emits next: Left {
+        unrestricted(next.value);
         LeftState next = {
             amount: amount + 1,
         };
@@ -238,6 +241,7 @@ state RightState {
 
 actor Right owns RightState {
     entry bump() emits next: Right {
+        unrestricted(next.value);
         RightState next = {
             amount: amount + 1,
         };
@@ -247,6 +251,7 @@ actor Right owns RightState {
 
 actor RightAlt owns RightState {
     entry bump() emits next: RightAlt {
+        unrestricted(next.value);
         RightState next = {
             amount: amount + 1,
         };
@@ -397,6 +402,7 @@ actor Shared owns SharedState {
         other: Shared,
     }
     emits next: Shared {
+        unrestricted(next.value);
         SharedState next = {
             count: count + other.count,
         };
@@ -408,6 +414,7 @@ state GuardState {}
 
 actor Guard owns GuardState {
     entry hold() emits next: Guard {
+        unrestricted(next.value);
         become next <- Guard(self.state);
     }
 }
@@ -550,6 +557,7 @@ state LeafState {
 
 actor Leaf owns LeafState {
     entry update() emits next: Leaf {
+        unrestricted(next.value);
         LeafState next = {
             n: n + 1,
         };
@@ -583,6 +591,7 @@ actor Middle owns MiddleState {
         }
     }
     emits next: Middle {
+        unrestricted(next.value);
         LeafState next_leaf = leaf.inputs.src.state;
         require leaf.outputs become {
             next <- Leaf(next_leaf),
@@ -620,6 +629,7 @@ actor Root owns RootState {
         }
     }
     emits next: Root {
+        unrestricted(next.value);
         MiddleState next_middle = middle.inputs.src.state;
         require middle.outputs become {
             next <- Middle(next_middle),
@@ -859,6 +869,7 @@ state AssetState {
 
 actor Asset owns AssetState {
     entry keep() emits next: Asset {
+        unrestricted(next.value);
         become next <- Asset(self.state);
     }
 }
@@ -889,6 +900,7 @@ actor Controller owns ControllerState {
         }
     }
     emits next: Controller {
+        unrestricted(next.value);
         AssetState current = asset.inputs.src.state;
         require(current.tag == ASSET_TAG);
         require asset.outputs become {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,12 +180,12 @@ state CounterState {
 }
 
 actor Counter owns CounterState {
-    entry bump(int delta) emits one Counter {
+    entry bump(int delta) emits next: Counter {
         CounterState next = {
             count: count + delta,
         };
 
-        become Counter(next);
+        become next <- Counter(next);
     }
 }
 
@@ -202,14 +202,14 @@ state IssuerState {
 }
 
 actor Issuer owns IssuerState {
-    entry issue(byte[] domain) emits one Issuer {
+    entry issue(byte[] domain) emits next: Issuer {
         byte[32] uid = invocation_uid(domain);
         require(uid == invocation_uid(domain));
 
         IssuerState next = {
             last_uid: uid,
         };
-        become Issuer(next);
+        become next <- Issuer(next);
     }
 }
 
@@ -224,11 +224,11 @@ state LeftState {
 }
 
 actor Left owns LeftState {
-    entry bump() emits one Left {
+    entry bump() emits next: Left {
         LeftState next = {
             amount: amount + 1,
         };
-        become Left(next);
+        become next <- Left(next);
     }
 }
 
@@ -237,20 +237,20 @@ state RightState {
 }
 
 actor Right owns RightState {
-    entry bump() emits one Right {
+    entry bump() emits next: Right {
         RightState next = {
             amount: amount + 1,
         };
-        become Right(next);
+        become next <- Right(next);
     }
 }
 
 actor RightAlt owns RightState {
-    entry bump() emits one RightAlt {
+    entry bump() emits next: RightAlt {
         RightState next = {
             amount: amount + 1,
         };
-        become RightAlt(next);
+        become next <- RightAlt(next);
     }
 }
 
@@ -396,19 +396,19 @@ actor Shared owns SharedState {
     consumes {
         other: Shared,
     }
-    emits one Shared {
+    emits next: Shared {
         SharedState next = {
             count: count + other.count,
         };
-        become Shared(next);
+        become next <- Shared(next);
     }
 }
 
 state GuardState {}
 
 actor Guard owns GuardState {
-    entry hold() emits one Guard {
-        become Guard(self.state);
+    entry hold() emits next: Guard {
+        become next <- Guard(self.state);
     }
 }
 
@@ -549,11 +549,11 @@ state LeafState {
 }
 
 actor Leaf owns LeafState {
-    entry update() emits one Leaf {
+    entry update() emits next: Leaf {
         LeafState next = {
             n: n + 1,
         };
-        become Leaf(next);
+        become next <- Leaf(next);
     }
 }
 
@@ -582,7 +582,7 @@ actor Middle owns MiddleState {
             next: Leaf,
         }
     }
-    emits one Middle {
+    emits next: Middle {
         LeafState next_leaf = leaf.inputs.src.state;
         require leaf.outputs become {
             next <- Leaf(next_leaf),
@@ -590,7 +590,7 @@ actor Middle owns MiddleState {
         MiddleState next = {
             n: n + 1,
         };
-        become Middle(next);
+        become next <- Middle(next);
     }
 }
 
@@ -619,7 +619,7 @@ actor Root owns RootState {
             next: Middle,
         }
     }
-    emits one Root {
+    emits next: Root {
         MiddleState next_middle = middle.inputs.src.state;
         require middle.outputs become {
             next <- Middle(next_middle),
@@ -627,7 +627,7 @@ actor Root owns RootState {
         RootState next = {
             n: n + 1,
         };
-        become Root(next);
+        become next <- Root(next);
     }
 }
 
@@ -858,8 +858,8 @@ state AssetState {
 }
 
 actor Asset owns AssetState {
-    entry keep() emits one Asset {
-        become Asset(self.state);
+    entry keep() emits next: Asset {
+        become next <- Asset(self.state);
     }
 }
 
@@ -888,13 +888,13 @@ actor Controller owns ControllerState {
             next: AssetApp::Asset,
         }
     }
-    emits one Controller {
+    emits next: Controller {
         AssetState current = asset.inputs.src.state;
         require(current.tag == ASSET_TAG);
         require asset.outputs become {
             next <- AssetApp::Asset(current),
         };
-        become Controller(self.state);
+        become next <- Controller(self.state);
     }
 }
 

--- a/src/model/entry.rs
+++ b/src/model/entry.rs
@@ -37,26 +37,18 @@ impl<'a> EntryModel<'a> {
             .enumerate()
             .map(|(index, consume)| EntryInteraction {
                 source: InteractionSource::Consume(consume),
-                handle: Some(&consume.name),
+                handle: &consume.name,
                 index,
                 target: ActorTarget::static_actor(&consume.actor),
             })
             .collect();
         let current_outputs = match &source.emits {
             EmitSpec::None => Vec::new(),
-            EmitSpec::One { actors } => {
-                vec![EntryInteraction {
-                    source: InteractionSource::CurrentOutput { declaration: &source.emits, output: None },
-                    handle: None,
-                    index: 0,
-                    target: ActorTarget::domain(actors, actor_enums),
-                }]
-            }
             EmitSpec::Outputs(outputs) => outputs
                 .iter()
                 .map(|output| EntryInteraction {
-                    source: InteractionSource::CurrentOutput { declaration: &source.emits, output: Some(output) },
-                    handle: Some(&output.name),
+                    source: InteractionSource::CurrentOutput(output),
+                    handle: &output.name,
                     index: output.auth_index,
                     target: ActorTarget::domain(&output.actors, actor_enums),
                 })
@@ -72,7 +64,7 @@ impl<'a> EntryModel<'a> {
                     .enumerate()
                     .map(|(index, input)| EntryInteraction {
                         source: InteractionSource::ObserveInput(input),
-                        handle: Some(&input.name),
+                        handle: &input.name,
                         index,
                         target: ActorTarget::observed(source, observe, input),
                     })
@@ -83,7 +75,7 @@ impl<'a> EntryModel<'a> {
                     .enumerate()
                     .map(|(index, output)| EntryInteraction {
                         source: InteractionSource::ObserveOutput(output),
-                        handle: Some(&output.name),
+                        handle: &output.name,
                         index,
                         target: ActorTarget::observed(source, observe, output),
                     })
@@ -99,7 +91,7 @@ impl<'a> EntryModel<'a> {
                     .iter()
                     .map(|output| EntryInteraction {
                         source: InteractionSource::SpawnOutput(output),
-                        handle: Some(&output.name),
+                        handle: &output.name,
                         index: output.group_index,
                         target: ActorTarget::source_or_static(source, &output.actor),
                     })
@@ -252,7 +244,7 @@ pub(crate) enum CovenantContext<'a> {
 #[derive(Debug)]
 pub(crate) struct EntryInteraction<'a> {
     source: InteractionSource<'a>,
-    handle: Option<&'a str>,
+    handle: &'a str,
     index: usize,
     target: ActorTarget,
 }
@@ -263,8 +255,8 @@ impl<'a> EntryInteraction<'a> {
         self.source
     }
 
-    /// Return the declared handle, or `None` for an implicit output.
-    pub(crate) fn handle(&self) -> Option<&'a str> {
+    /// Return the declared interaction handle.
+    pub(crate) fn handle(&self) -> &'a str {
         self.handle
     }
 
@@ -284,8 +276,8 @@ impl<'a> EntryInteraction<'a> {
 pub(crate) enum InteractionSource<'a> {
     /// A current-covenant input from `consumes`.
     Consume(&'a ConsumeDecl),
-    /// A current-covenant output and its optional named source node.
-    CurrentOutput { declaration: &'a EmitSpec, output: Option<&'a EmitOutput> },
+    /// A current-covenant output.
+    CurrentOutput(&'a EmitOutput),
     /// An input from an `observes` clause.
     ObserveInput(&'a ObservedActorDecl),
     /// An output from an `observes` clause.
@@ -732,9 +724,9 @@ mod tests {
                 covenant: "child".to_string(),
                 outputs: vec![SpawnOutputDecl { name: "child".to_string(), actor: "Child".to_string(), group_index: 0 }],
             }],
-            emits: EmitSpec::One { actors: vec!["Move".to_string()] },
+            emits: EmitSpec::Outputs(vec![EmitOutput { name: "next".to_string(), actors: vec!["Move".to_string()], auth_index: 0 }]),
             body: String::new(),
-            routes: vec![RouteCall { output: None, actor: "target".to_string(), state: "next".to_string() }],
+            routes: vec![RouteCall { output: "next".to_string(), actor: "target".to_string(), state: "next".to_string() }],
             terminal_route_sets: Vec::new(),
         };
         let selectors = BTreeMap::from([(
@@ -763,13 +755,16 @@ mod tests {
             panic!("current input must retain its consume declaration");
         };
         assert!(std::ptr::eq(consume, &entry.consumes[0]));
-        assert_eq!(model.current().inputs()[0].handle(), Some("peer"));
+        assert_eq!(model.current().inputs()[0].handle(), "peer");
         assert_eq!(model.current().inputs()[0].index(), 0);
-        let InteractionSource::CurrentOutput { declaration, output: None } = model.current().outputs()[0].source() else {
+        let InteractionSource::CurrentOutput(output) = model.current().outputs()[0].source() else {
             panic!("current output must retain its emits declaration");
         };
-        assert!(std::ptr::eq(declaration, &entry.emits));
-        assert_eq!(model.current().outputs()[0].handle(), None);
+        let EmitSpec::Outputs(outputs) = &entry.emits else {
+            panic!("test entry must have named outputs");
+        };
+        assert!(std::ptr::eq(output, &outputs[0]));
+        assert_eq!(model.current().outputs()[0].handle(), "next");
         assert_eq!(model.current().outputs()[0].index(), 0);
         assert_eq!(model.current().outputs()[0].target().actors().collect::<Vec<_>>(), ["Pawn", "King"]);
         let observe_group = model.existing_groups().next().expect("observe group");
@@ -778,7 +773,7 @@ mod tests {
             panic!("observe input must retain its source declaration");
         };
         assert!(std::ptr::eq(observed, &entry.observes[0].inputs[0]));
-        assert_eq!(observe_group.inputs()[0].handle(), Some("before"));
+        assert_eq!(observe_group.inputs()[0].handle(), "before");
         assert_eq!(observe_group.inputs()[0].index(), 0);
         assert_eq!(observe_group.inputs()[0].target().static_actors().collect::<Vec<_>>(), ["Remote"]);
 
@@ -788,7 +783,7 @@ mod tests {
             panic!("spawn output must retain its source declaration");
         };
         assert!(std::ptr::eq(output, &entry.spawns[0].outputs[0]));
-        assert_eq!(spawn_group.outputs()[0].handle(), Some("child"));
+        assert_eq!(spawn_group.outputs()[0].handle(), "child");
         assert_eq!(spawn_group.outputs()[0].index(), 0);
         assert_eq!(spawn_group.outputs()[0].target().static_actors().collect::<Vec<_>>(), ["Child"]);
 
@@ -870,24 +865,18 @@ mod tests {
         let EmitSpec::Outputs(outputs) = &entry.emits else {
             panic!("test entry must have named outputs");
         };
-        let InteractionSource::CurrentOutput { declaration: first_declaration, output: Some(first) } =
-            model.current().outputs()[0].source()
-        else {
+        let InteractionSource::CurrentOutput(first) = model.current().outputs()[0].source() else {
             panic!("named output must retain its emit output");
         };
-        let InteractionSource::CurrentOutput { declaration: second_declaration, output: Some(second) } =
-            model.current().outputs()[1].source()
-        else {
+        let InteractionSource::CurrentOutput(second) = model.current().outputs()[1].source() else {
             panic!("named output must retain its emit output");
         };
-        assert!(std::ptr::eq(first_declaration, &entry.emits));
-        assert!(std::ptr::eq(second_declaration, &entry.emits));
         assert!(std::ptr::eq(first, &outputs[0]));
         assert!(std::ptr::eq(second, &outputs[1]));
-        assert_eq!(model.current().outputs()[0].handle(), Some("first"));
+        assert_eq!(model.current().outputs()[0].handle(), "first");
         assert_eq!(model.current().outputs()[0].index(), 0);
         assert_eq!(model.current().outputs()[0].target().actors().collect::<Vec<_>>(), ["Pawn"]);
-        assert_eq!(model.current().outputs()[1].handle(), Some("second"));
+        assert_eq!(model.current().outputs()[1].handle(), "second");
         assert_eq!(model.current().outputs()[1].index(), 1);
         assert_eq!(model.current().outputs()[1].target().actors().collect::<Vec<_>>(), ["Pawn", "King"]);
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -433,9 +433,6 @@ impl Parser {
     fn parse_emits(&mut self) -> Result<EmitSpec> {
         if self.consume_ident(word::NONE) {
             Ok(EmitSpec::None)
-        } else if self.consume_ident(word::ONE) {
-            let actors = self.parse_actor_union_until_body()?;
-            Ok(EmitSpec::One { actors })
         } else if self.check_symbol('{') {
             self.expect_symbol('{')?;
             let mut outputs = Vec::new();
@@ -450,7 +447,13 @@ impl Parser {
             self.expect_symbol('}')?;
             Ok(EmitSpec::Outputs(outputs))
         } else {
-            Err(self.error(format!("expected emits spec, found {}", self.describe_current())))
+            let name = self.expect_any_ident()?;
+            if name == word::ONE && !self.check_symbol(':') {
+                return Err(self.error("`emits one Type` has been removed; declare a named output with `emits name: Type`"));
+            }
+            self.expect_symbol(':')?;
+            let actors = self.parse_actor_union_until_body()?;
+            Ok(EmitSpec::Outputs(vec![EmitOutput { name, actors, auth_index: 0 }]))
         }
     }
 
@@ -779,6 +782,78 @@ mod tests {
         assert_eq!(entry.consumes.len(), 2);
         assert!(matches!(&entry.emits, crate::ast::EmitSpec::Outputs(outputs) if outputs.len() == 2));
         assert_eq!(entry.routes.len(), 2);
+    }
+
+    #[test]
+    fn parses_named_single_output_shorthand() {
+        let module = parse_module(
+            PathBuf::from("single-output.ag"),
+            r#"
+            state State {}
+
+            actor Actor owns State {
+                entry update() emits result: Actor {
+                    become result <- Actor(self.state);
+                }
+            }
+            "#
+            .to_string(),
+        )
+        .expect("named single-output shorthand parses");
+
+        let entry = &module.actors[0].entries[0];
+        let crate::ast::EmitSpec::Outputs(outputs) = &entry.emits else {
+            panic!("single-output shorthand normalizes to named outputs");
+        };
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].name, "result");
+        assert_eq!(outputs[0].actors, ["Actor"]);
+        assert_eq!(outputs[0].auth_index, 0);
+        assert_eq!(entry.routes[0].output, "result");
+    }
+
+    #[test]
+    fn allows_one_as_named_single_output_handle() {
+        let module = parse_module(
+            PathBuf::from("single-output.ag"),
+            r#"
+            state State {}
+
+            actor Actor owns State {
+                entry update() emits one: Actor {
+                    become one <- Actor(self.state);
+                }
+            }
+            "#
+            .to_string(),
+        )
+        .expect("`one` is an ordinary named output handle");
+
+        let crate::ast::EmitSpec::Outputs(outputs) = &module.actors[0].entries[0].emits else {
+            panic!("single-output shorthand normalizes to named outputs");
+        };
+        assert_eq!(outputs[0].name, "one");
+        assert_eq!(module.actors[0].entries[0].routes[0].output, "one");
+    }
+
+    #[test]
+    fn rejects_removed_emits_one_syntax() {
+        let err = parse_module(
+            PathBuf::from("single-output.ag"),
+            r#"
+            state State {}
+
+            actor Actor owns State {
+                entry update() emits one Actor {
+                    become Actor(self.state);
+                }
+            }
+            "#
+            .to_string(),
+        )
+        .expect_err("removed emits-one syntax must not parse");
+
+        assert!(err.to_string().contains("`emits one Type` has been removed"), "unexpected error: {err}");
     }
 
     #[test]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -134,12 +134,11 @@ impl TerminalParser<'_> {
     }
 
     fn parse_route(&mut self) -> Result<RouteCall> {
-        let first = self.expect_any_ident()?;
-        let (output, actor) = if self.consume_left_arrow() {
-            (Some(first), self.parse_actor_name()?)
-        } else {
-            (None, self.parse_qualified_tail(first)?)
-        };
+        let output = self.expect_any_ident()?;
+        if !self.consume_left_arrow() {
+            return Err(self.error("every `become` route must name its output with `output <- Actor(state)`"));
+        }
+        let actor = self.parse_actor_name()?;
 
         self.expect_symbol('(')?;
         let start = self.current().span.start;
@@ -344,10 +343,10 @@ mod tests {
         .expect("routes parse");
 
         assert_eq!(routes.len(), 2);
-        assert_eq!(routes[0].output.as_deref(), Some("player_a_out"));
+        assert_eq!(routes[0].output, "player_a_out");
         assert_eq!(routes[0].actor, "Player");
         assert_eq!(routes[0].state, "next_player_a");
-        assert_eq!(routes[1].output.as_deref(), Some("player_b_out"));
+        assert_eq!(routes[1].output, "player_b_out");
         assert_eq!(routes[1].actor, "Player");
         assert_eq!(routes[1].state, "next_player_b");
     }
@@ -368,10 +367,10 @@ mod tests {
     }
 
     #[test]
-    fn extracts_implicit_single_output_route() {
+    fn extracts_inline_named_single_output_route() {
         let routes = collect_routes(
             r#"
-            become Done({
+            become next <- Done({
                 final_value: next_value,
             });
             "#,
@@ -379,9 +378,16 @@ mod tests {
         .expect("routes parse");
 
         assert_eq!(routes.len(), 1);
-        assert_eq!(routes[0].output, None);
+        assert_eq!(routes[0].output, "next");
         assert_eq!(routes[0].actor, "Done");
         assert!(routes[0].state.contains("final_value"));
+    }
+
+    #[test]
+    fn rejects_unnamed_single_output_route() {
+        let err = collect_routes("become Done(next);").expect_err("unnamed routes must not parse");
+
+        assert!(err.to_string().contains("must name its output"), "unexpected error: {err}");
     }
 
     #[test]

--- a/tests/fixtures/emit/capsule_route_context/ReserveAsset.sil
+++ b/tests/fixtures/emit/capsule_route_context/ReserveAsset.sil
@@ -31,7 +31,7 @@ contract ReserveAsset(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one ReserveAsset
+        // :: output next: ReserveAsset
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: co-spent with owner_id
@@ -63,7 +63,7 @@ contract ReserveAsset(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one WalletAsset
+        // :: output next: WalletAsset
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: co-spent with owner_id

--- a/tests/fixtures/emit/capsule_route_context/WalletAsset.sil
+++ b/tests/fixtures/emit/capsule_route_context/WalletAsset.sil
@@ -31,7 +31,7 @@ contract WalletAsset(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one WalletAsset
+        // :: output next: WalletAsset
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: become WalletAsset

--- a/tests/fixtures/emit/capsule_route_context/app.ag
+++ b/tests/fixtures/emit/capsule_route_context/app.ag
@@ -14,7 +14,7 @@ state ReserveAssetState expands AssetCapsule {
 }
 
 actor ReserveAsset owns ReserveAssetState {
-    entry settle(int next_balance) emits one ReserveAsset {
+    entry settle(int next_balance) emits next: ReserveAsset {
         require(owner_id.co_spent());
 
         ReserveAssetState next_asset = {
@@ -26,10 +26,10 @@ actor ReserveAsset owns ReserveAssetState {
             balance: next_balance,
         };
 
-        become ReserveAsset(next_asset);
+        become next <- ReserveAsset(next_asset);
     }
 
-    entry withdraw(int next_balance) emits one WalletAsset {
+    entry withdraw(int next_balance) emits next: WalletAsset {
         require(owner_id.co_spent());
 
         ReserveAssetState next_asset = {
@@ -41,13 +41,13 @@ actor ReserveAsset owns ReserveAssetState {
             balance: next_balance,
         };
 
-        become WalletAsset(next_asset);
+        become next <- WalletAsset(next_asset);
     }
 }
 
 actor WalletAsset owns ReserveAssetState {
-    entry hold() emits one WalletAsset {
-        become WalletAsset(self.state);
+    entry hold() emits next: WalletAsset {
+        become next <- WalletAsset(self.state);
     }
 }
 

--- a/tests/fixtures/emit/capsule_route_context/app.ag
+++ b/tests/fixtures/emit/capsule_route_context/app.ag
@@ -26,6 +26,7 @@ actor ReserveAsset owns ReserveAssetState {
             balance: next_balance,
         };
 
+        unrestricted(next.value);
         become next <- ReserveAsset(next_asset);
     }
 
@@ -41,12 +42,14 @@ actor ReserveAsset owns ReserveAssetState {
             balance: next_balance,
         };
 
+        unrestricted(next.value);
         become next <- WalletAsset(next_asset);
     }
 }
 
 actor WalletAsset owns ReserveAssetState {
     entry hold() emits next: WalletAsset {
+        unrestricted(next.value);
         become next <- WalletAsset(self.state);
     }
 }

--- a/tests/fixtures/emit/in_app_observe_routes/Foreign.sil
+++ b/tests/fixtures/emit/in_app_observe_routes/Foreign.sil
@@ -28,7 +28,8 @@ contract Foreign(
     entrypoint function hold() {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Foreign
+        // :: output next: Foreign
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: become Foreign
         require(
@@ -41,7 +42,7 @@ contract Foreign(
     entrypoint function route(byte[] gen__target_prefix, byte[] gen__target_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Target
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Target
 
         TargetState next = {
             // :: user declared fields

--- a/tests/fixtures/emit/in_app_observe_routes/Local.sil
+++ b/tests/fixtures/emit/in_app_observe_routes/Local.sil
@@ -52,7 +52,7 @@ contract Local(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Local
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Local
 
         Gen__ForeignState next_foreign = gen__remote_src_state;
         // :: observed become remote.next -> Foreign

--- a/tests/fixtures/emit/in_app_observe_routes/app.ag
+++ b/tests/fixtures/emit/in_app_observe_routes/app.ag
@@ -12,15 +12,15 @@ state TargetState {
 }
 
 actor Foreign owns ForeignState {
-    entry hold() emits one Foreign {
-        become Foreign(self.state);
+    entry hold() emits next: Foreign {
+        become next <- Foreign(self.state);
     }
 
-    entry route() emits one Target {
+    entry route() emits next: Target {
         TargetState next = {
             units: 0,
         };
-        become Target(next);
+        become next <- Target(next);
     }
 }
 
@@ -35,7 +35,7 @@ actor Local owns LocalState {
             next: Foreign,
         }
     }
-    emits one Local {
+    emits next: Local {
         ForeignState next_foreign = remote.inputs.src.state;
         require remote.outputs become {
             next <- Foreign(next_foreign),
@@ -45,7 +45,7 @@ actor Local owns LocalState {
             foreign_id: foreign_id,
             steps: steps + 1,
         };
-        become Local(next_local);
+        become next <- Local(next_local);
     }
 }
 

--- a/tests/fixtures/emit/in_app_observe_routes/app.ag
+++ b/tests/fixtures/emit/in_app_observe_routes/app.ag
@@ -13,6 +13,7 @@ state TargetState {
 
 actor Foreign owns ForeignState {
     entry hold() emits next: Foreign {
+        unrestricted(next.value);
         become next <- Foreign(self.state);
     }
 
@@ -20,6 +21,7 @@ actor Foreign owns ForeignState {
         TargetState next = {
             units: 0,
         };
+        unrestricted(next.value);
         become next <- Target(next);
     }
 }
@@ -45,6 +47,7 @@ actor Local owns LocalState {
             foreign_id: foreign_id,
             steps: steps + 1,
         };
+        unrestricted(next.value);
         become next <- Local(next_local);
     }
 }

--- a/tests/fixtures/emit/input_template_route_reuse/app.ag
+++ b/tests/fixtures/emit/input_template_route_reuse/app.ag
@@ -24,6 +24,7 @@ actor Controller owns ControllerState {
             count: peer.count + 1,
         };
 
+        unrestricted(peer.value);
         become peer <- Peer(next_peer);
     }
 }

--- a/tests/fixtures/emit/open_observed_actor_binding/app.ag
+++ b/tests/fixtures/emit/open_observed_actor_binding/app.ag
@@ -45,6 +45,7 @@ actor Cell owns CellState {
             tick: tick + 1,
         };
 
+        unrestricted(cell.value);
         become cell <- Cell(next_cell);
     }
 }

--- a/tests/fixtures/emit/open_observed_actor_binding/app.ag
+++ b/tests/fixtures/emit/open_observed_actor_binding/app.ag
@@ -27,7 +27,7 @@ actor Cell owns CellState {
         AgentCapsule prev_state = remote.inputs.agent.state;
 
         require(agent_type == observed_agent);
-        require(prev_state.controller_id == self.covenant_id);
+        require(prev_state.controller_id == self.cov_id);
 
         AgentCapsule next_state = {
             controller_id: prev_state.controller_id,

--- a/tests/fixtures/emit/open_observed_state_handle/app.ag
+++ b/tests/fixtures/emit/open_observed_state_handle/app.ag
@@ -43,6 +43,7 @@ actor Cell owns CellState {
             tick: tick + 1,
         };
 
+        unrestricted(cell.value);
         become cell <- Cell(next_cell);
     }
 }

--- a/tests/fixtures/emit/open_observed_state_handle/app.ag
+++ b/tests/fixtures/emit/open_observed_state_handle/app.ag
@@ -25,7 +25,7 @@ actor Cell owns CellState {
         cell: Cell,
     } {
         AgentCapsule prev_state = remote.inputs.agent.state;
-        require(prev_state.controller_id == self.covenant_id);
+        require(prev_state.controller_id == self.cov_id);
 
         AgentCapsule next_state = {
             controller_id: prev_state.controller_id,

--- a/tests/fixtures/emit/single_actor_self_consume/Counter.sil
+++ b/tests/fixtures/emit/single_actor_self_consume/Counter.sil
@@ -25,7 +25,8 @@ contract Counter(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Counter
+        // :: output next: Counter
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         State next = {
             // :: user declared fields

--- a/tests/fixtures/emit/single_actor_self_consume/app.ag
+++ b/tests/fixtures/emit/single_actor_self_consume/app.ag
@@ -7,12 +7,12 @@ actor Counter owns CounterState {
     consumes {
         other: Counter,
     }
-    emits one Counter {
+    emits next: Counter {
         CounterState next = {
             count: count + other.count,
         };
 
-        become Counter(next);
+        become next <- Counter(next);
     }
 
     entry hold() emits none {

--- a/tests/fixtures/emit/single_actor_self_consume/app.ag
+++ b/tests/fixtures/emit/single_actor_self_consume/app.ag
@@ -12,6 +12,7 @@ actor Counter owns CounterState {
             count: count + other.count,
         };
 
+        unrestricted(next.value);
         become next <- Counter(next);
     }
 

--- a/tests/fixtures/emit/state_expansion/Forager.sil
+++ b/tests/fixtures/emit/state_expansion/Forager.sil
@@ -23,7 +23,8 @@ contract Forager(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Forager
+        // :: output next: Forager
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         require(energy > 0);
         State next_state = {

--- a/tests/fixtures/emit/state_expansion/app.ag
+++ b/tests/fixtures/emit/state_expansion/app.ag
@@ -12,7 +12,7 @@ state ForagerState expands AgentCapsule {
 }
 
 actor Forager owns ForagerState {
-    entry hold() emits one Forager {
+    entry hold() emits next: Forager {
         require(energy > 0);
 
         ForagerState next_state = {
@@ -22,7 +22,7 @@ actor Forager owns ForagerState {
             energy: energy - 1,
         };
 
-        become Forager(next_state);
+        become next <- Forager(next_state);
     }
 }
 

--- a/tests/fixtures/emit/state_expansion/app.ag
+++ b/tests/fixtures/emit/state_expansion/app.ag
@@ -22,6 +22,7 @@ actor Forager owns ForagerState {
             energy: energy - 1,
         };
 
+        unrestricted(next.value);
         become next <- Forager(next_state);
     }
 }

--- a/tests/fixtures/runtime/context_closed_icc/asset.ag
+++ b/tests/fixtures/runtime/context_closed_icc/asset.ag
@@ -17,6 +17,7 @@ actor Badge owns BadgeState {
             balance: next_balance,
         };
 
+        unrestricted(badge.value);
         become badge <- Badge(next);
     }
 }

--- a/tests/fixtures/runtime/context_closed_icc/controller.ag
+++ b/tests/fixtures/runtime/context_closed_icc/controller.ag
@@ -33,6 +33,7 @@ actor Controller owns ControllerState {
             minted: minted + amount,
         };
 
+        unrestricted(controller.value);
         become controller <- Controller(next);
     }
 }

--- a/tests/fixtures/runtime/context_closed_icc/controller.ag
+++ b/tests/fixtures/runtime/context_closed_icc/controller.ag
@@ -21,7 +21,7 @@ actor Controller owns ControllerState {
         BadgeState previous = asset.inputs.badge.state;
         BadgeState next_badge = {
             owner: previous.owner,
-            controller_id: self.covenant_id,
+            controller_id: self.cov_id,
             balance: previous.balance + amount,
         };
 

--- a/tests/fixtures/runtime/context_genesis_spawn/Controller.sil
+++ b/tests/fixtures/runtime/context_genesis_spawn/Controller.sil
@@ -30,7 +30,7 @@ contract Controller(
     ) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one Controller
+        // :: output next: Controller
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: genesis covenants

--- a/tests/fixtures/runtime/context_genesis_spawn/Pair.sil
+++ b/tests/fixtures/runtime/context_genesis_spawn/Pair.sil
@@ -17,7 +17,7 @@ contract Pair(
     entrypoint function keep() {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Pair
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pair
 
         // :: become Pair
         require(

--- a/tests/fixtures/runtime/context_genesis_spawn/app.ag
+++ b/tests/fixtures/runtime/context_genesis_spawn/app.ag
@@ -27,16 +27,20 @@ actor Controller owns ControllerState {
             launches: launches + 1,
         };
 
+        unrestricted(new_pair.outputs.left.value);
+        unrestricted(new_pair.outputs.right.value);
         require new_pair.outputs become {
             left <- self.pair_type(left),
             right <- self.pair_type(right),
         };
+        unrestricted(next.value);
         become next <- Controller(next);
     }
 }
 
 actor Pair owns PairState {
     entry keep() emits next: Pair {
+        unrestricted(next.value);
         become next <- Pair(self.state);
     }
 }

--- a/tests/fixtures/runtime/context_genesis_spawn/app.ag
+++ b/tests/fixtures/runtime/context_genesis_spawn/app.ag
@@ -15,7 +15,7 @@ actor Controller owns ControllerState {
             right: self.pair_type,
         }
     }
-    emits one Controller {
+    emits next: Controller {
         PairState left = {
             amount: left_amount,
         };
@@ -31,13 +31,13 @@ actor Controller owns ControllerState {
             left <- self.pair_type(left),
             right <- self.pair_type(right),
         };
-        become Controller(next);
+        become next <- Controller(next);
     }
 }
 
 actor Pair owns PairState {
-    entry keep() emits one Pair {
-        become Pair(self.state);
+    entry keep() emits next: Pair {
+        become next <- Pair(self.state);
     }
 }
 

--- a/tests/fixtures/runtime/context_multiple_genesis_spawns/Controller.sil
+++ b/tests/fixtures/runtime/context_multiple_genesis_spawns/Controller.sil
@@ -36,7 +36,7 @@ contract Controller(
     ) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one Controller
+        // :: output next: Controller
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: genesis covenants

--- a/tests/fixtures/runtime/context_multiple_genesis_spawns/Pair.sil
+++ b/tests/fixtures/runtime/context_multiple_genesis_spawns/Pair.sil
@@ -17,7 +17,7 @@ contract Pair(
     entrypoint function keep() {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Pair
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pair
 
         // :: become Pair
         require(

--- a/tests/fixtures/runtime/context_multiple_genesis_spawns/app.ag
+++ b/tests/fixtures/runtime/context_multiple_genesis_spawns/app.ag
@@ -32,7 +32,7 @@ actor Controller owns ControllerState {
             right: self.pair_type,
         }
     }
-    emits one Controller {
+    emits next: Controller {
         PairState first_left = {
             amount: first_left_amount,
         };
@@ -64,13 +64,13 @@ actor Controller owns ControllerState {
             left <- self.pair_type(third_left),
             right <- self.pair_type(third_right),
         };
-        become Controller(next);
+        become next <- Controller(next);
     }
 }
 
 actor Pair owns PairState {
-    entry keep() emits one Pair {
-        become Pair(self.state);
+    entry keep() emits next: Pair {
+        become next <- Pair(self.state);
     }
 }
 

--- a/tests/fixtures/runtime/context_multiple_genesis_spawns/app.ag
+++ b/tests/fixtures/runtime/context_multiple_genesis_spawns/app.ag
@@ -53,23 +53,30 @@ actor Controller owns ControllerState {
             launches: launches + 3,
         };
 
+        unrestricted(first_pair.outputs.left.value);
+        unrestricted(first_pair.outputs.right.value);
         require first_pair.outputs become {
             left <- self.pair_type(first_left),
             right <- self.pair_type(first_right),
         };
+        unrestricted(second_pair.outputs.pair.value);
         require second_pair.outputs become {
             pair <- self.pair_type(second),
         };
+        unrestricted(third_pair.outputs.left.value);
+        unrestricted(third_pair.outputs.right.value);
         require third_pair.outputs become {
             left <- self.pair_type(third_left),
             right <- self.pair_type(third_right),
         };
+        unrestricted(next.value);
         become next <- Controller(next);
     }
 }
 
 actor Pair owns PairState {
     entry keep() emits next: Pair {
+        unrestricted(next.value);
         become next <- Pair(self.state);
     }
 }

--- a/tests/fixtures/runtime/context_observed_self_merge/asset.ag
+++ b/tests/fixtures/runtime/context_observed_self_merge/asset.ag
@@ -14,6 +14,7 @@ actor Asset owns AssetState {
             amount: amount,
         };
 
+        unrestricted(next.value);
         become next <- Asset(next_state);
     }
 
@@ -34,6 +35,8 @@ actor Asset owns AssetState {
             amount: amount - amount_a,
         };
 
+        unrestricted(part_a.value);
+        unrestricted(part_b.value);
         become {
             part_a <- Asset(first),
             part_b <- Asset(second),
@@ -54,6 +57,7 @@ actor Asset owns AssetState {
             amount: amount + other.amount,
         };
 
+        unrestricted(merged.value);
         become merged <- Asset(next_state);
     }
 }

--- a/tests/fixtures/runtime/context_observed_self_merge/controller.ag
+++ b/tests/fixtures/runtime/context_observed_self_merge/controller.ag
@@ -29,6 +29,7 @@ actor Ctrl owns CtrlState {
         CtrlState next_ctrl = {
             n: next_asset.amount,
         };
+        unrestricted(ctrl.value);
         become ctrl <- Ctrl(next_ctrl);
     }
 }

--- a/tests/fixtures/runtime/context_observed_self_merge/controller_app.ag
+++ b/tests/fixtures/runtime/context_observed_self_merge/controller_app.ag
@@ -29,6 +29,7 @@ actor Ctrl owns CtrlState {
         CtrlState next_ctrl = {
             n: next_asset.amount,
         };
+        unrestricted(ctrl.value);
         become ctrl <- Ctrl(next_ctrl);
     }
 }

--- a/tests/fixtures/runtime/context_observed_self_merge/controller_direct.ag
+++ b/tests/fixtures/runtime/context_observed_self_merge/controller_direct.ag
@@ -29,6 +29,7 @@ actor Ctrl owns CtrlState {
         CtrlState next_ctrl = {
             n: next_asset.amount,
         };
+        unrestricted(ctrl.value);
         become ctrl <- Ctrl(next_ctrl);
     }
 }

--- a/tests/fixtures/runtime/context_observed_self_merge/controller_module.ag
+++ b/tests/fixtures/runtime/context_observed_self_merge/controller_module.ag
@@ -29,6 +29,7 @@ actor Ctrl owns CtrlState {
         CtrlState next_ctrl = {
             n: next_asset.amount,
         };
+        unrestricted(ctrl.value);
         become ctrl <- Ctrl(next_ctrl);
     }
 }

--- a/tests/fixtures/runtime/context_shared_actor_witness/Anchor.sil
+++ b/tests/fixtures/runtime/context_shared_actor_witness/Anchor.sil
@@ -28,7 +28,7 @@ contract Anchor(
     entrypoint function advance(byte[] gen__pair_prefix, byte[] gen__pair_suffix) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Pair
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pair
 
         PairState next = {
             // :: user declared fields

--- a/tests/fixtures/runtime/context_shared_actor_witness/Controller.sil
+++ b/tests/fixtures/runtime/context_shared_actor_witness/Controller.sil
@@ -58,7 +58,7 @@ contract Controller(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        // :: emits one Controller
+        // :: output next: Controller
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: genesis covenants

--- a/tests/fixtures/runtime/context_shared_actor_witness/Pair.sil
+++ b/tests/fixtures/runtime/context_shared_actor_witness/Pair.sil
@@ -26,7 +26,7 @@ contract Pair(
     entrypoint function keep() {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Pair
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pair
 
         // :: become Pair
         require(

--- a/tests/fixtures/runtime/context_shared_actor_witness/app.ag
+++ b/tests/fixtures/runtime/context_shared_actor_witness/app.ag
@@ -26,7 +26,7 @@ actor Controller owns ControllerState {
             pair: self.pair_type,
         }
     }
-    emits one Controller {
+    emits next: Controller {
         PairState observed_next = {
             amount: existing.inputs.anchor.state.amount + 1,
         };
@@ -44,22 +44,22 @@ actor Controller owns ControllerState {
         require newborn.outputs become {
             pair <- self.pair_type(spawned),
         };
-        become Controller(next);
+        become next <- Controller(next);
     }
 }
 
 actor Anchor owns AnchorState {
-    entry advance() emits one Pair {
+    entry advance() emits next: Pair {
         PairState next = {
             amount: amount + 1,
         };
-        become Pair(next);
+        become next <- Pair(next);
     }
 }
 
 actor Pair owns PairState {
-    entry keep() emits one Pair {
-        become Pair(self.state);
+    entry keep() emits next: Pair {
+        become next <- Pair(self.state);
     }
 }
 

--- a/tests/fixtures/runtime/context_shared_actor_witness/app.ag
+++ b/tests/fixtures/runtime/context_shared_actor_witness/app.ag
@@ -41,9 +41,11 @@ actor Controller owns ControllerState {
         require existing.outputs become {
             pair <- self.pair_type(observed_next),
         };
+        unrestricted(newborn.outputs.pair.value);
         require newborn.outputs become {
             pair <- self.pair_type(spawned),
         };
+        unrestricted(next.value);
         become next <- Controller(next);
     }
 }
@@ -53,12 +55,14 @@ actor Anchor owns AnchorState {
         PairState next = {
             amount: amount + 1,
         };
+        unrestricted(next.value);
         become next <- Pair(next);
     }
 }
 
 actor Pair owns PairState {
     entry keep() emits next: Pair {
+        unrestricted(next.value);
         become next <- Pair(self.state);
     }
 }

--- a/tests/fixtures/runtime/context_signed_observed/asset.ag
+++ b/tests/fixtures/runtime/context_signed_observed/asset.ag
@@ -9,6 +9,7 @@ actor Asset owns AssetState {
             amount: amount,
         };
 
+        unrestricted(next.value);
         become next <- Asset(next);
     }
 }

--- a/tests/fixtures/runtime/context_signed_observed/asset.ag
+++ b/tests/fixtures/runtime/context_signed_observed/asset.ag
@@ -1,7 +1,7 @@
 import "./capsule.ag";
 
 actor Asset owns AssetState {
-    entry transfer(pubkey next_owner, sig owner_sig) emits one Asset {
+    entry transfer(pubkey next_owner, sig owner_sig) emits next: Asset {
         require(checkSig(owner_sig, owner));
 
         AssetState next = {
@@ -9,7 +9,7 @@ actor Asset owns AssetState {
             amount: amount,
         };
 
-        become Asset(next);
+        become next <- Asset(next);
     }
 }
 

--- a/tests/fixtures/runtime/context_signed_observed/controller.ag
+++ b/tests/fixtures/runtime/context_signed_observed/controller.ag
@@ -15,7 +15,7 @@ actor Controller owns ControllerState {
             reserve: self.asset_type,
         }
     }
-    emits one Controller {
+    emits next: Controller {
         AssetState payment = flow.inputs.payment.state;
         AssetState reserve = {
             owner: next_owner,
@@ -31,7 +31,7 @@ actor Controller owns ControllerState {
             swaps: swaps + 1,
         };
 
-        become Controller(next);
+        become next <- Controller(next);
     }
 }
 

--- a/tests/fixtures/runtime/context_signed_observed/controller.ag
+++ b/tests/fixtures/runtime/context_signed_observed/controller.ag
@@ -31,6 +31,7 @@ actor Controller owns ControllerState {
             swaps: swaps + 1,
         };
 
+        unrestricted(next.value);
         become next <- Controller(next);
     }
 }

--- a/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
+++ b/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
@@ -55,7 +55,8 @@ contract Child(
     ) {
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Launcher
+        // :: output next: Launcher
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         Gen__LauncherState next = {
             // :: generated fields

--- a/tests/fixtures/runtime/context_static_actor_spawn/Launcher.sil
+++ b/tests/fixtures/runtime/context_static_actor_spawn/Launcher.sil
@@ -49,7 +49,8 @@ contract Launcher(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Launcher
+        // :: output next: Launcher
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: genesis covenants
         byte[] gen__child_group_genesis_preimage =

--- a/tests/fixtures/runtime/context_static_actor_spawn/app.ag
+++ b/tests/fixtures/runtime/context_static_actor_spawn/app.ag
@@ -24,9 +24,11 @@ actor Launcher owns LauncherState {
             launches: launches + 1,
         };
 
+        unrestricted(child_group.outputs.child.value);
         require child_group.outputs become {
             child <- Child(child_state),
         };
+        unrestricted(next.value);
         become next <- Launcher(next);
     }
 }
@@ -41,6 +43,7 @@ actor Child owns ChildState {
         LauncherState next = {
             launches: 0,
         };
+        unrestricted(next.value);
         become next <- Launcher(next);
     }
 }

--- a/tests/fixtures/runtime/context_static_actor_spawn/app.ag
+++ b/tests/fixtures/runtime/context_static_actor_spawn/app.ag
@@ -16,7 +16,7 @@ actor Launcher owns LauncherState {
             child: Child,
         }
     }
-    emits one Launcher {
+    emits next: Launcher {
         ChildState child_state = {
             amount: source.amount + amount,
         };
@@ -27,7 +27,7 @@ actor Launcher owns LauncherState {
         require child_group.outputs become {
             child <- Child(child_state),
         };
-        become Launcher(next);
+        become next <- Launcher(next);
     }
 }
 
@@ -37,11 +37,11 @@ actor Child owns ChildState {
         launcher: Launcher,
     } {}
 
-    entry return_to_launcher() emits one Launcher {
+    entry return_to_launcher() emits next: Launcher {
         LauncherState next = {
             launches: 0,
         };
-        become Launcher(next);
+        become next <- Launcher(next);
     }
 }
 

--- a/tests/fixtures/runtime/context_static_linked_spawn/Launcher.sil
+++ b/tests/fixtures/runtime/context_static_linked_spawn/Launcher.sil
@@ -42,7 +42,8 @@ contract Launcher(
 
         // :: auth outputs
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
-        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // emits one Launcher
+        // :: output next: Launcher
+        int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
         // :: genesis covenants
         byte[] gen__children_genesis_preimage =

--- a/tests/fixtures/runtime/context_static_linked_spawn/launcher.ag
+++ b/tests/fixtures/runtime/context_static_linked_spawn/launcher.ag
@@ -25,9 +25,11 @@ actor Launcher owns LauncherState {
             launches: launches + 1,
         };
 
+        unrestricted(children.outputs.child.value);
         require children.outputs become {
             child <- ChildApp::Child(child_state),
         };
+        unrestricted(next.value);
         become next <- Launcher(next);
     }
 }

--- a/tests/fixtures/runtime/context_static_linked_spawn/launcher.ag
+++ b/tests/fixtures/runtime/context_static_linked_spawn/launcher.ag
@@ -16,7 +16,7 @@ actor Launcher owns LauncherState {
             child: ChildApp::Child,
         }
     }
-    emits one Launcher {
+    emits next: Launcher {
         ChildState source_state = source.inputs.child.state;
         ChildState child_state = {
             amount: source_state.amount + amount,
@@ -28,7 +28,7 @@ actor Launcher owns LauncherState {
         require children.outputs become {
             child <- ChildApp::Child(child_state),
         };
-        become Launcher(next);
+        become next <- Launcher(next);
     }
 }
 

--- a/vscode/argent-syntax/language-service.js
+++ b/vscode/argent-syntax/language-service.js
@@ -23,7 +23,6 @@ const KEYWORDS = Object.freeze([
   'leader',
   'none',
   'observes',
-  'one',
   'outputs',
   'owns',
   'return',
@@ -490,14 +489,14 @@ function callableClauseVariables(tokens, start, end) {
         continue;
       }
     } else if (ident(tokens[index], 'emits')) {
-      if (ident(tokens[index + 1], 'one')) {
-        add('emit', { kind: 'ident', value: 'next', start: tokens[index + 1].start, end: tokens[index + 1].end });
-      } else if (symbol(tokens[index + 1], '{')) {
+      if (symbol(tokens[index + 1], '{')) {
         const openIndex = index + 1;
         const closeIndex = matchingBraceIndex(tokens, openIndex);
         addNamedBlock('emit', openIndex, closeIndex);
         index = closeIndex >= 0 ? closeIndex + 1 : end;
         continue;
+      } else if (ident(tokens[index + 1]) && symbol(tokens[index + 2], ':')) {
+        add('emit', tokens[index + 1]);
       }
     } else if (ident(tokens[index], 'observes') && ident(tokens[index + 1])) {
       add('observe', tokens[index + 1]);

--- a/vscode/argent-syntax/language-service.js
+++ b/vscode/argent-syntax/language-service.js
@@ -99,6 +99,7 @@ const BUILTINS = Object.freeze([
   },
   { name: 'co_spent', signature: 'value.co_spent() -> bool', params: [] },
   { name: 'require', signature: 'require(condition: bool)', params: ['condition'] },
+  { name: 'unrestricted', signature: 'unrestricted(output.value)', params: ['output.value'] },
   {
     name: 'templateHash',
     signature: 'templateHash(templatePrefix: byte[], templateSuffix: byte[]) -> byte[32]',

--- a/vscode/argent-syntax/language-service.test.js
+++ b/vscode/argent-syntax/language-service.test.js
@@ -115,6 +115,13 @@ test('offers the Silverscript hash builtins exposed to Argent bodies', () => {
   assert.equal(names.has('unique'), false, 'legacy unique helper must not be offered');
 });
 
+test('offers the unrestricted output-value declaration', () => {
+  const unrestricted = BUILTINS.find((builtin) => builtin.name === 'unrestricted');
+  assert.ok(unrestricted);
+  assert.equal(unrestricted.signature, 'unrestricted(output.value)');
+  assert.deepEqual(unrestricted.params, ['output.value']);
+});
+
 test('offers the Silverscript query builtins except automated state-template helpers', () => {
   const names = new Set(BUILTINS.map((builtin) => builtin.name));
   const expected = [

--- a/vscode/argent-syntax/language-service.test.js
+++ b/vscode/argent-syntax/language-service.test.js
@@ -37,7 +37,7 @@ state PlayerState {
 }
 actor enum PlayerKind { Player; }
 actor League owns PlayerState {
-  entry join(pubkey owner) emits one League {
+  entry join(pubkey owner) emits result: League {
     // The body is intentionally unfinished.
   }
 }
@@ -322,8 +322,8 @@ actor Event owns EventState {
     require(event.value > 0);
   }
 
-  entry keep() emits one Event {
-    require(next.value > 0);
+  entry keep() emits result: Event {
+    require(result.value > 0);
   }
 
   delegate audit() consumes {
@@ -351,7 +351,7 @@ actor Event owns EventState {
     ],
   );
   assert.deepEqual(keep.clauseVariables.map(({ clause, name }) => ({ clause, name })), [
-    { clause: 'emit', name: 'next' },
+    { clause: 'emit', name: 'result' },
   ]);
   assert.deepEqual(audit.clauseVariables.map(({ clause, name }) => ({ clause, name })), [
     { clause: 'consume', name: 'leader' },

--- a/vscode/argent-syntax/syntaxes/argent.tmLanguage.json
+++ b/vscode/argent-syntax/syntaxes/argent.tmLanguage.json
@@ -60,7 +60,7 @@
       "patterns": [
         {
           "name": "keyword.other.assertion.argent",
-          "match": "\\brequire\\b"
+          "match": "\\b(require|unrestricted)\\b"
         }
       ]
     },

--- a/vscode/argent-syntax/syntaxes/argent.tmLanguage.json
+++ b/vscode/argent-syntax/syntaxes/argent.tmLanguage.json
@@ -28,7 +28,7 @@
         },
         {
           "name": "keyword.declaration.argent",
-          "match": "\\b(as|by|else|from|if|inputs|none|one|outputs)\\b"
+          "match": "\\b(as|by|else|from|if|inputs|none|outputs)\\b"
         },
         {
           "name": "keyword.declaration.argent",


### PR DESCRIPTION
## Summary

This PR introduces three user-facing breaking changes that make output and covenant semantics explicit in Argent source.

### Named singleton outputs

The implicit `emits one Actor` form is removed. Singleton outputs now use the same named-handle model as multi-output entries:

```ag
entry bump() emits next: Counter {
    CounterState next_state = {
        count: count + 1,
    };

    become next <- Counter(next_state);
}
```

The old implicit `become Counter(state)` form becomes the explicit route binding:

```ag
become next <- Counter(state);
```

### Explicit output-value references

Every output created by an entry must reference its exact `.value` path somewhere in the entry body. This applies to ordinary emitted outputs and spawned outputs:

```ag
require(next.value == self.value);
require(children.outputs.child.value > 0);
```

When a value is intentionally unconstrained, it must be declared explicitly:

```ag
unrestricted(next.value);
```

`unrestricted(...)` is compile-time-only and emits no Silverscript. Observed outputs are exempt because their emitting contracts own their value policy.

This initial rule is deliberately syntactic and entry-scoped: it verifies that the value path appears in the body, not that every execution path meaningfully constrains it.

### Active covenant ID

The undocumented `self.covenant_id` spelling is removed. Argent now exposes:

```ag
self.cov_id
```

This evaluates to the covenant ID carried by the active input.

## Migration

```ag
// Before
entry bump() emits one Counter {
    CounterState next = {
        count: count + 1,
    };

    become Counter(next);
}

// After
entry bump() emits next: Counter {
    unrestricted(next.value);

    CounterState next_state = {
        count: count + 1,
    };

    become next <- Counter(next_state);
}
```

Examples, fixtures, generated artifacts, editor support, and design documentation have been updated to the new syntax.