### PR TITLE
Make body reference lowering token-aware (refactor)

### DIFF
--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1691,9 +1691,8 @@ struct BodyLowerer<'a, 'm> {
     selectors: BTreeMap<String, TemplateSelector>,
     materialized_selectors: BTreeSet<String>,
     materialized_route_locals: BTreeMap<String, String>,
-    input_names: BTreeSet<String>,
     output_values: Vec<OutputValueRef>,
-    observed_input_state_refs: Vec<(String, String)>,
+    ref_replacements: RefReplacements,
     observed_output_fields: Vec<ObservedOutputFieldWitnessSpec>,
     validated_spawns: BTreeSet<String>,
     conditional_depth: usize,
@@ -1703,6 +1702,39 @@ struct BodyLowerer<'a, 'm> {
 struct OutputValueRef {
     source: String,
     lowered: String,
+}
+
+/// Builds the fixed dotted-reference lowering plan for one entry body.
+fn entry_ref_replacements(
+    actor: &ActorDecl,
+    model: &Model<'_>,
+    input_names: BTreeSet<String>,
+    output_values: &[OutputValueRef],
+    observed_input_state_refs: Vec<(String, String)>,
+) -> Result<RefReplacements> {
+    assert_eq!(word::SELF, "self");
+    assert_eq!(word::VALUE, "value");
+    assert_eq!(word::COVENANT_ID, "cov_id");
+    let mut replacements = vec![
+        ("self.value".to_string(), "tx.inputs[this.activeInputIndex].value".to_string()),
+        ("self.cov_id".to_string(), "OpInputCovenantId(this.activeInputIndex)".to_string()),
+    ];
+    for spec in state_expansion_witness_specs_for_actor(actor, model) {
+        for field in &model.state(&spec.memory_state)?.fields {
+            let local = hidden_state_expansion_field_name(&spec, &field.name);
+            replacements.push((format!("self.{}.{}", spec.field, field.name), local.clone()));
+            replacements.push((format!("{}.{}", spec.field, field.name), local));
+        }
+    }
+    for field in &model.storage_state(&actor.state)?.fields {
+        replacements.push((format!("self.{}", field.name), field.name.clone()));
+    }
+    replacements.extend(observed_input_state_refs);
+    replacements.extend(output_values.iter().map(|output| (output.source.clone(), output.lowered.clone())));
+    replacements.extend(
+        input_names.into_iter().map(|name| (format!("{name}.value"), format!("tx.inputs[{}].value", hidden_input_idx_name(&name)))),
+    );
+    Ok(RefReplacements::new(replacements))
 }
 
 impl<'a, 'm> BodyLowerer<'a, 'm> {
@@ -1749,10 +1781,12 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             types.insert(consume.name.clone(), ty);
             source_types.insert(consume.name.clone(), state);
         }
+        let mut observed_input_state_refs = Vec::new();
         for observe in &entry.observes {
             for input in &observe.inputs {
                 let source_ref = format!("{}.inputs.{}.state", observe.name, input.name);
                 let lowered_ref = hidden_observed_input_state_name(&observe.name, &input.name);
+                observed_input_state_refs.push((source_ref.clone(), lowered_ref.clone()));
                 let state = if let Some(state) = observed_open_state_for_decl(actor, entry, observe, input, model)? {
                     state.to_string()
                 } else {
@@ -1786,19 +1820,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         // Preserve most-specific-first ordering in value-policy diagnostics.
         output_values.sort_by(|left, right| right.source.len().cmp(&left.source.len()).then_with(|| left.source.cmp(&right.source)));
 
-        let observed_input_state_refs = entry
-            .observes
-            .iter()
-            .flat_map(|observe| {
-                observe.inputs.iter().map(|input| {
-                    (
-                        format!("{}.inputs.{}.state", observe.name, input.name),
-                        hidden_observed_input_state_name(&observe.name, &input.name),
-                    )
-                })
-            })
-            .collect();
-
+        let ref_replacements = entry_ref_replacements(actor, model, input_names, &output_values, observed_input_state_refs)?;
         let selectors = model.template_selectors_for_entry(actor, entry)?;
         let observed_output_fields = observed_output_field_witness_specs(actor, entry, model);
 
@@ -1814,9 +1836,8 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             selectors,
             materialized_selectors: BTreeSet::new(),
             materialized_route_locals: BTreeMap::new(),
-            input_names,
             output_values,
-            observed_input_state_refs,
+            ref_replacements,
             observed_output_fields,
             validated_spawns: BTreeSet::new(),
             conditional_depth: 0,
@@ -2935,33 +2956,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     }
 
     fn lower_refs(&self, expr: &str) -> Result<String> {
-        assert_eq!(word::SELF, "self");
-        assert_eq!(word::VALUE, "value");
-        assert_eq!(word::COVENANT_ID, "cov_id");
-        let mut replacements = vec![
-            ("self.value".to_string(), "tx.inputs[this.activeInputIndex].value".to_string()),
-            ("self.cov_id".to_string(), "OpInputCovenantId(this.activeInputIndex)".to_string()),
-        ];
-        for spec in state_expansion_witness_specs_for_actor(self.actor, self.model) {
-            for field in &self.model.state(&spec.memory_state)?.fields {
-                let local = hidden_state_expansion_field_name(&spec, &field.name);
-                replacements.push((format!("self.{}.{}", spec.field, field.name), local.clone()));
-                replacements.push((format!("{}.{}", spec.field, field.name), local));
-            }
-        }
-        for field in &self.model.storage_state(&self.actor.state)?.fields {
-            replacements.push((format!("self.{}", field.name), field.name.clone()));
-        }
-        for (source, lowered) in &self.observed_input_state_refs {
-            replacements.push((source.clone(), lowered.clone()));
-        }
-        for output in &self.output_values {
-            replacements.push((output.source.clone(), output.lowered.clone()));
-        }
-        for name in &self.input_names {
-            replacements.push((format!("{name}.value"), format!("tx.inputs[{}].value", hidden_input_idx_name(name))));
-        }
-        let out = RefReplacements::new(replacements).rewrite(expr)?;
+        let out = self.ref_replacements.rewrite(expr)?;
         let out = lower_co_spent_calls(&out, &self.source_types)?;
         lower_actor_enum_literals(&out, self.model)
     }

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1734,7 +1734,7 @@ fn entry_ref_replacements(
     replacements.extend(
         input_names.into_iter().map(|name| (format!("{name}.value"), format!("tx.inputs[{}].value", hidden_input_idx_name(&name)))),
     );
-    Ok(RefReplacements::new(replacements))
+    RefReplacements::new(replacements)
 }
 
 impl<'a, 'm> BodyLowerer<'a, 'm> {
@@ -2956,8 +2956,12 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     }
 
     fn lower_refs(&self, expr: &str) -> Result<String> {
-        let out = self.ref_replacements.rewrite(expr)?;
-        let out = lower_co_spent_calls(&out, &self.source_types)?;
+        // Co-spend lowering must run first: it uses the source lexer, which
+        // rejects the generated identifiers introduced by reference lowering.
+        // TODO: Separate tokenization from source-only identifier validation
+        // so lowering passes can safely inspect generated intermediate text.
+        let out = lower_co_spent_calls(expr, &self.source_types)?;
+        let out = self.ref_replacements.rewrite(&out)?;
         lower_actor_enum_literals(&out, self.model)
     }
 
@@ -8410,6 +8414,33 @@ mod tests {
         assert_eq!(proxy_entry.params[0].ty, TypeArtifact::Struct { name: "State".to_string() });
 
         let _ = fs::remove_dir_all(out_dir);
+    }
+
+    #[test]
+    fn lowers_co_spend_and_output_value_in_the_same_expression() {
+        let source = r#"
+            state CounterState {
+                cov_id guard;
+            }
+
+            actor Counter owns CounterState {
+                entry bump() emits next: Counter {
+                    require(guard.co_spent() && next.value >= 0);
+                    become next <- Counter(self.state);
+                }
+            }
+
+            app Test {
+                actor Counter;
+            }
+        "#;
+        let path = PathBuf::from("test.ag");
+        let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
+        let program = Program { root: path, modules: vec![module] };
+        let model = Model::from_program(&program).expect("model validates");
+        let sil = emit_actor(model.actor("Counter").expect("actor exists"), &model).expect("actor emits");
+
+        assert!(sil.contains("require(OpCovInputCount(guard) > 0 && tx.outputs[gen__next_output_idx].value >= 0);"), "{sil}");
     }
 
     #[test]

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -16,7 +16,7 @@ use crate::model::{
     parse_actor_enum_variant,
 };
 use crate::naming::{is_identifier, to_snake};
-use crate::token_refs::{count_qualified_ref, rewrite_qualified_refs};
+use crate::token_refs::{RefReplacements, count_qualified_ref};
 use silverscript_lang::ast::Expr as SilExpr;
 use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract};
 
@@ -2961,7 +2961,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         for name in &self.input_names {
             replacements.push((format!("{name}.value"), format!("tx.inputs[{}].value", hidden_input_idx_name(name))));
         }
-        let out = rewrite_qualified_refs(expr, replacements.iter().map(|(source, lowered)| (source.as_str(), lowered.as_str())))?;
+        let out = RefReplacements::new(replacements).rewrite(expr)?;
         let out = lower_co_spent_calls(&out, &self.source_types)?;
         lower_actor_enum_literals(&out, self.model)
     }

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -16,6 +16,7 @@ use crate::model::{
     parse_actor_enum_variant,
 };
 use crate::naming::{is_identifier, to_snake};
+use crate::token_refs::{count_qualified_ref, rewrite_qualified_refs};
 use silverscript_lang::ast::Expr as SilExpr;
 use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract};
 
@@ -1782,8 +1783,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
                 lowered: format!("tx.outputs[{}].value", hidden_spawn_output_idx_name(&spawn.name, &output.name)),
             }));
         }
-        // A qualified spawn reference can contain an ordinary emit reference as
-        // a suffix. Lower and recognize the most specific spelling first.
+        // Preserve most-specific-first ordering in value-policy diagnostics.
         output_values.sort_by(|left, right| right.source.len().cmp(&left.source.len()).then_with(|| left.source.cmp(&right.source)));
 
         let observed_input_state_refs = entry
@@ -2938,35 +2938,31 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         assert_eq!(word::SELF, "self");
         assert_eq!(word::VALUE, "value");
         assert_eq!(word::COVENANT_ID, "cov_id");
-        let mut out = replace_exact_identifier(expr, "self.value", "tx.inputs[this.activeInputIndex].value");
-        out = replace_exact_identifier(&out, "self.cov_id", "OpInputCovenantId(this.activeInputIndex)");
-        // TODO: Replace the raw qualified-reference substitutions below with a
-        // token-aware rewriter shared with `count_qualified_ref`. Each source
-        // should match an exact identifier-and-dot token path rooted at the
-        // expression level (in particular, not after another `.`), without
-        // matching longer identifiers or prefix-related fields. Replacements
-        // should be selected from the original token spans in one pass so that
-        // generated text is never reconsidered by a later substitution.
+        let mut replacements = vec![
+            ("self.value".to_string(), "tx.inputs[this.activeInputIndex].value".to_string()),
+            ("self.cov_id".to_string(), "OpInputCovenantId(this.activeInputIndex)".to_string()),
+        ];
         for spec in state_expansion_witness_specs_for_actor(self.actor, self.model) {
             for field in &self.model.state(&spec.memory_state)?.fields {
                 let local = hidden_state_expansion_field_name(&spec, &field.name);
-                out = out.replace(&format!("self.{}.{}", spec.field, field.name), &local);
-                out = out.replace(&format!("{}.{}", spec.field, field.name), &local);
+                replacements.push((format!("self.{}.{}", spec.field, field.name), local.clone()));
+                replacements.push((format!("{}.{}", spec.field, field.name), local));
             }
         }
         for field in &self.model.storage_state(&self.actor.state)?.fields {
-            out = out.replace(&format!("self.{}", field.name), &field.name);
+            replacements.push((format!("self.{}", field.name), field.name.clone()));
         }
-        out = lower_co_spent_calls(&out, &self.source_types)?;
         for (source, lowered) in &self.observed_input_state_refs {
-            out = out.replace(source, lowered);
+            replacements.push((source.clone(), lowered.clone()));
         }
         for output in &self.output_values {
-            out = out.replace(&output.source, &output.lowered);
+            replacements.push((output.source.clone(), output.lowered.clone()));
         }
         for name in &self.input_names {
-            out = out.replace(&format!("{name}.value"), &format!("tx.inputs[{}].value", hidden_input_idx_name(name)));
+            replacements.push((format!("{name}.value"), format!("tx.inputs[{}].value", hidden_input_idx_name(name))));
         }
+        let out = rewrite_qualified_refs(expr, replacements.iter().map(|(source, lowered)| (source.as_str(), lowered.as_str())))?;
+        let out = lower_co_spent_calls(&out, &self.source_types)?;
         lower_actor_enum_literals(&out, self.model)
     }
 
@@ -5668,43 +5664,6 @@ fn parse_unrestricted_output_value(statement: &str) -> Option<&str> {
 fn parse_call_statement<'a>(statement: &'a str, callee: &str) -> Option<&'a str> {
     let tail = statement.trim().strip_prefix(callee)?;
     tail.strip_prefix('(')?.strip_suffix(')').map(str::trim)
-}
-
-/// Replace an exact identifier reference without matching within a longer identifier.
-fn replace_exact_identifier(input: &str, source: &str, replacement: &str) -> String {
-    let mut out = String::with_capacity(input.len());
-    let mut cursor = 0;
-    let bytes = input.as_bytes();
-    let identifier_char = |byte: &u8| byte.is_ascii_alphanumeric() || *byte == b'_';
-    for (start, _) in input.match_indices(source) {
-        let end = start + source.len();
-        let continues_previous = start.checked_sub(1).and_then(|previous| bytes.get(previous)).is_some_and(identifier_char);
-        let continues_next = bytes.get(end).is_some_and(identifier_char);
-        if continues_previous || continues_next {
-            continue;
-        }
-        out.push_str(&input[cursor..start]);
-        out.push_str(replacement);
-        cursor = end;
-    }
-    out.push_str(&input[cursor..]);
-    out
-}
-
-fn count_qualified_ref(tokens: &[Token], source: &str) -> usize {
-    let segments = source.split('.').collect::<Vec<_>>();
-    let token_count = segments.len() * 2 - 1;
-    tokens
-        .windows(token_count)
-        .enumerate()
-        .filter(|(start, window)| {
-            (*start == 0 || !matches!(&tokens[*start - 1].kind, TokenKind::Symbol('.')))
-                && segments.iter().enumerate().all(|(idx, segment)| {
-                    matches!(&window[idx * 2].kind, TokenKind::Ident(actual) if actual == segment)
-                        && (idx + 1 == segments.len() || matches!(&window[idx * 2 + 1].kind, TokenKind::Symbol('.')))
-                })
-        })
-        .count()
 }
 
 fn parse_co_spent_call(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod parser;
 pub mod routes;
 pub mod routing;
 mod stdlib;
+mod token_refs;
 
 pub use error::{ArgentError, Result};
 

--- a/src/token_refs.rs
+++ b/src/token_refs.rs
@@ -5,8 +5,9 @@
 
 use std::collections::BTreeMap;
 
-use crate::error::Result;
+use crate::error::{ArgentError, Result};
 use crate::lexer::{Span, Token, TokenKind, lex};
+use crate::naming::is_identifier;
 
 enum RefToken {
     Ident(String),
@@ -32,7 +33,7 @@ impl QualifiedRef {
     fn parse(reference: &str) -> Option<Self> {
         let mut tokens = Vec::new();
         for (idx, segment) in reference.split('.').enumerate() {
-            if segment.is_empty() {
+            if !is_identifier(segment) {
                 return None;
             }
             if idx > 0 {
@@ -80,7 +81,7 @@ struct RefReplacementMatch<'a> {
 }
 
 impl RefReplacements {
-    pub(crate) fn new<R, T>(replacements: impl IntoIterator<Item = (R, T)>) -> Self
+    pub(crate) fn new<R, T>(replacements: impl IntoIterator<Item = (R, T)>) -> Result<Self>
     where
         R: Into<String>,
         T: Into<String>,
@@ -88,16 +89,15 @@ impl RefReplacements {
         let mut by_root = BTreeMap::<_, Vec<_>>::new();
         for (reference, text) in replacements {
             let reference_text = reference.into();
-            let Some(reference) = QualifiedRef::parse(&reference_text) else {
-                continue;
-            };
+            let reference = QualifiedRef::parse(&reference_text)
+                .ok_or_else(|| ArgentError::new(format!("invalid qualified reference `{reference_text}` in replacement plan")))?;
             by_root.entry(reference.root().to_string()).or_default().push(RefReplacement { reference, text: text.into() });
         }
         for candidates in by_root.values_mut() {
             // The first matching candidate must be the most specific path.
             candidates.sort_by(|left, right| right.reference.tokens.len().cmp(&left.reference.tokens.len()));
         }
-        Self { by_root }
+        Ok(Self { by_root })
     }
 
     fn is_empty(&self) -> bool {
@@ -164,7 +164,10 @@ mod tests {
     #[test]
     fn rewrites_only_token_matched_references() {
         let source = r#"self.value + foo.self.value + self.value_note + "self.value" /* self.value */"#;
-        let out = RefReplacements::new([("self.value", "active_value")]).rewrite(source).expect("references rewrite");
+        let out = RefReplacements::new([("self.value", "active_value")])
+            .expect("replacement plan is valid")
+            .rewrite(source)
+            .expect("references rewrite");
 
         assert_eq!(out, r#"active_value + foo.self.value + self.value_note + "self.value" /* self.value */"#);
     }
@@ -173,6 +176,7 @@ mod tests {
     fn selects_the_most_specific_reference_at_each_source_position() {
         let source = "remote.inputs.asset.state + remote.inputs.count";
         let out = RefReplacements::new([("remote.inputs", "group"), ("remote.inputs.asset.state", "asset_state")])
+            .expect("replacement plan is valid")
             .rewrite(source)
             .expect("references rewrite");
 
@@ -182,9 +186,22 @@ mod tests {
     #[test]
     fn does_not_reconsider_replacement_text() {
         let out = RefReplacements::new([("next.value", "self.value"), ("self.value", "active_value")])
+            .expect("replacement plan is valid")
             .rewrite("next.value + self.value")
             .expect("references rewrite");
 
         assert_eq!(out, "self.value + active_value");
+    }
+
+    #[test]
+    fn rejects_invalid_replacement_references() {
+        for reference in ["self..value", "self-value", "self.0"] {
+            let err = match RefReplacements::new([(reference, "active_value")]) {
+                Ok(_) => panic!("invalid replacement plan must fail"),
+                Err(err) => err,
+            };
+
+            assert!(err.to_string().contains(&format!("invalid qualified reference `{reference}`")), "unexpected error: {err}");
+        }
     }
 }

--- a/src/token_refs.rs
+++ b/src/token_refs.rs
@@ -8,12 +8,12 @@ use std::collections::BTreeMap;
 use crate::error::Result;
 use crate::lexer::{Span, Token, TokenKind, lex};
 
-enum RefToken<'a> {
-    Ident(&'a str),
+enum RefToken {
+    Ident(String),
     Dot,
 }
 
-impl RefToken<'_> {
+impl RefToken {
     fn matches(&self, token: &TokenKind) -> bool {
         match (self, token) {
             (Self::Ident(reference_ident), TokenKind::Ident(input_ident)) => reference_ident == input_ident,
@@ -24,12 +24,12 @@ impl RefToken<'_> {
 }
 
 /// A dotted identifier path such as `self.value` or `remote.inputs.asset.state`.
-struct QualifiedRef<'a> {
-    tokens: Vec<RefToken<'a>>,
+struct QualifiedRef {
+    tokens: Vec<RefToken>,
 }
 
-impl<'a> QualifiedRef<'a> {
-    fn parse(reference: &'a str) -> Option<Self> {
+impl QualifiedRef {
+    fn parse(reference: &str) -> Option<Self> {
         let mut tokens = Vec::new();
         for (idx, segment) in reference.split('.').enumerate() {
             if segment.is_empty() {
@@ -38,12 +38,12 @@ impl<'a> QualifiedRef<'a> {
             if idx > 0 {
                 tokens.push(RefToken::Dot);
             }
-            tokens.push(RefToken::Ident(segment));
+            tokens.push(RefToken::Ident(segment.to_string()));
         }
         (!tokens.is_empty()).then_some(Self { tokens })
     }
 
-    fn root(&self) -> &'a str {
+    fn root(&self) -> &str {
         let Some(RefToken::Ident(root)) = self.tokens.first() else {
             unreachable!("a parsed qualified reference starts with an identifier");
         };
@@ -63,56 +63,91 @@ impl<'a> QualifiedRef<'a> {
     }
 }
 
+struct RefReplacement {
+    reference: QualifiedRef,
+    text: String,
+}
+
+/// Indexes replacements by root identifier so matching only inspects viable paths.
+pub(crate) struct RefReplacements {
+    by_root: BTreeMap<String, Vec<RefReplacement>>,
+}
+
+struct RefReplacementMatch<'a> {
+    token_len: usize,
+    span: Span,
+    text: &'a str,
+}
+
+impl RefReplacements {
+    pub(crate) fn new<R, T>(replacements: impl IntoIterator<Item = (R, T)>) -> Self
+    where
+        R: Into<String>,
+        T: Into<String>,
+    {
+        let mut by_root = BTreeMap::<_, Vec<_>>::new();
+        for (reference, text) in replacements {
+            let reference_text = reference.into();
+            let Some(reference) = QualifiedRef::parse(&reference_text) else {
+                continue;
+            };
+            by_root.entry(reference.root().to_string()).or_default().push(RefReplacement { reference, text: text.into() });
+        }
+        for candidates in by_root.values_mut() {
+            // The first matching candidate must be the most specific path.
+            candidates.sort_by(|left, right| right.reference.tokens.len().cmp(&left.reference.tokens.len()));
+        }
+        Self { by_root }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.by_root.is_empty()
+    }
+
+    fn match_at(&self, tokens: &[Token], pos: usize) -> Option<RefReplacementMatch<'_>> {
+        let TokenKind::Ident(root) = &tokens.get(pos)?.kind else {
+            return None;
+        };
+        self.by_root.get(root.as_str())?.iter().find_map(|candidate| {
+            candidate.reference.match_at(tokens, pos).map(|(token_len, span)| RefReplacementMatch {
+                token_len,
+                span,
+                text: &candidate.text,
+            })
+        })
+    }
+
+    /// Rewrite dotted references selected from the original input tokens.
+    pub(crate) fn rewrite(&self, input: &str) -> Result<String> {
+        if self.is_empty() {
+            return Ok(input.to_string());
+        }
+
+        let tokens = lex(input)?;
+        let mut out = String::with_capacity(input.len());
+        let mut cursor = 0usize;
+        let mut pos = 0usize;
+        while pos < tokens.len() {
+            let Some(replacement) = self.match_at(&tokens, pos) else {
+                pos += 1;
+                continue;
+            };
+            out.push_str(&input[cursor..replacement.span.start]);
+            out.push_str(replacement.text);
+            cursor = replacement.span.end;
+            pos += replacement.token_len;
+        }
+        out.push_str(&input[cursor..]);
+        Ok(out)
+    }
+}
+
 /// Count rooted occurrences of one dotted reference in an existing token stream.
 pub(crate) fn count_qualified_ref(tokens: &[Token], reference: &str) -> usize {
     let Some(reference) = QualifiedRef::parse(reference) else {
         return 0;
     };
     (0..tokens.len()).filter(|start| reference.match_at(tokens, *start).is_some()).count()
-}
-
-/// Rewrite dotted references selected from the original source tokens.
-pub(crate) fn rewrite_qualified_refs<'a>(input: &str, replacements: impl IntoIterator<Item = (&'a str, &'a str)>) -> Result<String> {
-    // Index paths by their root so each input token checks only candidates that can match it.
-    let mut replacements_by_root = BTreeMap::<_, Vec<_>>::new();
-    for (reference, replacement) in replacements {
-        let Some(reference) = QualifiedRef::parse(reference) else {
-            continue;
-        };
-        replacements_by_root.entry(reference.root()).or_default().push((reference, replacement));
-    }
-    for candidates in replacements_by_root.values_mut() {
-        // The first matching candidate must be the most specific path.
-        candidates.sort_by(|(left, _), (right, _)| right.tokens.len().cmp(&left.tokens.len()));
-    }
-    if replacements_by_root.is_empty() {
-        return Ok(input.to_string());
-    }
-
-    let tokens = lex(input)?;
-    let mut out = String::with_capacity(input.len());
-    let mut cursor = 0usize;
-    let mut pos = 0usize;
-    while pos < tokens.len() {
-        let selected = match &tokens[pos].kind {
-            TokenKind::Ident(root) => replacements_by_root.get(root.as_str()).and_then(|candidates| {
-                candidates
-                    .iter()
-                    .find_map(|(reference, replacement)| reference.match_at(&tokens, pos).map(|(len, span)| (len, span, *replacement)))
-            }),
-            _ => None,
-        };
-        let Some((token_len, span, replacement)) = selected else {
-            pos += 1;
-            continue;
-        };
-        out.push_str(&input[cursor..span.start]);
-        out.push_str(replacement);
-        cursor = span.end;
-        pos += token_len;
-    }
-    out.push_str(&input[cursor..]);
-    Ok(out)
 }
 
 #[cfg(test)]
@@ -129,7 +164,7 @@ mod tests {
     #[test]
     fn rewrites_only_token_matched_references() {
         let source = r#"self.value + foo.self.value + self.value_note + "self.value" /* self.value */"#;
-        let out = rewrite_qualified_refs(source, [("self.value", "active_value")]).expect("references rewrite");
+        let out = RefReplacements::new([("self.value", "active_value")]).rewrite(source).expect("references rewrite");
 
         assert_eq!(out, r#"active_value + foo.self.value + self.value_note + "self.value" /* self.value */"#);
     }
@@ -137,7 +172,8 @@ mod tests {
     #[test]
     fn selects_the_most_specific_reference_at_each_source_position() {
         let source = "remote.inputs.asset.state + remote.inputs.count";
-        let out = rewrite_qualified_refs(source, [("remote.inputs", "group"), ("remote.inputs.asset.state", "asset_state")])
+        let out = RefReplacements::new([("remote.inputs", "group"), ("remote.inputs.asset.state", "asset_state")])
+            .rewrite(source)
             .expect("references rewrite");
 
         assert_eq!(out, "asset_state + group.count");
@@ -145,7 +181,8 @@ mod tests {
 
     #[test]
     fn does_not_reconsider_replacement_text() {
-        let out = rewrite_qualified_refs("next.value + self.value", [("next.value", "self.value"), ("self.value", "active_value")])
+        let out = RefReplacements::new([("next.value", "self.value"), ("self.value", "active_value")])
+            .rewrite("next.value + self.value")
             .expect("references rewrite");
 
         assert_eq!(out, "self.value + active_value");

--- a/src/token_refs.rs
+++ b/src/token_refs.rs
@@ -1,0 +1,153 @@
+//! Token-aware helpers for inspecting and rewriting source references.
+//!
+//! Matches are selected from the original token stream and replacements are
+//! applied once, so generated text is never reconsidered as source.
+
+use std::collections::BTreeMap;
+
+use crate::error::Result;
+use crate::lexer::{Span, Token, TokenKind, lex};
+
+enum RefToken<'a> {
+    Ident(&'a str),
+    Dot,
+}
+
+impl RefToken<'_> {
+    fn matches(&self, token: &TokenKind) -> bool {
+        match (self, token) {
+            (Self::Ident(reference_ident), TokenKind::Ident(input_ident)) => reference_ident == input_ident,
+            (Self::Dot, TokenKind::Symbol('.')) => true,
+            _ => false,
+        }
+    }
+}
+
+/// A dotted identifier path such as `self.value` or `remote.inputs.asset.state`.
+struct QualifiedRef<'a> {
+    tokens: Vec<RefToken<'a>>,
+}
+
+impl<'a> QualifiedRef<'a> {
+    fn parse(reference: &'a str) -> Option<Self> {
+        let mut tokens = Vec::new();
+        for (idx, segment) in reference.split('.').enumerate() {
+            if segment.is_empty() {
+                return None;
+            }
+            if idx > 0 {
+                tokens.push(RefToken::Dot);
+            }
+            tokens.push(RefToken::Ident(segment));
+        }
+        (!tokens.is_empty()).then_some(Self { tokens })
+    }
+
+    fn root(&self) -> &'a str {
+        let Some(RefToken::Ident(root)) = self.tokens.first() else {
+            unreachable!("a parsed qualified reference starts with an identifier");
+        };
+        root
+    }
+
+    fn match_at(&self, tokens: &[Token], start: usize) -> Option<(usize, Span)> {
+        // A suffix of another access path is not rooted at this identifier.
+        if start > 0 && matches!(tokens[start - 1].kind, TokenKind::Symbol('.')) {
+            return None;
+        }
+
+        let token_len = self.tokens.len();
+        let window = tokens.get(start..start + token_len)?;
+        let matches = self.tokens.iter().zip(window).all(|(reference_token, input_token)| reference_token.matches(&input_token.kind));
+        matches.then_some((token_len, Span { start: window[0].span.start, end: window[token_len - 1].span.end }))
+    }
+}
+
+/// Count rooted occurrences of one dotted reference in an existing token stream.
+pub(crate) fn count_qualified_ref(tokens: &[Token], reference: &str) -> usize {
+    let Some(reference) = QualifiedRef::parse(reference) else {
+        return 0;
+    };
+    (0..tokens.len()).filter(|start| reference.match_at(tokens, *start).is_some()).count()
+}
+
+/// Rewrite dotted references selected from the original source tokens.
+pub(crate) fn rewrite_qualified_refs<'a>(input: &str, replacements: impl IntoIterator<Item = (&'a str, &'a str)>) -> Result<String> {
+    // Index paths by their root so each input token checks only candidates that can match it.
+    let mut replacements_by_root = BTreeMap::<_, Vec<_>>::new();
+    for (reference, replacement) in replacements {
+        let Some(reference) = QualifiedRef::parse(reference) else {
+            continue;
+        };
+        replacements_by_root.entry(reference.root()).or_default().push((reference, replacement));
+    }
+    for candidates in replacements_by_root.values_mut() {
+        // The first matching candidate must be the most specific path.
+        candidates.sort_by(|(left, _), (right, _)| right.tokens.len().cmp(&left.tokens.len()));
+    }
+    if replacements_by_root.is_empty() {
+        return Ok(input.to_string());
+    }
+
+    let tokens = lex(input)?;
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0usize;
+    let mut pos = 0usize;
+    while pos < tokens.len() {
+        let selected = match &tokens[pos].kind {
+            TokenKind::Ident(root) => replacements_by_root.get(root.as_str()).and_then(|candidates| {
+                candidates
+                    .iter()
+                    .find_map(|(reference, replacement)| reference.match_at(&tokens, pos).map(|(len, span)| (len, span, *replacement)))
+            }),
+            _ => None,
+        };
+        let Some((token_len, span, replacement)) = selected else {
+            pos += 1;
+            continue;
+        };
+        out.push_str(&input[cursor..span.start]);
+        out.push_str(replacement);
+        cursor = span.end;
+        pos += token_len;
+    }
+    out.push_str(&input[cursor..]);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_only_references_rooted_at_the_matched_identifier() {
+        let tokens = lex(r#"next.value + parent.next.value + next.value_note + "next.value" /* next.value */"#).expect("source lexes");
+
+        assert_eq!(count_qualified_ref(&tokens, "next.value"), 1);
+    }
+
+    #[test]
+    fn rewrites_only_token_matched_references() {
+        let source = r#"self.value + foo.self.value + self.value_note + "self.value" /* self.value */"#;
+        let out = rewrite_qualified_refs(source, [("self.value", "active_value")]).expect("references rewrite");
+
+        assert_eq!(out, r#"active_value + foo.self.value + self.value_note + "self.value" /* self.value */"#);
+    }
+
+    #[test]
+    fn selects_the_most_specific_reference_at_each_source_position() {
+        let source = "remote.inputs.asset.state + remote.inputs.count";
+        let out = rewrite_qualified_refs(source, [("remote.inputs", "group"), ("remote.inputs.asset.state", "asset_state")])
+            .expect("references rewrite");
+
+        assert_eq!(out, "asset_state + group.count");
+    }
+
+    #[test]
+    fn does_not_reconsider_replacement_text() {
+        let out = rewrite_qualified_refs("next.value + self.value", [("next.value", "self.value"), ("self.value", "active_value")])
+            .expect("references rewrite");
+
+        assert_eq!(out, "self.value + active_value");
+    }
+}


### PR DESCRIPTION
### Context

Argent entry bodies contain Silverscript code together with references that Argent must lower, such as:

```text
self.value
self.foo
next.value
observe.inputs.account.state
```

`BodyLowerer` previously handled many of these references with repeated string replacements. This could confuse a real reference with text inside a longer identifier, another access path, a string, or a comment. A replacement could also produce text that a later replacement processed again.

### Change

This PR adds a small token-aware layer for dotted references.

It:

- matches exact identifier-and-dot token paths
- requires references to be rooted at the matched identifier
- prefers the most specific matching path
- applies replacements against the original token stream
- does not reconsider generated replacement text
- shares the same matching rules with output-value reference counting
- indexes replacements by their root identifier
- builds the replacement plan once per entry body and reuses it during lowering

This keeps entry bodies as passthrough Silverscript source while giving Argent a safer, focused mechanism for the references it owns.

### Validation

- Argent `./check.sh`
- Argent Playground `./check.sh`
- formatting and Clippy checks

---

This is one small step in a broader, incremental refactor toward structured entry-body lowering and more local code generation.