### PR TITLE
Structure entry body lowering

### DIFF
--- a/docs/body-lowering-notes.md
+++ b/docs/body-lowering-notes.md
@@ -4,6 +4,12 @@ Small implementation hints to revisit during the current compiler work.
 
 - Give helper `fn` bodies token lowering for `cov_id` locals and `.co_spent()`, using parameter, field, and local types.
 - Accept Sil ternaries, bitwise XOR, and single-quoted strings in the shared lexer.
+- Track `for`, tuple, and destructuring binders in type-sensitive body lowering.
+- Reject locals that shadow fixed Argent references before applying entry-wide rewrites.
 - Decide whether unbraced `if` bodies pass through or are rejected by `EntryBody`; remove the policy from emission.
+- Put statement terminator policy in `EntryBody`; plain statements and `become` currently enforce it differently.
+- Reject or define empty `become {}`; it currently becomes a no-op for `emits none`.
+- Retain each entry body's file offset so body diagnostics use source-file locations.
 - Unify `EntryRoute` to `RouteCall` conversion when it has a clean dependency home.
 - Match route-target delimiter kinds so malformed expressions receive structural errors.
+- Replace BodyLowerer’s cloned type maps with a scoped binding table that carries optional source and lowered types plus scope-local materialization state.

--- a/docs/body-lowering-notes.md
+++ b/docs/body-lowering-notes.md
@@ -4,12 +4,11 @@ Small implementation hints to revisit during the current compiler work.
 
 - Give helper `fn` bodies token lowering for `cov_id` locals and `.co_spent()`, using parameter, field, and local types.
 - Accept Sil ternaries, bitwise XOR, and single-quoted strings in the shared lexer.
-- Track `for`, tuple, and destructuring binders in type-sensitive body lowering.
 - Reject locals that shadow fixed Argent references before applying entry-wide rewrites.
+- Attach body-local selector metadata to parsed binding identities instead of discovering it with an entry-wide raw token scan.
 - Decide whether unbraced `if` bodies pass through or are rejected by `EntryBody`; remove the policy from emission.
 - Put statement terminator policy in `EntryBody`; plain statements and `become` currently enforce it differently.
 - Reject or define empty `become {}`; it currently becomes a no-op for `emits none`.
 - Retain each entry body's file offset so body diagnostics use source-file locations.
 - Unify `EntryRoute` to `RouteCall` conversion when it has a clean dependency home.
 - Match route-target delimiter kinds so malformed expressions receive structural errors.
-- Replace BodyLowerer’s cloned type maps with a scoped binding table that carries optional source and lowered types plus scope-local materialization state.

--- a/docs/body-lowering-notes.md
+++ b/docs/body-lowering-notes.md
@@ -5,6 +5,5 @@ Small implementation hints to revisit during the current compiler work.
 - Give helper `fn` bodies token lowering for `cov_id` locals and `.co_spent()`, using parameter, field, and local types.
 - Accept Sil ternaries, bitwise XOR, and single-quoted strings in the shared lexer.
 - Decide whether unbraced `if` bodies pass through or are rejected by `EntryBody`; remove the policy from emission.
-- Make `BodyLowerer` type and materialization bookkeeping follow lexical block scope.
 - Unify `EntryRoute` to `RouteCall` conversion when it has a clean dependency home.
 - Match route-target delimiter kinds so malformed expressions receive structural errors.

--- a/docs/body-lowering-notes.md
+++ b/docs/body-lowering-notes.md
@@ -2,7 +2,6 @@
 
 Small implementation hints to revisit during the current compiler work.
 
-- Recognize Sil `{ ... } = ...;` destructuring before treating `{` as a standalone block.
 - Give helper `fn` bodies token lowering for `cov_id` locals and `.co_spent()`, using parameter, field, and local types.
 - Accept Sil ternaries, bitwise XOR, and single-quoted strings in the shared lexer.
 - Decide whether unbraced `if` bodies pass through or are rejected by `EntryBody`; remove the policy from emission.

--- a/docs/body-lowering-notes.md
+++ b/docs/body-lowering-notes.md
@@ -1,0 +1,11 @@
+# Body lowering notes
+
+Small implementation hints to revisit during the current compiler work.
+
+- Recognize Sil `{ ... } = ...;` destructuring before treating `{` as a standalone block.
+- Give helper `fn` bodies token lowering for `cov_id` locals and `.co_spent()`, using parameter, field, and local types.
+- Accept Sil ternaries, bitwise XOR, and single-quoted strings in the shared lexer.
+- Decide whether unbraced `if` bodies pass through or are rejected by `EntryBody`; remove the policy from emission.
+- Make `BodyLowerer` type and materialization bookkeeping follow lexical block scope.
+- Unify `EntryRoute` to `RouteCall` conversion when it has a clean dependency home.
+- Match route-target delimiter kinds so malformed expressions receive structural errors.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -39,27 +39,35 @@ explicit indices or an unambiguous matching rule. Record openness and the
 binding rule in the artifact so the runtime and transaction builder resolve
 the same handles.
 
-## Resolve observed state read types
+## Authenticate actors with no runtime state
 
-**Area:** Compiler code generation and Silverscript type checking.
+**Area:** Actor-type handles and compiler code generation.
 
-**Context:** Argent assigns each `readInputStateWithTemplate` result to the
-declared state type. Two valid observation shapes do not compile:
+**Context:** `readInputStateWithTemplate` authenticates a template while it
+decodes state fields. It is not the right operation when an actor's complete
+physical state, including compiler-owned fields, is empty. In that case the
+redeem script is fixed, so its P2SH hash identifies the complete actor script.
 
-- An observed actor has an empty state.
-- Two observed actors have different state names but the same Sil field
-  layout.
+Silverscript can construct the locking script from a runtime hash with
+`new ScriptPubKeyP2SH(hash)`.
 
-In the second case, Silverscript reports more than one matching struct layout
-even though the generated assignment names the target type. These failures also
-occur for actors in one app. They are not specific to app linking.
+**Follow-up:** Represent an empty-state actor-type handle by its redeem-script
+hash. Authenticate its inputs and outputs by comparing their script public keys
+instead of generating an empty state read or validation.
 
-**Follow-up:** Define how an empty-state observation authenticates the input
-template without a state value to decode. Make Silverscript use the declared
-assignment type before it tries to match a struct by field layout.
+The default handle for such an actor must be `blake2b(redeem_script)`, with the
+complete script hashed as one unit. It is not Silverscript's template hash over
+the length-delimited template prefix and suffix. With no state boundary to
+preserve, the exact redeem script is the actor identity.
 
-Add compiler tests for both shapes. Add a runtime test that proves the observed
-input template is still authenticated.
+For a static actor reference, embed the expected script public key as a contract
+constant. For a runtime actor-type handle, construct it with
+`new ScriptPubKeyP2SH(handle)`. Keep using the typed state-template operations
+when the effective physical state is non-empty, even if the authored state has
+no fields.
+
+Add pinned generated-Sil and runtime coverage for static and runtime-selected
+empty-state actors, including rejection of an incorrect actor-type handle.
 
 ## Decode observed application transactions
 

--- a/examples/build/route_state_bodies/sil/Archive.sil
+++ b/examples/build/route_state_bodies/sil/Archive.sil
@@ -49,18 +49,22 @@ contract Archive(
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Pawn
 
-        Gen__PawnState next_board = {
+        BoardState next_board = {
+            // :: user declared fields
+            ply: final_ply + 1,
+        };
+        Gen__PawnState gen__state_next_gen__pawn_state = {
             // :: generated fields
             gen__archive_template: gen__archive_template,
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
             // :: user declared fields
-            ply: final_ply + 1,
+            ply: next_board.ply,
         };
         // :: become Pawn
         validateOutputStateWithTemplate(
             gen__next_output_idx,
-            next_board,
+            gen__state_next_gen__pawn_state,
             gen__pawn_prefix,
             gen__pawn_suffix,
             gen__pawn_template

--- a/examples/build/route_state_bodies/sil/Lobby.sil
+++ b/examples/build/route_state_bodies/sil/Lobby.sil
@@ -48,18 +48,22 @@ contract Lobby(
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Mux
 
-        Gen__MuxState next_board = {
+        BoardState next_board = {
+            // :: user declared fields
+            ply: nonce,
+        };
+        Gen__MuxState gen__state_next_gen__mux_state = {
             // :: generated fields
             gen__archive_template: gen__archive_template,
             gen__mux_template: gen__mux_template,
             gen__mux_routes: gen__mux_routes,
             // :: user declared fields
-            ply: nonce,
+            ply: next_board.ply,
         };
         // :: become Mux
         validateOutputStateWithTemplate(
             gen__next_output_idx,
-            next_board,
+            gen__state_next_gen__mux_state,
             gen__mux_prefix,
             gen__mux_suffix,
             gen__mux_template

--- a/examples/build/route_state_bodies/sil/Mux.sil
+++ b/examples/build/route_state_bodies/sil/Mux.sil
@@ -73,18 +73,22 @@ contract Mux(
         // :: output next: Archive
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
-        Gen__ArchiveState next_archive = {
+        ArchiveState next_archive = {
+            // :: user declared fields
+            final_ply: ply,
+        };
+        Gen__ArchiveState gen__state_next_gen__archive_state = {
             // :: generated fields
             gen__archive_template: gen__archive_template,
             gen__mux_template: gen__mux_template,
             gen__mux_routes_digest: blake2b(gen__mux_routes),
             // :: user declared fields
-            final_ply: ply,
+            final_ply: next_archive.final_ply,
         };
         // :: become Archive
         validateOutputStateWithTemplate(
             gen__next_output_idx,
-            next_archive,
+            gen__state_next_gen__archive_state,
             gen__archive_prefix,
             gen__archive_suffix,
             gen__archive_template

--- a/examples/build/stones/sil/League.sil
+++ b/examples/build/stones/sil/League.sil
@@ -122,11 +122,7 @@ contract League(
         require(checkSig(owner_sig, owner_pk));
         byte[32] owner = blake2b(owner_pk);
         byte[32] player_id = invocation_uid(bytes("StonesPlayer"));
-        Gen__PlayerState next_player = {
-            // :: generated fields
-            gen__player_template: gen__player_template,
-            gen__stones_game_template: gen__stones_game_template,
-            gen__stones_settle_template: gen__stones_settle_template,
+        PlayerState next_player = {
             // :: user declared fields
             owner: owner,
             player_id: player_id,
@@ -142,10 +138,23 @@ contract League(
             tx.outputs[gen__league_output_idx].scriptPubKey
                 == tx.inputs[this.activeInputIndex].scriptPubKey
         );
+        Gen__PlayerState gen__state_player_gen__player_state = {
+            // :: generated fields
+            gen__player_template: gen__player_template,
+            gen__stones_game_template: gen__stones_game_template,
+            gen__stones_settle_template: gen__stones_settle_template,
+            // :: user declared fields
+            owner: next_player.owner,
+            player_id: next_player.player_id,
+            open_games: next_player.open_games,
+            games: next_player.games,
+            wins: next_player.wins,
+            losses: next_player.losses,
+        };
         // :: become Player
         validateOutputStateWithTemplate(
             gen__player_output_idx,
-            next_player,
+            gen__state_player_gen__player_state,
             gen__player_prefix,
             gen__player_suffix,
             gen__player_template

--- a/examples/build/stones/sil/Player.sil
+++ b/examples/build/stones/sil/Player.sil
@@ -184,11 +184,7 @@ contract Player(
             wins: opponent.wins,
             losses: opponent.losses,
         };
-        Gen__StonesGameState next_game = {
-            // :: generated fields
-            gen__player_template: gen__player_template,
-            gen__stones_game_template: gen__stones_game_template,
-            gen__stones_settle_template: gen__stones_settle_template,
+        GameState next_game = {
             // :: user declared fields
             player_a: self_ref,
             player_b: opponent_ref,
@@ -203,10 +199,22 @@ contract Player(
         validateOutputState(gen__self_out_output_idx, next_self);
         // :: become Player
         validateOutputState(gen__opponent_out_output_idx, next_opponent);
+        Gen__StonesGameState gen__state_game_gen__stones_game_state = {
+            // :: generated fields
+            gen__player_template: gen__player_template,
+            gen__stones_game_template: gen__stones_game_template,
+            gen__stones_settle_template: gen__stones_settle_template,
+            // :: user declared fields
+            player_a: next_game.player_a,
+            player_b: next_game.player_b,
+            pile: next_game.pile,
+            max_take: next_game.max_take,
+            turn: next_game.turn,
+        };
         // :: become StonesGame
         validateOutputStateWithTemplate(
             gen__game_output_idx,
-            next_game,
+            gen__state_game_gen__stones_game_state,
             gen__stones_game_prefix,
             gen__stones_game_suffix,
             gen__stones_game_template

--- a/examples/build/stones/sil/StonesGame.sil
+++ b/examples/build/stones/sil/StonesGame.sil
@@ -190,20 +190,26 @@ contract StonesGame(
         require(checkSig(move_sig, move_pk));
         require(tx.outputs[gen__settle_output_idx].value == tx.inputs[this.activeInputIndex].value);
         int winner = other_side(turn);
-        Gen__StonesSettleState ticket = {
-            // :: generated fields
-            gen__player_template: gen__player_template,
-            gen__stones_game_template: gen__stones_game_template,
-            gen__stones_settle_template: gen__stones_settle_template,
+        SettleState ticket = {
             // :: user declared fields
             player_a: player_a,
             player_b: player_b,
             status: win_status(winner),
         };
+        Gen__StonesSettleState gen__state_settle_gen__stones_settle_state = {
+            // :: generated fields
+            gen__player_template: gen__player_template,
+            gen__stones_game_template: gen__stones_game_template,
+            gen__stones_settle_template: gen__stones_settle_template,
+            // :: user declared fields
+            player_a: ticket.player_a,
+            player_b: ticket.player_b,
+            status: ticket.status,
+        };
         // :: become StonesSettle
         validateOutputStateWithTemplate(
             gen__settle_output_idx,
-            ticket,
+            gen__state_settle_gen__stones_settle_state,
             gen__stones_settle_prefix,
             gen__stones_settle_suffix,
             gen__stones_settle_template

--- a/examples/build/stones/sil/StonesSettle.sil
+++ b/examples/build/stones/sil/StonesSettle.sil
@@ -155,11 +155,7 @@ contract StonesSettle(
             require(tx.outputs[gen__player_a_out_output_idx].value == tx.inputs[gen__player_a_in_input_idx].value);
             require(tx.outputs[gen__player_b_out_output_idx].value == tx.inputs[gen__player_b_in_input_idx].value + tx.inputs[this.activeInputIndex].value);
         }
-        Gen__PlayerState next_player_a = {
-            // :: generated fields
-            gen__player_template: gen__player_template,
-            gen__stones_game_template: gen__stones_game_template,
-            gen__stones_settle_template: gen__stones_settle_template,
+        PlayerState next_player_a = {
             // :: user declared fields
             owner: player_a_in.owner,
             player_id: player_a_in.player_id,
@@ -168,11 +164,7 @@ contract StonesSettle(
             wins: player_a_wins,
             losses: player_a_losses,
         };
-        Gen__PlayerState next_player_b = {
-            // :: generated fields
-            gen__player_template: gen__player_template,
-            gen__stones_game_template: gen__stones_game_template,
-            gen__stones_settle_template: gen__stones_settle_template,
+        PlayerState next_player_b = {
             // :: user declared fields
             owner: player_b_in.owner,
             player_id: player_b_in.player_id,
@@ -181,19 +173,45 @@ contract StonesSettle(
             wins: player_b_wins,
             losses: player_b_losses,
         };
+        Gen__PlayerState gen__state_player_a_out_gen__player_state = {
+            // :: generated fields
+            gen__player_template: gen__player_template,
+            gen__stones_game_template: gen__stones_game_template,
+            gen__stones_settle_template: gen__stones_settle_template,
+            // :: user declared fields
+            owner: next_player_a.owner,
+            player_id: next_player_a.player_id,
+            open_games: next_player_a.open_games,
+            games: next_player_a.games,
+            wins: next_player_a.wins,
+            losses: next_player_a.losses,
+        };
         // :: become Player
         validateOutputStateWithInputTemplate(
             gen__player_a_out_output_idx,
-            next_player_a,
+            gen__state_player_a_out_gen__player_state,
             gen__player_a_in_input_idx,
             gen__player_prefix_len,
             gen__player_suffix_len,
             gen__player_template
         );
+        Gen__PlayerState gen__state_player_b_out_gen__player_state = {
+            // :: generated fields
+            gen__player_template: gen__player_template,
+            gen__stones_game_template: gen__stones_game_template,
+            gen__stones_settle_template: gen__stones_settle_template,
+            // :: user declared fields
+            owner: next_player_b.owner,
+            player_id: next_player_b.player_id,
+            open_games: next_player_b.open_games,
+            games: next_player_b.games,
+            wins: next_player_b.wins,
+            losses: next_player_b.losses,
+        };
         // :: become Player
         validateOutputStateWithInputTemplate(
             gen__player_b_out_output_idx,
-            next_player_b,
+            gen__state_player_b_out_gen__player_state,
             gen__player_a_in_input_idx,
             gen__player_prefix_len,
             gen__player_suffix_len,

--- a/examples/build/toy_chess/sil/League.sil
+++ b/examples/build/toy_chess/sil/League.sil
@@ -41,17 +41,21 @@ contract League(
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Player
 
-        Gen__PlayerState next_player = {
+        PlayerState next_player = {
+            // :: user declared fields
+            nonce: nonce + 1,
+        };
+        Gen__PlayerState gen__state_next_gen__player_state = {
             // :: generated fields
             gen__mux_template: gen__mux_template,
             gen__mux_routes_digest: gen__mux_routes_digest,
             // :: user declared fields
-            nonce: nonce + 1,
+            nonce: next_player.nonce,
         };
         // :: become Player
         validateOutputStateWithTemplate(
             gen__next_output_idx,
-            next_player,
+            gen__state_next_gen__player_state,
             gen__player_prefix,
             gen__player_suffix,
             gen__player_template

--- a/examples/build/toy_chess/sil/Player.sil
+++ b/examples/build/toy_chess/sil/Player.sil
@@ -47,18 +47,23 @@ contract Player(
         require(OpAuthOutputCount(this.activeInputIndex) == 1);
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0); // output next: Mux
 
-        Gen__MuxState next_board = {
-            // :: generated fields
-            gen__mux_template: gen__mux_template,
-            gen__mux_routes: gen__mux_routes,
+        BoardState next_board = {
             // :: user declared fields
             selector: nonce,
             ply: 0,
         };
+        Gen__MuxState gen__state_next_gen__mux_state = {
+            // :: generated fields
+            gen__mux_template: gen__mux_template,
+            gen__mux_routes: gen__mux_routes,
+            // :: user declared fields
+            selector: next_board.selector,
+            ply: next_board.ply,
+        };
         // :: become Mux
         validateOutputStateWithTemplate(
             gen__next_output_idx,
-            next_board,
+            gen__state_next_gen__mux_state,
             gen__mux_prefix,
             gen__mux_suffix,
             gen__mux_template

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 use crate::artifact::*;
 use crate::ast::*;
 use crate::codec::encode_hex;
-use crate::entry_body::EntryBodyCursor;
+use crate::entry_body::{EntryRoute, EntryStatement};
 use crate::error::{ArgentError, Result};
 use crate::language::word;
-use crate::lexer::{RESERVED_GENERATED_PREFIX, RESERVED_GENERATED_TYPE_PREFIX, Token, TokenKind, lex};
+use crate::lexer::{RESERVED_GENERATED_PREFIX, RESERVED_GENERATED_TYPE_PREFIX, Span, Token, TokenKind, lex};
 use crate::link::{LinkedActor, LinkedContext, link_imported_actors};
 use crate::model::{
     ActorEnumInfo, ActorModel, ActorTarget, AppActors, CompilerRoutePlan, CompilerRoutePlanner, CompilerRouteTransition,
@@ -1681,7 +1681,6 @@ impl<'a> CovenantOutputContext<'a> {
 }
 
 struct BodyLowerer<'a, 'm> {
-    cursor: EntryBodyCursor<'a>,
     actor: &'a ActorDecl,
     entry: &'a EntryDecl,
     model: &'m Model<'a>,
@@ -1695,6 +1694,7 @@ struct BodyLowerer<'a, 'm> {
     observed_output_fields: Vec<ObservedOutputFieldWitnessSpec>,
     validated_spawns: BTreeSet<String>,
     conditional_depth: usize,
+    current_statement: Option<Span>,
 }
 
 #[derive(Debug)]
@@ -1821,7 +1821,6 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let observed_output_fields = observed_output_field_witness_specs(actor, entry, model);
 
         Ok(Self {
-            cursor: entry.body.cursor(),
             actor,
             entry,
             model,
@@ -1835,12 +1834,14 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             observed_output_fields,
             validated_spawns: BTreeSet::new(),
             conditional_depth: 0,
+            current_statement: None,
         })
     }
 
     fn lower(mut self) -> Result<LoweredEntryBody> {
         let mut out = String::new();
-        self.lower_statements(&mut out, 8, None)?;
+        self.lower_statements(&mut out, 8, self.entry.body.statements())?;
+        self.current_statement = None;
         if out.trim().is_empty() {
             out.push_str("        require(1 == 1);\n");
         }
@@ -1874,55 +1875,67 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         )))
     }
 
-    fn lower_statements(&mut self, out: &mut String, indent: usize, end: Option<char>) -> Result<()> {
-        while !self.cursor.is_eof() && !end.is_some_and(|symbol| self.cursor.check_symbol(symbol)) {
-            if self.cursor.consume_ident(word::IF) {
-                self.lower_if(out, indent)?;
-            } else if self.cursor.consume_ident(word::BECOME) {
-                self.lower_become(out, indent)?;
-            } else if self.check_outputs_become_start() {
-                self.lower_outputs_become(out, indent)?;
-            } else if self.cursor.check_symbol(';') {
-                self.cursor.advance();
-            } else {
-                self.lower_plain_statement(out, indent)?;
+    fn lower_statements(&mut self, out: &mut String, indent: usize, statements: &[EntryStatement]) -> Result<()> {
+        for statement in statements {
+            self.current_statement = Some(statement.span());
+            match statement {
+                EntryStatement::If { condition, then_branch, else_branch, .. } => {
+                    self.lower_if(out, indent, *condition, then_branch, else_branch.as_deref(), true)?;
+                }
+                EntryStatement::Become { routes, .. } => self.lower_become(out, indent, routes)?,
+                EntryStatement::ValidateOutputsBecome { group, routes, .. } => {
+                    self.lower_outputs_become(out, indent, group, routes)?;
+                }
+                EntryStatement::Plain { span } => self.lower_plain_statement(out, indent, *span)?,
+                EntryStatement::Block { statements, .. } => {
+                    push_indent(out, indent);
+                    out.push_str("{\n");
+                    self.lower_statements(out, indent + 4, statements)?;
+                    push_indent(out, indent);
+                    out.push_str("}\n");
+                }
             }
         }
         Ok(())
     }
 
-    fn lower_if(&mut self, out: &mut String, indent: usize) -> Result<()> {
-        self.lower_if_inner(out, indent, true)
-    }
-
-    fn lower_if_inner(&mut self, out: &mut String, indent: usize, push_leading_indent: bool) -> Result<()> {
-        self.expect_symbol('(')?;
-        let condition = self.take_balanced_expr('(', ')')?;
-        self.expect_symbol('{')?;
-
+    fn lower_if(
+        &mut self,
+        out: &mut String,
+        indent: usize,
+        condition: Span,
+        then_branch: &EntryStatement,
+        else_branch: Option<&EntryStatement>,
+        push_leading_indent: bool,
+    ) -> Result<()> {
+        let EntryStatement::Block { statements: then_statements, .. } = then_branch else {
+            return Err(self.error("expected `{`"));
+        };
         if push_leading_indent {
             push_indent(out, indent);
         }
-        out.push_str(&format!("if ({}) {{\n", self.lower_expr(&condition, None, indent)?));
+        let condition = self.entry.body.span_text(condition).trim();
+        out.push_str(&format!("if ({}) {{\n", self.lower_expr(condition, None, indent)?));
         self.conditional_depth += 1;
-        self.lower_statements(out, indent + 4, Some('}'))?;
+        self.lower_statements(out, indent + 4, then_statements)?;
         self.conditional_depth -= 1;
-        self.expect_symbol('}')?;
         push_indent(out, indent);
         out.push('}');
 
-        if self.cursor.consume_ident(word::ELSE) {
-            if self.cursor.consume_ident(word::IF) {
+        if let Some(else_branch) = else_branch {
+            self.current_statement = Some(else_branch.span());
+            if let EntryStatement::If { condition, then_branch, else_branch, .. } = else_branch {
                 out.push_str(" else ");
-                self.lower_if_inner(out, indent, false)?;
+                self.lower_if(out, indent, *condition, then_branch, else_branch.as_deref(), false)?;
                 return Ok(());
             }
-            self.expect_symbol('{')?;
+            let EntryStatement::Block { statements: else_statements, .. } = else_branch else {
+                return Err(self.error("expected `{`"));
+            };
             out.push_str(" else {\n");
             self.conditional_depth += 1;
-            self.lower_statements(out, indent + 4, Some('}'))?;
+            self.lower_statements(out, indent + 4, else_statements)?;
             self.conditional_depth -= 1;
-            self.expect_symbol('}')?;
             push_indent(out, indent);
             out.push('}');
         }
@@ -1930,8 +1943,9 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         Ok(())
     }
 
-    fn lower_plain_statement(&mut self, out: &mut String, indent: usize) -> Result<()> {
-        let statement = self.take_until_semicolon()?;
+    fn lower_plain_statement(&mut self, out: &mut String, indent: usize, span: Span) -> Result<()> {
+        let source = self.entry.body.span_text(span).trim();
+        let statement = source.strip_suffix(';').ok_or_else(|| self.error("unterminated statement"))?.trim().to_string();
         if let Some((source_ty, name, expr)) = parse_typed_local_statement(&statement) {
             if let Some(state) = parse_actor_type(source_ty) {
                 self.lower_actor_type_statement(out, indent, state, name, expr)?;
@@ -2122,95 +2136,38 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         Ok(template_var)
     }
 
-    fn lower_become(&mut self, out: &mut String, indent: usize) -> Result<()> {
-        let routes = self.parse_become_routes()?;
+    fn lower_become(&mut self, out: &mut String, indent: usize, routes: &[EntryRoute]) -> Result<()> {
         for route in routes {
+            let route = self.route_call(route);
             self.lower_route(out, indent, route)?;
         }
         Ok(())
     }
 
-    fn parse_become_routes(&mut self) -> Result<Vec<RouteCall>> {
-        if self.cursor.consume_symbol('{') {
-            let mut routes = Vec::new();
-            while !self.cursor.check_symbol('}') && !self.cursor.is_eof() {
-                routes.push(self.parse_become_route()?);
-                self.expect_list_separator_or_end('}')?;
-            }
-            self.expect_symbol('}')?;
-            self.cursor.consume_symbol(';');
-            return Ok(routes);
+    fn route_call(&self, route: &EntryRoute) -> RouteCall {
+        RouteCall {
+            output: route.output.clone(),
+            actor: self.entry.body.span_text(route.actor).trim().to_string(),
+            state: self.entry.body.span_text(route.state).trim().to_string(),
         }
-
-        let route = self.parse_become_route()?;
-        self.cursor.consume_symbol(';');
-        Ok(vec![route])
     }
 
-    fn parse_become_route(&mut self) -> Result<RouteCall> {
-        let output = self.expect_any_ident()?;
-        if !self.consume_left_arrow() {
-            return Err(self.error("every `become` route must name its output with `output <- Actor(state)`"));
-        }
-        let actor = self.take_route_actor_expr()?;
-        self.expect_symbol('(')?;
-        let state = self.take_balanced_expr('(', ')')?;
-        Ok(RouteCall { output, actor, state })
-    }
-
-    fn take_route_actor_expr(&mut self) -> Result<String> {
-        let start = self.cursor.byte_offset();
-        self.take_route_actor_expr_from(start)
-    }
-
-    fn take_route_actor_expr_from(&mut self, start: usize) -> Result<String> {
-        let mut depth = 0usize;
-        while !self.cursor.is_eof() {
-            let token = self.cursor.current().clone();
-            match token.kind {
-                TokenKind::Symbol('(') if depth == 0 => {
-                    let expr = self.cursor.span_text(self.cursor.span_to_current(start)).trim().to_string();
-                    if expr.is_empty() {
-                        return Err(self.error("become target is empty"));
-                    }
-                    return Ok(expr);
-                }
-                TokenKind::Symbol('{') | TokenKind::Symbol('[') | TokenKind::Symbol('<') => {
-                    depth += 1;
-                    self.cursor.advance();
-                }
-                TokenKind::Symbol('}') | TokenKind::Symbol(']') | TokenKind::Symbol('>') => {
-                    depth = depth.saturating_sub(1);
-                    self.cursor.advance();
-                }
-                _ => self.cursor.advance(),
-            }
-        }
-        Err(self.error("unterminated become target"))
-    }
-
-    fn lower_outputs_become(&mut self, out: &mut String, indent: usize) -> Result<()> {
-        self.expect_ident(word::REQUIRE)?;
-        let group_name = self.expect_any_ident()?;
-        self.expect_symbol('.')?;
-        self.expect_ident(word::OUTPUTS)?;
-        self.expect_ident(word::BECOME)?;
-        let routes = self.parse_become_routes()?;
-
+    fn lower_outputs_become(&mut self, out: &mut String, indent: usize, group_name: &str, routes: &[EntryRoute]) -> Result<()> {
         let entry_model = self.model.entry_model(self.actor, self.entry)?;
         let group = entry_model
             .existing_groups()
             .chain(entry_model.genesis_groups())
-            .find(|group| group.name() == Some(group_name.as_str()))
+            .find(|group| group.name() == Some(group_name))
             .ok_or_else(|| self.error(format!("unknown observe or spawn `{group_name}`")))?;
         if group.spawn().is_some() {
             if self.conditional_depth != 0 {
                 return Err(self.error(format!("spawn `{group_name}` output validation must be unconditional")));
             }
-            if !self.validated_spawns.insert(group_name.clone()) {
+            if !self.validated_spawns.insert(group_name.to_string()) {
                 return Err(self.error(format!("spawn `{group_name}` outputs are validated more than once")));
             }
         }
+        let routes = routes.iter().map(|route| self.route_call(route)).collect();
         self.lower_covenant_outputs_become(out, indent, group, routes)
     }
 
@@ -2957,93 +2914,13 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         lower_actor_enum_literals(&out, self.model)
     }
 
-    fn take_until_semicolon(&mut self) -> Result<String> {
-        let start = self.cursor.byte_offset();
-        let mut depth = 0usize;
-        while !self.cursor.is_eof() {
-            let token = self.cursor.current().clone();
-            match token.kind {
-                TokenKind::Symbol('{') | TokenKind::Symbol('(') | TokenKind::Symbol('[') => {
-                    depth += 1;
-                    self.cursor.advance();
-                }
-                TokenKind::Symbol('}') | TokenKind::Symbol(')') | TokenKind::Symbol(']') => {
-                    depth = depth.saturating_sub(1);
-                    self.cursor.advance();
-                }
-                TokenKind::Symbol(';') if depth == 0 => {
-                    let text = self.cursor.span_text(self.cursor.span_to_current(start)).trim().to_string();
-                    self.cursor.advance();
-                    return Ok(text);
-                }
-                _ => self.cursor.advance(),
-            }
-        }
-        Err(self.error("unterminated statement"))
-    }
-
-    fn take_balanced_expr(&mut self, open: char, close: char) -> Result<String> {
-        let span =
-            self.cursor.take_balanced_after_open(open, close).ok_or_else(|| self.error(format!("unterminated `{open}` group")))?;
-        Ok(self.cursor.span_text(span).trim().to_string())
-    }
-
-    fn expect_any_ident(&mut self) -> Result<String> {
-        match self.cursor.current().kind.clone() {
-            TokenKind::Ident(name) => {
-                self.cursor.advance();
-                Ok(name)
-            }
-            _ => Err(self.error("expected identifier")),
-        }
-    }
-
-    fn expect_ident(&mut self, expected: &str) -> Result<()> {
-        if self.cursor.consume_ident(expected) { Ok(()) } else { Err(self.error(format!("expected `{expected}`"))) }
-    }
-
-    fn expect_symbol(&mut self, expected: char) -> Result<()> {
-        if self.cursor.consume_symbol(expected) { Ok(()) } else { Err(self.error(format!("expected `{expected}`"))) }
-    }
-
-    fn expect_list_separator_or_end(&mut self, end: char) -> Result<()> {
-        if self.cursor.consume_symbol(',') || self.cursor.check_symbol(end) {
-            Ok(())
-        } else {
-            Err(self.error(format!("expected `,` or `{end}`")))
-        }
-    }
-
-    fn consume_left_arrow(&mut self) -> bool {
-        match self.cursor.current().kind {
-            TokenKind::LeftArrow => {
-                self.cursor.advance();
-                true
-            }
-            TokenKind::Symbol('<') if matches!(self.cursor.peek_kind(1), Some(TokenKind::Symbol('-'))) => {
-                self.cursor.advance();
-                self.cursor.advance();
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn check_outputs_become_start(&self) -> bool {
-        matches!(&self.cursor.current().kind, TokenKind::Ident(actual) if actual == word::REQUIRE)
-            && matches!(self.cursor.peek_kind(1), Some(TokenKind::Ident(_)))
-            && matches!(self.cursor.peek_kind(2), Some(TokenKind::Symbol('.')))
-            && matches!(self.cursor.peek_kind(3), Some(TokenKind::Ident(actual)) if actual == word::OUTPUTS)
-            && matches!(self.cursor.peek_kind(4), Some(TokenKind::Ident(actual)) if actual == word::BECOME)
-    }
-
     fn error(&self, message: impl Into<String>) -> ArgentError {
         ArgentError::new(format!(
-            "{} in `{}::{}` at body byte {}",
+            "{} in `{}::{}`{}",
             message.into(),
             self.actor.name,
             self.entry.name,
-            self.cursor.byte_offset()
+            self.current_statement.map(|span| format!(" at body bytes {span}")).unwrap_or_default(),
         ))
     }
 }
@@ -8862,7 +8739,7 @@ mod tests {
 
     #[test]
     fn rejects_semicolons_in_observed_become_route_lists() {
-        let err = emit_inline_error(
+        let err = parse_and_validate(
             r#"
             state ForeignState {
                 int amount;
@@ -8903,7 +8780,8 @@ mod tests {
                 actor Local;
             }
             "#,
-        );
+        )
+        .expect_err("semicolon-separated output routes must not parse");
 
         assert!(err.to_string().contains("expected `,` or `}`"), "unexpected error: {err}");
     }
@@ -11050,12 +10928,118 @@ mod tests {
     }
 
     fn inline_artifact(name: &str, source: &str) -> Artifact {
+        inline_actor_sil_and_artifact(name, source).1
+    }
+
+    fn inline_actor_sil_and_artifact(name: &str, source: &str) -> (BTreeMap<String, String>, Artifact) {
         let path = PathBuf::from(format!("{name}.ag"));
         let module = crate::parser::parse_module(path.clone(), source.to_string()).expect("source parses");
         let program = Program { root: path, modules: vec![module] };
         let model = Model::from_program(&program).expect("model validates");
         let actor_sil = actor_sil_for_model(&model);
-        emit_artifact(&program, &model, &actor_sil).expect("artifact emits")
+        let artifact = emit_artifact(&program, &model, &actor_sil).expect("artifact emits");
+        (actor_sil, artifact)
+    }
+
+    #[test]
+    fn standalone_entry_body_block_lowers_and_compiles() {
+        let (actor_sil, _) = inline_actor_sil_and_artifact(
+            "standalone-entry-body-block",
+            r#"
+            state CounterState {
+                int count;
+            }
+
+            actor Counter owns CounterState {
+                entry inspect(int delta) emits none {
+                    {
+                        int candidate = count + delta;
+                        require((candidate >= count) || (delta < 0));
+                    }
+                    require(count >= 0);
+                }
+            }
+
+            app StandaloneEntryBodyBlock {
+                actor Counter;
+            }
+            "#,
+        );
+
+        let sil = actor_sil.get("Counter").expect("Counter emits");
+        assert!(
+            sil.contains(
+                r#"        {
+            int candidate = count + delta;
+            require((candidate >= count) || (delta < 0));
+        }
+        require(count >= 0);"#
+            ),
+            "standalone block must remain a nested Sil block:\n{sil}"
+        );
+    }
+
+    #[test]
+    fn complex_nested_entry_body_lowers_and_compiles() {
+        inline_artifact(
+            "complex-nested-entry-body",
+            r#"
+            state CounterState {
+                int count;
+                int limit;
+            }
+
+            actor Counter owns CounterState {
+                entry advance(int delta, int scale, bool prefer_limit) emits next: Counter {
+                    int base = count + ((delta * scale) + (limit - count));
+                    {
+                        int bounded = base + ((limit - base) * scale);
+                        require((bounded >= count) || ((delta < 0) && !prefer_limit));
+                        {
+                            int mixed = (bounded + (delta * (scale + 1))) % (limit + 1);
+                            require(((mixed >= 0) && (bounded <= limit)) || prefer_limit);
+                        }
+                    }
+
+                    if ((delta > 0) && ((base < limit) || prefer_limit)) {
+                        CounterState next_state = {
+                            count: base + (scale * 2),
+                            limit: limit,
+                        };
+                        require(
+                            (next.value >= self.value)
+                                && ((next_state.count > count) || (delta > scale))
+                        );
+                        become next <- Counter(next_state);
+                    } else if ((delta == 0) || ((scale > limit) && !prefer_limit)) {
+                        CounterState next_state = {
+                            count: count,
+                            limit: limit + (scale - delta),
+                        };
+                        require(
+                            (next.value == self.value)
+                                || ((next.value > self.value) && (next_state.limit >= limit))
+                        );
+                        become next <- Counter(next_state);
+                    } else {
+                        CounterState next_state = {
+                            count: count + ((limit - scale) * (delta + 1)),
+                            limit: limit,
+                        };
+                        require(
+                            ((next.value >= 0) && (self.value >= 0))
+                                || ((next_state.count <= limit) && !prefer_limit)
+                        );
+                        become next <- Counter(next_state);
+                    }
+                }
+            }
+
+            app ComplexNestedEntryBody {
+                actor Counter;
+            }
+            "#,
+        );
     }
 
     #[test]

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1882,6 +1882,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
                 EntryStatement::If { condition, then_branch, else_branch, .. } => {
                     self.lower_if(out, indent, *condition, then_branch, else_branch.as_deref(), true)?;
                 }
+                EntryStatement::For { header, body, .. } => self.lower_for(out, indent, *header, body)?,
                 EntryStatement::Become { routes, .. } => self.lower_become(out, indent, routes)?,
                 EntryStatement::ValidateOutputsBecome { group, routes, .. } => {
                     self.lower_outputs_become(out, indent, group, routes)?;
@@ -1940,6 +1941,23 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             out.push('}');
         }
         out.push('\n');
+        Ok(())
+    }
+
+    fn lower_for(&mut self, out: &mut String, indent: usize, header: Span, body: &EntryStatement) -> Result<()> {
+        let header = self.entry.body.span_text(header).trim();
+        push_indent(out, indent);
+        out.push_str(&format!("for ({}) {{\n", self.lower_expr(header, None, indent)?));
+
+        self.conditional_depth += 1;
+        match body {
+            EntryStatement::Block { statements, .. } => self.lower_statements(out, indent + 4, statements)?,
+            statement => self.lower_statements(out, indent + 4, std::slice::from_ref(statement))?,
+        }
+        self.conditional_depth -= 1;
+
+        push_indent(out, indent);
+        out.push_str("}\n");
         Ok(())
     }
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1831,8 +1831,17 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
         let ref_replacements = entry_ref_replacements(actor, model, input_names, &output_values, observed_input_state_refs)?;
         let selectors = model.template_selectors_for_entry(actor, entry)?;
-        let visible_selectors =
-            entry.params.iter().filter(|param| selectors.contains_key(&param.name)).map(|param| param.name.clone()).collect();
+        // A same-named body local may also contribute entry-wide selector
+        // metadata; only an actor-enum parameter defines a visible parameter
+        // binding.
+        let visible_selectors = entry
+            .params
+            .iter()
+            .filter(|param| {
+                param.ty.array.is_none() && selectors.get(&param.name).is_some_and(|selector| selector.actor_enum == param.ty.name)
+            })
+            .map(|param| param.name.clone())
+            .collect();
         let observed_output_fields = observed_output_field_witness_specs(actor, entry, model);
 
         Ok(Self {

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1686,7 +1686,10 @@ struct BodyLowerer<'a, 'm> {
     model: &'m Model<'a>,
     types: BTreeMap<String, String>,
     source_types: BTreeMap<String, String>,
+    /// Entry-wide selector metadata used by route analysis and lowering.
     selectors: BTreeMap<String, TemplateSelector>,
+    /// Selector bindings currently visible at the lowering cursor.
+    visible_selectors: BTreeSet<String>,
     materialized_selectors: BTreeSet<String>,
     materialized_route_locals: BTreeMap<String, String>,
     output_values: Vec<OutputValueRef>,
@@ -1702,6 +1705,7 @@ struct BodyLowerer<'a, 'm> {
 struct BodyScopeSnapshot {
     types: BTreeMap<String, String>,
     source_types: BTreeMap<String, String>,
+    visible_selectors: BTreeSet<String>,
     materialized_selectors: BTreeSet<String>,
     materialized_route_locals: BTreeMap<String, String>,
 }
@@ -1827,6 +1831,8 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
         let ref_replacements = entry_ref_replacements(actor, model, input_names, &output_values, observed_input_state_refs)?;
         let selectors = model.template_selectors_for_entry(actor, entry)?;
+        let visible_selectors =
+            entry.params.iter().filter(|param| selectors.contains_key(&param.name)).map(|param| param.name.clone()).collect();
         let observed_output_fields = observed_output_field_witness_specs(actor, entry, model);
 
         Ok(Self {
@@ -1836,6 +1842,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             types,
             source_types,
             selectors,
+            visible_selectors,
             materialized_selectors: BTreeSet::new(),
             materialized_route_locals: BTreeMap::new(),
             output_values,
@@ -1913,12 +1920,14 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let outer = BodyScopeSnapshot {
             types: self.types.clone(),
             source_types: self.source_types.clone(),
+            visible_selectors: self.visible_selectors.clone(),
             materialized_selectors: self.materialized_selectors.clone(),
             materialized_route_locals: self.materialized_route_locals.clone(),
         };
         let result = self.lower_statements(out, indent, statements);
         self.types = outer.types;
         self.source_types = outer.source_types;
+        self.visible_selectors = outer.visible_selectors;
         self.materialized_selectors = outer.materialized_selectors;
         self.materialized_route_locals = outer.materialized_route_locals;
         result
@@ -2021,6 +2030,9 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
             push_indent(out, indent);
             out.push_str(&format!("{ty} {name} = {lowered};\n"));
+            if self.selectors.get(name).is_some_and(|selector| selector.actor_enum == source_ty) {
+                self.visible_selectors.insert(name.to_string());
+            }
             return Ok(());
         }
 
@@ -2116,6 +2128,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         }
         self.validate_actor_type_initializer(name, expr, &selector)?;
         self.ensure_selector_template(out, indent, name)?;
+        self.visible_selectors.insert(name.to_string());
         Ok(())
     }
 
@@ -2518,8 +2531,11 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     }
 
     fn lower_route(&mut self, out: &mut String, indent: usize, route: RouteCall) -> Result<()> {
-        if self.selectors.contains_key(&route.actor) {
+        if self.visible_selectors.contains(&route.actor) {
             return self.lower_selector_route(out, indent, route);
+        }
+        if self.selectors.contains_key(&route.actor) {
+            return Err(self.error(format!("actor handle `{}` is not visible in this scope", route.actor)));
         }
         self.model.actor_state(&route.actor)?;
         let output_idx = hidden_output_idx_name(&route.output);

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -11043,6 +11043,30 @@ mod tests {
     }
 
     #[test]
+    fn for_loop_entry_body_lowers_and_compiles() {
+        inline_artifact(
+            "for-loop-entry-body",
+            r#"
+            state CounterState {
+                int count;
+            }
+
+            actor Counter owns CounterState {
+                entry inspect(int iterations) emits none {
+                    for (i, 0, iterations, 16) {
+                        require((i >= 0) && (i < iterations));
+                    }
+                }
+            }
+
+            app ForLoopEntryBody {
+                actor Counter;
+            }
+            "#,
+        );
+    }
+
+    #[test]
     fn genesis_spawn_lowers_to_pinned_sil_and_artifact_metadata() {
         let (controller_sil, controller_artifact) =
             emit_selected_fixture("tests/fixtures/runtime/context_genesis_spawn/app.ag", "ControllerApp", "Controller");

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::artifact::*;
 use crate::ast::*;
 use crate::codec::encode_hex;
-use crate::entry_body::{EntryRoute, EntryStatement};
+use crate::entry_body::{EntryBinding, EntryRoute, EntryStatement};
 use crate::error::{ArgentError, Result};
 use crate::language::word;
 use crate::lexer::{RESERVED_GENERATED_PREFIX, RESERVED_GENERATED_TYPE_PREFIX, Span, Token, TokenKind, lex};
@@ -1684,14 +1684,9 @@ struct BodyLowerer<'a, 'm> {
     actor: &'a ActorDecl,
     entry: &'a EntryDecl,
     model: &'m Model<'a>,
-    types: BTreeMap<String, String>,
-    source_types: BTreeMap<String, String>,
-    /// Entry-wide selector metadata used by route analysis and lowering.
-    selectors: BTreeMap<String, TemplateSelector>,
-    /// Selector bindings currently visible at the lowering cursor.
-    visible_selectors: BTreeSet<String>,
-    materialized_selectors: BTreeSet<String>,
-    materialized_route_locals: BTreeMap<String, String>,
+    bindings: BodyBindings,
+    /// Entry-wide candidates; the current binding decides selector visibility.
+    selector_catalog: BTreeMap<String, TemplateSelector>,
     output_values: Vec<OutputValueRef>,
     ref_replacements: RefReplacements,
     observed_output_fields: Vec<ObservedOutputFieldWitnessSpec>,
@@ -1700,14 +1695,102 @@ struct BodyLowerer<'a, 'm> {
     current_statement: Option<Span>,
 }
 
-/// Argent metadata restored when a nested Sil lexical scope ends.
-#[derive(Clone)]
-struct BodyScopeSnapshot {
-    types: BTreeMap<String, String>,
-    source_types: BTreeMap<String, String>,
-    visible_selectors: BTreeSet<String>,
-    materialized_selectors: BTreeSet<String>,
-    materialized_route_locals: BTreeMap<String, String>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct BodyBindingId(usize);
+
+/// Type and lowering facts attached to one lexically resolved value.
+struct BodyBinding {
+    source_type: Option<String>,
+    lowered_type: Option<String>,
+    selector: Option<TemplateSelector>,
+}
+
+impl BodyBinding {
+    fn typed(source_type: impl Into<String>, lowered_type: impl Into<String>) -> Self {
+        Self { source_type: Some(source_type.into()), lowered_type: Some(lowered_type.into()), selector: None }
+    }
+
+    fn source_typed(source_type: impl Into<String>) -> Self {
+        Self { source_type: Some(source_type.into()), lowered_type: None, selector: None }
+    }
+
+    fn lowered_typed(lowered_type: impl Into<String>) -> Self {
+        Self { source_type: None, lowered_type: Some(lowered_type.into()), selector: None }
+    }
+
+    fn with_selector(mut self, selector: TemplateSelector) -> Self {
+        self.selector = Some(selector);
+        self
+    }
+}
+
+struct ScopedBodyBinding {
+    id: BodyBindingId,
+    value: BodyBinding,
+}
+
+#[derive(Default)]
+struct BodyScope {
+    bindings: BTreeMap<String, ScopedBodyBinding>,
+    /// Generated selector locals available in this emitted Sil scope.
+    materialized_selectors: BTreeSet<BodyBindingId>,
+}
+
+/// Resolves body values through the same lexical scopes emitted to Sil.
+struct BodyBindings {
+    scopes: Vec<BodyScope>,
+    next_id: usize,
+}
+
+impl BodyBindings {
+    fn new() -> Self {
+        Self { scopes: vec![BodyScope::default()], next_id: 0 }
+    }
+
+    fn enter_scope(&mut self) {
+        self.scopes.push(BodyScope::default());
+    }
+
+    fn exit_scope(&mut self) {
+        assert!(self.scopes.len() > 1, "cannot exit the entry body root scope");
+        self.scopes.pop();
+    }
+
+    fn declare(&mut self, name: impl Into<String>, binding: BodyBinding) -> BodyBindingId {
+        let id = BodyBindingId(self.next_id);
+        self.next_id += 1;
+        self.scopes
+            .last_mut()
+            .expect("body bindings retain a root scope")
+            .bindings
+            .insert(name.into(), ScopedBodyBinding { id, value: binding });
+        id
+    }
+
+    fn get(&self, name: &str) -> Option<&ScopedBodyBinding> {
+        self.scopes.iter().rev().find_map(|scope| scope.bindings.get(name))
+    }
+
+    fn lowered_type(&self, name: &str) -> Option<&str> {
+        self.get(name).and_then(|binding| binding.value.lowered_type.as_deref())
+    }
+
+    fn source_type(&self, name: &str) -> Option<&str> {
+        self.get(name).and_then(|binding| binding.value.source_type.as_deref())
+    }
+
+    fn selector(&self, name: &str) -> Option<(BodyBindingId, &TemplateSelector)> {
+        let binding = self.get(name)?;
+        Some((binding.id, binding.value.selector.as_ref()?))
+    }
+
+    fn selector_is_materialized(&self, id: BodyBindingId) -> bool {
+        self.scopes.iter().rev().any(|scope| scope.materialized_selectors.contains(&id))
+    }
+
+    fn mark_selector_materialized(&mut self, id: BodyBindingId) {
+        self.scopes.last_mut().expect("body bindings retain a root scope").materialized_selectors.insert(id);
+    }
 }
 
 #[derive(Debug)]
@@ -1751,35 +1834,38 @@ fn entry_ref_replacements(
 
 impl<'a, 'm> BodyLowerer<'a, 'm> {
     fn new(actor: &'a ActorDecl, entry: &'a EntryDecl, model: &'m Model<'a>) -> Result<Self> {
-        let mut types = BTreeMap::new();
-        let mut source_types = BTreeMap::new();
+        let selector_catalog = model.template_selectors_for_entry(actor, entry)?;
+        let mut bindings = BodyBindings::new();
         let expanded_digest_fields = state_expansion_digest_fields_for_state(&actor.state, model);
         for field in &model.storage_state(&actor.state)?.fields {
             if expanded_digest_fields.contains(field.name.as_str()) {
                 continue;
             }
-            types.insert(field.name.clone(), lower_type_ref(&field.ty, model));
-            source_types.insert(field.name.clone(), source_type_ref(&field.ty));
+            bindings.declare(field.name.clone(), BodyBinding::typed(source_type_ref(&field.ty), lower_type_ref(&field.ty, model)));
         }
         if let Some(expansion) = model.state(&actor.state)?.expansion.as_ref() {
             for digest in &expansion.digests {
-                source_types.insert(digest.field.clone(), digest.state.clone());
+                bindings.declare(digest.field.clone(), BodyBinding::source_typed(digest.state.clone()));
             }
         }
         for param in &entry.params {
             let ty = lower_entry_param_type(actor, &param.ty, model);
-            types.insert(param.name.clone(), ty);
-            source_types.insert(param.name.clone(), source_type_ref(&param.ty));
+            let mut binding = BodyBinding::typed(source_type_ref(&param.ty), ty);
+            if param.ty.array.is_none()
+                && let Some(selector) = selector_catalog.get(&param.name)
+                && selector.actor_enum == param.ty.name
+            {
+                binding = binding.with_selector(selector.clone());
+            }
+            bindings.declare(param.name.clone(), binding);
         }
         for observe in &entry.observes {
             for (binding, state) in observed_open_bindings(observe) {
-                types.insert(binding.to_string(), "byte[32]".to_string());
-                source_types.insert(binding.to_string(), format!("{}<{state}>", word::ACTOR_TYPE));
+                bindings.declare(binding.to_string(), BodyBinding::typed(format!("{}<{state}>", word::ACTOR_TYPE), "byte[32]"));
             }
         }
         for spawn in &entry.spawns {
-            types.insert(spawn.covenant.clone(), "byte[32]".to_string());
-            source_types.insert(spawn.covenant.clone(), word::COVENANT_ID.to_string());
+            bindings.declare(spawn.covenant.clone(), BodyBinding::typed(word::COVENANT_ID, "byte[32]"));
         }
 
         let mut input_names = BTreeSet::new();
@@ -1787,8 +1873,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             input_names.insert(consume.name.clone());
             let state = model.actor(&consume.actor)?.state.clone();
             let ty = contract_state_type_for_actor(&consume.actor, actor, model)?;
-            types.insert(consume.name.clone(), ty);
-            source_types.insert(consume.name.clone(), state);
+            bindings.declare(consume.name.clone(), BodyBinding::typed(state, ty));
         }
         let mut observed_input_state_refs = Vec::new();
         for observe in &entry.observes {
@@ -1802,9 +1887,8 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
                     model.actor(&input.actor)?.state.clone()
                 };
                 let ty = contract_state_type_for_observed_actor(actor, entry, observe, input, model)?;
-                types.insert(source_ref.clone(), ty.clone());
-                types.insert(lowered_ref, ty);
-                source_types.insert(source_ref, state);
+                bindings.declare(source_ref, BodyBinding::typed(state, ty.clone()));
+                bindings.declare(lowered_ref, BodyBinding::lowered_typed(ty));
             }
         }
 
@@ -1830,30 +1914,14 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         output_values.sort_by(|left, right| right.source.len().cmp(&left.source.len()).then_with(|| left.source.cmp(&right.source)));
 
         let ref_replacements = entry_ref_replacements(actor, model, input_names, &output_values, observed_input_state_refs)?;
-        let selectors = model.template_selectors_for_entry(actor, entry)?;
-        // A same-named body local may also contribute entry-wide selector
-        // metadata; only an actor-enum parameter defines a visible parameter
-        // binding.
-        let visible_selectors = entry
-            .params
-            .iter()
-            .filter(|param| {
-                param.ty.array.is_none() && selectors.get(&param.name).is_some_and(|selector| selector.actor_enum == param.ty.name)
-            })
-            .map(|param| param.name.clone())
-            .collect();
         let observed_output_fields = observed_output_field_witness_specs(actor, entry, model);
 
         Ok(Self {
             actor,
             entry,
             model,
-            types,
-            source_types,
-            selectors,
-            visible_selectors,
-            materialized_selectors: BTreeSet::new(),
-            materialized_route_locals: BTreeMap::new(),
+            bindings,
+            selector_catalog,
             output_values,
             ref_replacements,
             observed_output_fields,
@@ -1907,12 +1975,12 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
                 EntryStatement::If { condition, then_branch, else_branch, .. } => {
                     self.lower_if(out, indent, *condition, then_branch, else_branch.as_deref(), true)?;
                 }
-                EntryStatement::For { header, body, .. } => self.lower_for(out, indent, *header, body)?,
+                EntryStatement::For { binding, header, body, .. } => self.lower_for(out, indent, binding, *header, body)?,
                 EntryStatement::Become { routes, .. } => self.lower_become(out, indent, routes)?,
                 EntryStatement::ValidateOutputsBecome { group, routes, .. } => {
                     self.lower_outputs_become(out, indent, group, routes)?;
                 }
-                EntryStatement::Plain { span } => self.lower_plain_statement(out, indent, *span)?,
+                EntryStatement::Plain { bindings, span } => self.lower_plain_statement(out, indent, bindings, *span)?,
                 EntryStatement::Block { statements, .. } => {
                     push_indent(out, indent);
                     out.push_str("{\n");
@@ -1926,19 +1994,9 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     }
 
     fn lower_scoped_statements(&mut self, out: &mut String, indent: usize, statements: &[EntryStatement]) -> Result<()> {
-        let outer = BodyScopeSnapshot {
-            types: self.types.clone(),
-            source_types: self.source_types.clone(),
-            visible_selectors: self.visible_selectors.clone(),
-            materialized_selectors: self.materialized_selectors.clone(),
-            materialized_route_locals: self.materialized_route_locals.clone(),
-        };
+        self.bindings.enter_scope();
         let result = self.lower_statements(out, indent, statements);
-        self.types = outer.types;
-        self.source_types = outer.source_types;
-        self.visible_selectors = outer.visible_selectors;
-        self.materialized_selectors = outer.materialized_selectors;
-        self.materialized_route_locals = outer.materialized_route_locals;
+        self.bindings.exit_scope();
         result
     }
 
@@ -1986,62 +2044,64 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         Ok(())
     }
 
-    fn lower_for(&mut self, out: &mut String, indent: usize, header: Span, body: &EntryStatement) -> Result<()> {
+    fn lower_for(
+        &mut self,
+        out: &mut String,
+        indent: usize,
+        binding: &EntryBinding,
+        header: Span,
+        body: &EntryStatement,
+    ) -> Result<()> {
         let header = self.entry.body.span_text(header).trim();
         push_indent(out, indent);
         out.push_str(&format!("for ({}) {{\n", self.lower_expr(header, None, indent)?));
 
         self.conditional_depth += 1;
-        match body {
-            EntryStatement::Block { statements, .. } => self.lower_scoped_statements(out, indent + 4, statements)?,
-            statement => self.lower_scoped_statements(out, indent + 4, std::slice::from_ref(statement))?,
-        }
+        self.bindings.enter_scope();
+        self.declare_sil_binding(binding);
+        let result = match body {
+            EntryStatement::Block { statements, .. } => self.lower_statements(out, indent + 4, statements),
+            statement => self.lower_statements(out, indent + 4, std::slice::from_ref(statement)),
+        };
+        self.bindings.exit_scope();
         self.conditional_depth -= 1;
+        result?;
 
         push_indent(out, indent);
         out.push_str("}\n");
         Ok(())
     }
 
-    fn lower_plain_statement(&mut self, out: &mut String, indent: usize, span: Span) -> Result<()> {
+    fn lower_plain_statement(&mut self, out: &mut String, indent: usize, bindings: &[EntryBinding], span: Span) -> Result<()> {
         let source = self.entry.body.span_text(span).trim();
         let statement = source.strip_suffix(';').ok_or_else(|| self.error("unterminated statement"))?.trim().to_string();
-        if let Some((source_ty, name, expr)) = parse_typed_local_statement(&statement) {
+        if let [declared_binding] = bindings
+            && let Some((declaration_type, name, expr)) = parse_typed_local_statement(&statement)
+        {
+            let source_ty = &declared_binding.source_type;
             if let Some(state) = parse_actor_type(source_ty) {
                 self.lower_actor_type_statement(out, indent, state, name, expr)?;
                 return Ok(());
             }
-            let ty = if self.model.has_state(source_ty) {
-                self.types.get(expr.trim()).cloned().unwrap_or_else(|| self.lower_local_type(source_ty))
+            let lowered_ty = if self.model.has_state(source_ty) {
+                self.bindings.lowered_type(expr.trim()).map(str::to_string).unwrap_or_else(|| self.lower_local_type(source_ty))
             } else {
                 self.lower_local_type(source_ty)
             };
-            if let Some(target_actor) = self.single_route_target_for_state_local(source_ty, name, expr, &ty)? {
-                let target_ty = contract_state_type_for_actor(&target_actor, self.actor, self.model)?;
-                let transition = (target_actor != self.actor.name).then(|| {
-                    self.model
-                        .route_transition(&self.actor.name, &target_actor)
-                        .expect("validated non-self route has a planned cut transition")
-                });
-                let state_expr = format!("{source_ty} {}", expr.trim());
-                let lowered = self.lower_state_expr_for_actor(&target_actor, transition, &state_expr, indent)?;
-                self.types.insert(name.to_string(), target_ty.clone());
-                self.source_types.insert(name.to_string(), source_ty.to_string());
-                self.materialized_route_locals.insert(name.to_string(), target_actor);
-
-                push_indent(out, indent);
-                out.push_str(&format!("{target_ty} {name} = {lowered};\n"));
-                return Ok(());
-            }
-            let lowered = self.lower_typed_local_initializer(source_ty, &ty, expr, indent)?;
-            self.types.insert(name.to_string(), ty.clone());
-            self.source_types.insert(name.to_string(), source_ty.to_string());
+            let type_suffix =
+                declaration_type.strip_prefix(source_ty).expect("binding parser and typed-local parser agree on the leading type");
+            let emitted_type = format!("{lowered_ty}{type_suffix}");
+            let lowered = self.lower_typed_local_initializer(source_ty, &lowered_ty, expr, indent)?;
 
             push_indent(out, indent);
-            out.push_str(&format!("{ty} {name} = {lowered};\n"));
-            if self.selectors.get(name).is_some_and(|selector| selector.actor_enum == source_ty) {
-                self.visible_selectors.insert(name.to_string());
+            out.push_str(&format!("{emitted_type} {name} = {lowered};\n"));
+            let mut binding = BodyBinding::typed(source_ty, lowered_ty);
+            if let Some(selector) = self.selector_catalog.get(name)
+                && selector.actor_enum == source_ty.as_str()
+            {
+                binding = binding.with_selector(selector.clone());
             }
+            self.bindings.declare(name, binding);
             return Ok(());
         }
 
@@ -2051,7 +2111,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         }
 
         if let Some(require_expr) = parse_require_statement(&statement) {
-            for covenant_id in co_spent_covenant_ids(require_expr, &self.source_types)? {
+            for covenant_id in co_spent_covenant_ids(require_expr, &self.bindings)? {
                 push_indent(out, indent);
                 out.push_str(&format!("// :: co-spent with {}\n", covenant_id.trim()));
             }
@@ -2060,7 +2120,15 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         push_indent(out, indent);
         out.push_str(&self.lower_expr(&statement, None, indent)?);
         out.push_str(";\n");
+        for binding in bindings {
+            self.declare_sil_binding(binding);
+        }
         Ok(())
+    }
+
+    fn declare_sil_binding(&mut self, binding: &EntryBinding) {
+        let lowered_type = self.lower_local_type(&binding.source_type);
+        self.bindings.declare(&binding.name, BodyBinding::typed(&binding.source_type, lowered_type));
     }
 
     fn validate_unrestricted_output_value(&self, value: &str) -> Result<()> {
@@ -2074,56 +2142,9 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         Ok(())
     }
 
-    fn single_route_target_for_state_local(
-        &self,
-        source_ty: &str,
-        name: &str,
-        expr: &str,
-        lowered_ty: &str,
-    ) -> Result<Option<String>> {
-        // A route-neutral state object used only by one concrete route can
-        // receive that target layout at its declaration point. Output handles
-        // and their value references are not state-local uses, even when they
-        // have the same source name. Any other read, rewrite, or second route
-        // preserves the route-neutral body.
-        let route_handle_uses = self.entry.routes.iter().filter(|route| route.output == name).count();
-        let output_value_ident_uses = self
-            .output_values
-            .iter()
-            .map(|output| {
-                count_qualified_ref(self.entry.body.tokens(), &output.source)
-                    * output.source.split('.').filter(|segment| *segment == name).count()
-            })
-            .sum::<usize>();
-        if self.conditional_depth != 0
-            || lowered_ty != source_ty
-            || split_state_object_literal(expr).is_none()
-            || self.entry.body.tokens().iter().filter(|token| matches!(&token.kind, TokenKind::Ident(ident) if ident == name)).count()
-                != 2 + route_handle_uses + output_value_ident_uses
-        {
-            return Ok(None);
-        }
-
-        let mut routes = self.entry.routes.iter().filter(|route| route.state.trim() == name);
-        let Some(route) = routes.next() else {
-            return Ok(None);
-        };
-        if routes.next().is_some() {
-            return Ok(None);
-        }
-        let targets = self.model.route_targets(self.actor, self.entry, route)?;
-        let [target_actor] = targets.as_slice() else {
-            return Ok(None);
-        };
-        if contract_state_type_for_actor(target_actor, self.actor, self.model)? == lowered_ty {
-            return Ok(None);
-        }
-        Ok(Some(target_actor.clone()))
-    }
-
     fn lower_actor_type_statement(&mut self, out: &mut String, indent: usize, state: &str, name: &str, expr: &str) -> Result<()> {
         let selector = self
-            .selectors
+            .selector_catalog
             .get(name)
             .ok_or_else(|| ArgentError::new(format!("actor handle `{name}` must be initialized as `ActorEnum[selector]`")))?
             .clone();
@@ -2136,8 +2157,10 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             )));
         }
         self.validate_actor_type_initializer(name, expr, &selector)?;
-        self.ensure_selector_template(out, indent, name)?;
-        self.visible_selectors.insert(name.to_string());
+        self.materialize_selector_template(out, indent, &selector)?;
+        let id =
+            self.bindings.declare(name, BodyBinding::source_typed(format!("{}<{state}>", word::ACTOR_TYPE)).with_selector(selector));
+        self.bindings.mark_selector_materialized(id);
         Ok(())
     }
 
@@ -2165,15 +2188,23 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
     fn ensure_selector_template(&mut self, out: &mut String, indent: usize, selector_name: &str) -> Result<String> {
         let template_var = hidden_template_selector_template_name(selector_name);
-        if !self.materialized_selectors.insert(selector_name.to_string()) {
+        let (binding_id, selector) = self
+            .bindings
+            .selector(selector_name)
+            .map(|(id, selector)| (id, selector.clone()))
+            .ok_or_else(|| ArgentError::new(format!("unknown actor handle `{selector_name}`")))?;
+        if self.bindings.selector_is_materialized(binding_id) {
             return Ok(template_var);
         }
-        let selector = self
-            .selectors
-            .get(selector_name)
-            .ok_or_else(|| ArgentError::new(format!("unknown actor handle `{selector_name}`")))?
-            .clone();
-        let family = self.selector_family(&selector)?;
+        self.materialize_selector_template(out, indent, &selector)?;
+        self.bindings.mark_selector_materialized(binding_id);
+        Ok(template_var)
+    }
+
+    fn materialize_selector_template(&self, out: &mut String, indent: usize, selector: &TemplateSelector) -> Result<()> {
+        let selector_name = &selector.name;
+        let template_var = hidden_template_selector_template_name(selector_name);
+        let family = self.selector_family(selector)?;
         if !family.table_actors().starts_with(&selector.variants) {
             return Err(ArgentError::new(format!(
                 "actor enum `{}` order must prefix route family `{}` table order for selector lowering",
@@ -2197,7 +2228,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             "byte[32]",
             &[format!("{table}.slice({selector_var} * 32, {selector_var} * 32 + 32)")],
         );
-        Ok(template_var)
+        Ok(())
     }
 
     fn lower_become(&mut self, out: &mut String, indent: usize, routes: &[EntryRoute]) -> Result<()> {
@@ -2325,7 +2356,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         };
         let state_expr = route.state.trim();
         let packs_family = transition.is_some_and(|transition| !transition.families_to_pack.is_empty());
-        let state_arg = if !packs_family && self.types.get(state_expr).is_some_and(|ty| ty == &state_ty) {
+        let state_arg = if !packs_family && self.bindings.lowered_type(state_expr).is_some_and(|ty| ty == state_ty) {
             self.lower_expr(state_expr, Some(&state_ty), indent)?
         } else {
             let name = generated_state_name(&route, &state_ty);
@@ -2504,7 +2535,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         indent: usize,
     ) -> Result<String> {
         let expr = expr.trim();
-        if !force_materialization && self.types.get(expr).is_some_and(|ty| ty == state_ty) {
+        if !force_materialization && self.bindings.lowered_type(expr).is_some_and(|ty| ty == state_ty) {
             return self.lower_expr(expr, Some(state_ty), indent);
         }
         if let Some((source_state, body)) = split_state_constructor(expr) {
@@ -2517,7 +2548,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let source_state = if expr == "self.state" {
             Some(self.actor.state.as_str())
         } else {
-            self.source_types.get(expr).map(String::as_str).filter(|source_ty| self.model.has_state(source_ty))
+            self.bindings.source_type(expr).filter(|source_ty| self.model.has_state(source_ty))
         };
         if let Some(source_state) = source_state {
             if self.model.storage_state_name(source_state)? != self.model.storage_state_name(state_name)? {
@@ -2540,11 +2571,13 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
     }
 
     fn lower_route(&mut self, out: &mut String, indent: usize, route: RouteCall) -> Result<()> {
-        if self.visible_selectors.contains(&route.actor) {
+        if self.bindings.selector(&route.actor).is_some() {
             return self.lower_selector_route(out, indent, route);
         }
-        if self.selectors.contains_key(&route.actor) {
-            return Err(self.error(format!("actor handle `{}` is not visible in this scope", route.actor)));
+        if self.selector_catalog.contains_key(&route.actor) {
+            let reason =
+                if self.bindings.get(&route.actor).is_some() { "is shadowed by a non-selector binding" } else { "is not visible" };
+            return Err(self.error(format!("actor handle `{}` {reason} in this scope", route.actor)));
         }
         self.model.actor_state(&route.actor)?;
         let output_idx = hidden_output_idx_name(&route.output);
@@ -2569,8 +2602,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let state_ty = contract_state_type_for_actor(&route.actor, self.actor, self.model)?;
         let state_expr = route.state.trim();
         let packs_family = transition.is_some_and(|transition| !transition.families_to_pack.is_empty());
-        let already_materialized = self.materialized_route_locals.get(state_expr).is_some_and(|actor| actor == &route.actor);
-        let state_arg = if (!packs_family || already_materialized) && self.types.get(state_expr).is_some_and(|ty| ty == &state_ty) {
+        let state_arg = if !packs_family && self.bindings.lowered_type(state_expr).is_some_and(|ty| ty == state_ty) {
             self.lower_expr(state_expr, Some(&state_ty), indent)?
         } else {
             let name = generated_state_name(&route, &state_ty);
@@ -2626,8 +2658,9 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
     fn lower_selector_route(&mut self, out: &mut String, indent: usize, route: RouteCall) -> Result<()> {
         let selector = self
-            .selectors
-            .get(&route.actor)
+            .bindings
+            .selector(&route.actor)
+            .map(|(_, selector)| selector)
             .ok_or_else(|| ArgentError::new(format!("unknown actor handle `{}`", route.actor)))?
             .clone();
         let output_idx = hidden_output_idx_name(&route.output);
@@ -2643,7 +2676,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let state_ty = contract_state_type_for_actor(layout_actor, self.actor, self.model)?;
         let state_expr = route.state.trim();
         let packs_family = !transition.families_to_pack.is_empty();
-        let state_arg = if !packs_family && self.types.get(state_expr).is_some_and(|ty| ty == &state_ty) {
+        let state_arg = if !packs_family && self.bindings.lowered_type(state_expr).is_some_and(|ty| ty == state_ty) {
             self.lower_expr(state_expr, Some(&state_ty), indent)?
         } else {
             let name = generated_state_name(&route, &state_ty);
@@ -2719,7 +2752,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
     fn lower_digest_expr(&self, value: &str) -> Result<String> {
         let value = value.trim();
-        let state_name = self.source_types.get(value).ok_or_else(|| {
+        let state_name = self.bindings.source_type(value).ok_or_else(|| {
             ArgentError::new(format!("`digest(...)` requires a named state value, but `{value}` has no known source type"))
         })?;
         self.model.state(state_name)?;
@@ -2735,7 +2768,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         {
             return self.lower_state_object_for_state(&state_name, body, indent);
         }
-        if self.model.has_state(source_ty) && self.types.get(expr.trim()).is_none_or(|ty| ty != lowered_ty) {
+        if self.model.has_state(source_ty) && self.bindings.lowered_type(expr.trim()).is_none_or(|ty| ty != lowered_ty) {
             let lowered_expr = self.lower_expr(expr, None, indent)?;
             let fields = self
                 .model
@@ -2976,7 +3009,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
     fn lower_refs(&self, expr: &str) -> Result<String> {
         // Lower source-level co-spend calls before general reference rewrites.
-        let out = lower_co_spent_calls(expr, &self.source_types)?;
+        let out = lower_co_spent_calls(expr, &self.bindings)?;
         let out = self.ref_replacements.rewrite(&out)?;
         lower_actor_enum_literals(&out, self.model)
     }
@@ -5458,7 +5491,7 @@ fn entry_param_type_artifact(actor: &ActorDecl, ty: &TypeRef, model: &Model<'_>)
     }
 }
 
-fn lower_co_spent_calls(expr: &str, source_types: &BTreeMap<String, String>) -> Result<String> {
+fn lower_co_spent_calls(expr: &str, bindings: &BodyBindings) -> Result<String> {
     let method = format!(".{}", word::CO_SPENT);
     if !expr.contains(&method) {
         return Ok(expr.to_string());
@@ -5469,9 +5502,7 @@ fn lower_co_spent_calls(expr: &str, source_types: &BTreeMap<String, String>) -> 
     let mut cursor = 0usize;
     let mut pos = 0usize;
     while pos < tokens.len() {
-        if let Some((replacement_start, replacement_end, next_pos, covenant_id)) =
-            parse_co_spent_call(expr, &tokens, pos, source_types)?
-        {
+        if let Some((replacement_start, replacement_end, next_pos, covenant_id)) = parse_co_spent_call(expr, &tokens, pos, bindings)? {
             out.push_str(&expr[cursor..replacement_start]);
             out.push_str(&format!("OpCovInputCount({}) > 0", covenant_id.trim()));
             cursor = replacement_end;
@@ -5495,7 +5526,7 @@ fn lower_co_spent_calls(expr: &str, source_types: &BTreeMap<String, String>) -> 
     Ok(out)
 }
 
-fn co_spent_covenant_ids(expr: &str, source_types: &BTreeMap<String, String>) -> Result<Vec<String>> {
+fn co_spent_covenant_ids(expr: &str, bindings: &BodyBindings) -> Result<Vec<String>> {
     if !expr.contains(&format!(".{}", word::CO_SPENT)) {
         return Ok(Vec::new());
     }
@@ -5504,8 +5535,7 @@ fn co_spent_covenant_ids(expr: &str, source_types: &BTreeMap<String, String>) ->
     let mut ids = Vec::new();
     let mut pos = 0usize;
     while pos < tokens.len() {
-        if let Some((_replacement_start, _replacement_end, next_pos, covenant_id)) =
-            parse_co_spent_call(expr, &tokens, pos, source_types)?
+        if let Some((_replacement_start, _replacement_end, next_pos, covenant_id)) = parse_co_spent_call(expr, &tokens, pos, bindings)?
         {
             ids.push(covenant_id.trim().to_string());
             pos = next_pos;
@@ -5536,7 +5566,7 @@ fn parse_co_spent_call(
     expr: &str,
     tokens: &[Token],
     pos: usize,
-    source_types: &BTreeMap<String, String>,
+    bindings: &BodyBindings,
 ) -> Result<Option<(usize, usize, usize, String)>> {
     if is_ident(tokens, pos, word::COVENANT_ID) && is_symbol(tokens, pos + 1, '(') {
         let close = matching_symbol(tokens, pos + 1, '(', ')')
@@ -5563,7 +5593,7 @@ fn parse_co_spent_call(
         && is_symbol(tokens, pos + 4, ')')
     {
         let ident = expr[tokens[pos].span.start..tokens[pos].span.end].to_string();
-        if source_types.get(&ident).is_none_or(|ty| ty != word::COVENANT_ID) {
+        if bindings.source_type(&ident).is_none_or(|ty| ty != word::COVENANT_ID) {
             return Err(ArgentError::new(format!(
                 "`.{}()` is only available on `{}` values, found `{ident}`",
                 word::CO_SPENT,
@@ -9414,8 +9444,9 @@ mod tests {
             .expect("A receives an actor-qualified foreign state layout");
         assert!(actor_layout.contains("byte[32] gen__tail_a_template;"), "{source_sil}");
         assert!(!actor_layout.contains("gen__tail_b_template"), "{source_sil}");
-        assert!(source_sil.contains("Gen__AState next = {"), "{source_sil}");
-        assert!(!source_sil.contains("gen__state_a_gen__a_state"), "{source_sil}");
+        assert!(source_sil.contains("SharedState next = {"), "{source_sil}");
+        assert!(source_sil.contains("Gen__AState gen__state_next_gen__a_state = {"), "{source_sil}");
+        assert!(source_sil.contains("amount: next.amount,"), "{source_sil}");
         assert!(source_sil.contains("gen__tail_a_template: gen__tail_a_template,"), "{source_sil}");
         assert!(!source_sil.contains("gen__tail_b_template:"), "{source_sil}");
 
@@ -9921,7 +9952,7 @@ mod tests {
     }
 
     #[test]
-    fn route_neutral_state_locals_materialize_into_actor_layouts() {
+    fn route_neutral_state_locals_convert_at_actor_routes() {
         let straight_path = PathBuf::from("examples/route_state_bodies.ag");
         let straight_source = fs::read_to_string(&straight_path).expect("route state body example exists");
         let straight_module = crate::parser::parse_module(straight_path.clone(), straight_source.clone()).expect("example parses");
@@ -9930,10 +9961,13 @@ mod tests {
         let straight_sil = actor_sil_for_model(&straight_model);
 
         assert!(straight_sil["Lobby"].contains("struct BoardState {"), "{}", straight_sil["Lobby"]);
-        assert!(straight_sil["Lobby"].contains("Gen__MuxState next_board = {"), "{}", straight_sil["Lobby"]);
+        assert!(straight_sil["Lobby"].contains("BoardState next_board = {"), "{}", straight_sil["Lobby"]);
+        assert!(straight_sil["Lobby"].contains("Gen__MuxState gen__state_next_gen__mux_state = {"), "{}", straight_sil["Lobby"]);
         assert!(straight_sil["Mux"].contains("struct ArchiveState {"), "{}", straight_sil["Mux"]);
-        assert!(straight_sil["Mux"].contains("Gen__ArchiveState next_archive = {"), "{}", straight_sil["Mux"]);
-        assert!(straight_sil["Archive"].contains("Gen__PawnState next_board = {"), "{}", straight_sil["Archive"]);
+        assert!(straight_sil["Mux"].contains("ArchiveState next_archive = {"), "{}", straight_sil["Mux"]);
+        assert!(straight_sil["Mux"].contains("Gen__ArchiveState gen__state_next_gen__archive_state = {"), "{}", straight_sil["Mux"]);
+        assert!(straight_sil["Archive"].contains("BoardState next_board = {"), "{}", straight_sil["Archive"]);
+        assert!(straight_sil["Archive"].contains("Gen__PawnState gen__state_next_gen__pawn_state = {"), "{}", straight_sil["Archive"]);
 
         let choice_path = PathBuf::from("examples/route_state_body_choice.ag");
         let choice_source = fs::read_to_string(&choice_path).expect("route state body choice example exists");
@@ -10129,7 +10163,8 @@ mod tests {
         assert!(player_sil.contains("byte[] gen__mux_suffix,"), "{player_sil}");
         assert!(player_sil.contains("byte[64] gen__mux_routes"), "{player_sil}");
         assert!(player_sil.contains("require(blake2b(gen__mux_routes) == gen__mux_routes_digest);"), "{player_sil}");
-        assert!(player_sil.contains("Gen__MuxState next_board = {"), "{player_sil}");
+        assert!(player_sil.contains("BoardState next_board = {"), "{player_sil}");
+        assert!(player_sil.contains("Gen__MuxState gen__state_next_gen__mux_state = {"), "{player_sil}");
         assert!(!player_sil.contains("gen__pawn_template"), "{player_sil}");
         assert!(!player_sil.contains("gen__knight_template"), "{player_sil}");
 
@@ -11142,14 +11177,27 @@ mod tests {
                 int count;
             }
 
+            fn identity(int value) -> int {
+                return value;
+            }
+
             actor Counter owns CounterState {
-                entry inspect() emits none {
+                entry inspect(byte[4] packed) emits none {
                     CounterState snapshot = {
                         count: count,
                     };
                     {count: int copied} = snapshot;
                     {count: int current} = readInputState(this.activeInputIndex);
-                    require((copied == count) && (current == count));
+                    (byte[2] left, byte[2] right) = packed.split(2);
+                    byte[2] first, byte[2] second = packed.split(2);
+                    (int returned) = identity(count);
+                    require(
+                        (copied == count)
+                            && (current == count)
+                            && (left == first)
+                            && (right == second)
+                            && (returned == count)
+                    );
                 }
             }
 
@@ -11162,6 +11210,9 @@ mod tests {
         let sil = actor_sil.get("Counter").expect("Counter emits");
         assert!(sil.contains("{count: int copied} = snapshot;"), "{sil}");
         assert!(sil.contains("{count: int current} = readInputState(this.activeInputIndex);"), "{sil}");
+        assert!(sil.contains("(byte[2] left, byte[2] right) = packed.split(2);"), "{sil}");
+        assert!(sil.contains("byte[2] first, byte[2] second = packed.split(2);"), "{sil}");
+        assert!(sil.contains("(int returned) = identity(count);"), "{sil}");
     }
 
     #[test]

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -1697,6 +1697,15 @@ struct BodyLowerer<'a, 'm> {
     current_statement: Option<Span>,
 }
 
+/// Argent metadata restored when a nested Sil lexical scope ends.
+#[derive(Clone)]
+struct BodyScopeSnapshot {
+    types: BTreeMap<String, String>,
+    source_types: BTreeMap<String, String>,
+    materialized_selectors: BTreeSet<String>,
+    materialized_route_locals: BTreeMap<String, String>,
+}
+
 #[derive(Debug)]
 struct OutputValueRef {
     source: String,
@@ -1891,13 +1900,28 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
                 EntryStatement::Block { statements, .. } => {
                     push_indent(out, indent);
                     out.push_str("{\n");
-                    self.lower_statements(out, indent + 4, statements)?;
+                    self.lower_scoped_statements(out, indent + 4, statements)?;
                     push_indent(out, indent);
                     out.push_str("}\n");
                 }
             }
         }
         Ok(())
+    }
+
+    fn lower_scoped_statements(&mut self, out: &mut String, indent: usize, statements: &[EntryStatement]) -> Result<()> {
+        let outer = BodyScopeSnapshot {
+            types: self.types.clone(),
+            source_types: self.source_types.clone(),
+            materialized_selectors: self.materialized_selectors.clone(),
+            materialized_route_locals: self.materialized_route_locals.clone(),
+        };
+        let result = self.lower_statements(out, indent, statements);
+        self.types = outer.types;
+        self.source_types = outer.source_types;
+        self.materialized_selectors = outer.materialized_selectors;
+        self.materialized_route_locals = outer.materialized_route_locals;
+        result
     }
 
     fn lower_if(
@@ -1918,7 +1942,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
         let condition = self.entry.body.span_text(condition).trim();
         out.push_str(&format!("if ({}) {{\n", self.lower_expr(condition, None, indent)?));
         self.conditional_depth += 1;
-        self.lower_statements(out, indent + 4, then_statements)?;
+        self.lower_scoped_statements(out, indent + 4, then_statements)?;
         self.conditional_depth -= 1;
         push_indent(out, indent);
         out.push('}');
@@ -1935,7 +1959,7 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
             };
             out.push_str(" else {\n");
             self.conditional_depth += 1;
-            self.lower_statements(out, indent + 4, else_statements)?;
+            self.lower_scoped_statements(out, indent + 4, else_statements)?;
             self.conditional_depth -= 1;
             push_indent(out, indent);
             out.push('}');
@@ -1951,8 +1975,8 @@ impl<'a, 'm> BodyLowerer<'a, 'm> {
 
         self.conditional_depth += 1;
         match body {
-            EntryStatement::Block { statements, .. } => self.lower_statements(out, indent + 4, statements)?,
-            statement => self.lower_statements(out, indent + 4, std::slice::from_ref(statement))?,
+            EntryStatement::Block { statements, .. } => self.lower_scoped_statements(out, indent + 4, statements)?,
+            statement => self.lower_scoped_statements(out, indent + 4, std::slice::from_ref(statement))?,
         }
         self.conditional_depth -= 1;
 

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -11085,6 +11085,37 @@ mod tests {
     }
 
     #[test]
+    fn brace_leading_assignments_lower_and_compile_as_sil_statements() {
+        let (actor_sil, _) = inline_actor_sil_and_artifact(
+            "brace-leading-assignments",
+            r#"
+            state CounterState {
+                int count;
+            }
+
+            actor Counter owns CounterState {
+                entry inspect() emits none {
+                    CounterState snapshot = {
+                        count: count,
+                    };
+                    {count: int copied} = snapshot;
+                    {count: int current} = readInputState(this.activeInputIndex);
+                    require((copied == count) && (current == count));
+                }
+            }
+
+            app BraceLeadingAssignments {
+                actor Counter;
+            }
+            "#,
+        );
+
+        let sil = actor_sil.get("Counter").expect("Counter emits");
+        assert!(sil.contains("{count: int copied} = snapshot;"), "{sil}");
+        assert!(sil.contains("{count: int current} = readInputState(this.activeInputIndex);"), "{sil}");
+    }
+
+    #[test]
     fn genesis_spawn_lowers_to_pinned_sil_and_artifact_metadata() {
         let (controller_sil, controller_artifact) =
             emit_selected_fixture("tests/fixtures/runtime/context_genesis_spawn/app.ag", "ControllerApp", "Controller");

--- a/src/entry_body.rs
+++ b/src/entry_body.rs
@@ -52,6 +52,7 @@ impl Default for EntryBody {
 #[derive(Debug, Clone)]
 pub(crate) enum EntryStatement {
     If { condition: Span, then_branch: Box<EntryStatement>, else_branch: Option<Box<EntryStatement>>, span: Span },
+    For { header: Span, body: Box<EntryStatement>, span: Span },
     Block { statements: Vec<EntryStatement>, span: Span },
     Become { routes: Vec<EntryRoute>, span: Span },
     ValidateOutputsBecome { group: String, routes: Vec<EntryRoute>, span: Span },
@@ -62,6 +63,7 @@ impl EntryStatement {
     pub(crate) fn span(&self) -> Span {
         match self {
             Self::If { span, .. }
+            | Self::For { span, .. }
             | Self::Block { span, .. }
             | Self::Become { span, .. }
             | Self::ValidateOutputsBecome { span, .. }
@@ -198,6 +200,12 @@ impl EntryStatementParser<'_> {
                 if self.cursor.consume_ident(word::ELSE) { Some(Box::new(self.parse_block_or_statement()?)) } else { None };
             let end = else_branch.as_deref().unwrap_or(&then_branch).span().end;
             Ok(EntryStatement::If { condition, then_branch, else_branch, span: Span { start, end } })
+        } else if self.cursor.consume_ident(word::FOR) {
+            self.expect_symbol('(')?;
+            let header = self.cursor.take_balanced_after_open('(', ')').ok_or_else(|| self.error("unterminated `(` group"))?;
+            let body = Box::new(self.parse_block_or_statement()?);
+            let span = Span { start, end: body.span().end };
+            Ok(EntryStatement::For { header, body, span })
         } else if self.cursor.consume_ident(word::BECOME) {
             let routes = self.parse_become_tail()?;
             Ok(EntryStatement::Become { routes, span: self.cursor.consumed_span_from(start) })
@@ -443,6 +451,27 @@ mod tests {
         assert_eq!(body.span_text(*condition), "done");
         assert!(matches!(then_branch.as_ref(), EntryStatement::Block { .. }));
         assert!(matches!(else_branch.as_deref(), Some(EntryStatement::Block { .. })));
+    }
+
+    #[test]
+    fn statements_keep_for_structure_and_the_following_boundary() {
+        let body = EntryBody::new(
+            r#"
+            for (i, 0, count, MAX_COUNT) {
+                check(i);
+            }
+            require(done);
+            "#,
+        )
+        .expect("body lexes");
+
+        let [EntryStatement::For { header, body: loop_body, .. }, EntryStatement::Plain { span: following }] = body.statements()
+        else {
+            panic!("expected one for loop followed by one plain statement");
+        };
+        assert_eq!(body.span_text(*header), "i, 0, count, MAX_COUNT");
+        assert!(matches!(loop_body.as_ref(), EntryStatement::Block { .. }));
+        assert_eq!(body.span_text(*following).trim(), "require(done);");
     }
 
     #[test]

--- a/src/entry_body.rs
+++ b/src/entry_body.rs
@@ -37,7 +37,7 @@ impl EntryBody {
         &self.text[span.start..span.end]
     }
 
-    pub(crate) fn cursor(&self) -> EntryBodyCursor<'_> {
+    fn cursor(&self) -> EntryBodyCursor<'_> {
         EntryBodyCursor { body: self, pos: 0 }
     }
 }
@@ -48,34 +48,24 @@ impl Default for EntryBody {
     }
 }
 
-/// The structural statements Argent needs to understand before full Sil parsing.
+/// The structural statements Argent understands without parsing ordinary Sil statements.
 #[derive(Debug, Clone)]
 pub(crate) enum EntryStatement {
-    If {
-        // Kept for the lowering pass that will consume this structure next.
-        #[allow(dead_code)]
-        condition: Span,
-        then_branch: Box<EntryStatement>,
-        else_branch: Option<Box<EntryStatement>>,
-        span: Span,
-    },
-    Block {
-        statements: Vec<EntryStatement>,
-        span: Span,
-    },
-    Become {
-        routes: Vec<EntryRoute>,
-        span: Span,
-    },
-    Plain {
-        span: Span,
-    },
+    If { condition: Span, then_branch: Box<EntryStatement>, else_branch: Option<Box<EntryStatement>>, span: Span },
+    Block { statements: Vec<EntryStatement>, span: Span },
+    Become { routes: Vec<EntryRoute>, span: Span },
+    ValidateOutputsBecome { group: String, routes: Vec<EntryRoute>, span: Span },
+    Plain { span: Span },
 }
 
 impl EntryStatement {
     pub(crate) fn span(&self) -> Span {
         match self {
-            Self::If { span, .. } | Self::Block { span, .. } | Self::Become { span, .. } | Self::Plain { span } => *span,
+            Self::If { span, .. }
+            | Self::Block { span, .. }
+            | Self::Become { span, .. }
+            | Self::ValidateOutputsBecome { span, .. }
+            | Self::Plain { span } => *span,
         }
     }
 }
@@ -84,40 +74,40 @@ impl EntryStatement {
 #[derive(Debug, Clone)]
 pub(crate) struct EntryRoute {
     pub(crate) output: String,
-    pub(crate) actor: String,
+    pub(crate) actor: Span,
     pub(crate) state: Span,
 }
 
 /// Traverses a body's shared tokens while retaining access to their source text.
-pub(crate) struct EntryBodyCursor<'a> {
+struct EntryBodyCursor<'a> {
     body: &'a EntryBody,
     pos: usize,
 }
 
 impl<'a> EntryBodyCursor<'a> {
-    pub(crate) fn current(&self) -> &Token {
+    fn current(&self) -> &Token {
         &self.body.tokens[self.pos]
     }
 
-    pub(crate) fn peek_kind(&self, offset: usize) -> Option<&TokenKind> {
+    fn peek_kind(&self, offset: usize) -> Option<&TokenKind> {
         self.body.tokens.get(self.pos + offset).map(|token| &token.kind)
     }
 
-    pub(crate) fn advance(&mut self) {
+    fn advance(&mut self) {
         if !self.is_eof() {
             self.pos += 1;
         }
     }
 
-    pub(crate) fn is_eof(&self) -> bool {
+    fn is_eof(&self) -> bool {
         matches!(self.current().kind, TokenKind::Eof)
     }
 
-    pub(crate) fn check_ident(&self, expected: &str) -> bool {
+    fn check_ident(&self, expected: &str) -> bool {
         matches!(&self.current().kind, TokenKind::Ident(actual) if actual == expected)
     }
 
-    pub(crate) fn consume_ident(&mut self, expected: &str) -> bool {
+    fn consume_ident(&mut self, expected: &str) -> bool {
         if self.check_ident(expected) {
             self.advance();
             true
@@ -126,11 +116,11 @@ impl<'a> EntryBodyCursor<'a> {
         }
     }
 
-    pub(crate) fn check_symbol(&self, expected: char) -> bool {
+    fn check_symbol(&self, expected: char) -> bool {
         matches!(self.current().kind, TokenKind::Symbol(actual) if actual == expected)
     }
 
-    pub(crate) fn consume_symbol(&mut self, expected: char) -> bool {
+    fn consume_symbol(&mut self, expected: char) -> bool {
         if self.check_symbol(expected) {
             self.advance();
             true
@@ -140,7 +130,7 @@ impl<'a> EntryBodyCursor<'a> {
     }
 
     /// Takes the source span inside a group after its opening token was consumed.
-    pub(crate) fn take_balanced_after_open(&mut self, open: char, close: char) -> Option<Span> {
+    fn take_balanced_after_open(&mut self, open: char, close: char) -> Option<Span> {
         let start = self.current().span.start;
         let mut depth = 1usize;
         while !self.is_eof() {
@@ -164,11 +154,7 @@ impl<'a> EntryBodyCursor<'a> {
         None
     }
 
-    pub(crate) fn span_text(&self, span: Span) -> &'a str {
-        self.body.span_text(span)
-    }
-
-    pub(crate) fn span_to_current(&self, start: usize) -> Span {
+    fn span_to_current(&self, start: usize) -> Span {
         Span { start, end: self.byte_offset() }
     }
 
@@ -177,11 +163,11 @@ impl<'a> EntryBodyCursor<'a> {
         Span { start, end }
     }
 
-    pub(crate) fn byte_offset(&self) -> usize {
+    fn byte_offset(&self) -> usize {
         self.current().span.start
     }
 
-    pub(crate) fn remaining_text(&self) -> &'a str {
+    fn remaining_text(&self) -> &'a str {
         self.body.text.get(self.byte_offset()..).unwrap_or("")
     }
 }
@@ -215,6 +201,9 @@ impl EntryStatementParser<'_> {
         } else if self.cursor.consume_ident(word::BECOME) {
             let routes = self.parse_become_tail()?;
             Ok(EntryStatement::Become { routes, span: self.cursor.consumed_span_from(start) })
+        } else if self.check_outputs_become_start() {
+            let (group, routes) = self.parse_outputs_become()?;
+            Ok(EntryStatement::ValidateOutputsBecome { group, routes, span: self.cursor.consumed_span_from(start) })
         } else if self.cursor.consume_symbol('{') {
             self.parse_block_after_open(start)
         } else {
@@ -259,25 +248,60 @@ impl EntryStatementParser<'_> {
         Ok(vec![route])
     }
 
+    fn parse_outputs_become(&mut self) -> Result<(String, Vec<EntryRoute>)> {
+        self.expect_ident(word::REQUIRE)?;
+        let group = self.expect_any_ident()?;
+        self.expect_symbol('.')?;
+        self.expect_ident(word::OUTPUTS)?;
+        self.expect_ident(word::BECOME)?;
+        Ok((group, self.parse_become_tail()?))
+    }
+
     fn parse_route(&mut self) -> Result<EntryRoute> {
         let output = self.expect_any_ident()?;
         if !self.consume_left_arrow() {
             return Err(self.error("every `become` route must name its output with `output <- Actor(state)`"));
         }
-        let actor = self.parse_actor_name()?;
+        let actor = self.take_route_actor_expr()?;
 
         self.expect_symbol('(')?;
         let state = self.cursor.take_balanced_after_open('(', ')').ok_or_else(|| self.error("unterminated route state expression"))?;
         Ok(EntryRoute { output, actor, state })
     }
 
-    fn parse_actor_name(&mut self) -> Result<String> {
-        let first = self.expect_any_ident()?;
-        if !self.cursor.consume_symbol(':') {
-            return Ok(first);
+    fn take_route_actor_expr(&mut self) -> Result<Span> {
+        let start = self.cursor.byte_offset();
+        let mut depth = 0usize;
+        while !self.cursor.is_eof() {
+            match self.cursor.current().kind {
+                TokenKind::Symbol('(') if depth == 0 => {
+                    if self.cursor.byte_offset() == start {
+                        return Err(self.error("become target is empty"));
+                    }
+                    return Ok(self.cursor.span_to_current(start));
+                }
+                TokenKind::Symbol('{') | TokenKind::Symbol('[') | TokenKind::Symbol('<') => {
+                    depth += 1;
+                    self.cursor.advance();
+                }
+                TokenKind::Symbol('}') | TokenKind::Symbol(']') | TokenKind::Symbol('>') if depth > 0 => {
+                    depth -= 1;
+                    self.cursor.advance();
+                }
+                TokenKind::Symbol(',')
+                | TokenKind::Symbol(';')
+                | TokenKind::Symbol(')')
+                | TokenKind::Symbol('}')
+                | TokenKind::Symbol(']')
+                | TokenKind::Symbol('>')
+                    if depth == 0 =>
+                {
+                    return Err(self.error("expected `(` after become target"));
+                }
+                _ => self.cursor.advance(),
+            }
         }
-        self.expect_symbol(':')?;
-        Ok(format!("{first}::{}", self.expect_any_ident()?))
+        Err(self.error("unterminated become target"))
     }
 
     fn consume_left_arrow(&mut self) -> bool {
@@ -343,12 +367,24 @@ impl EntryStatementParser<'_> {
         if self.cursor.consume_symbol(expected) { Ok(()) } else { Err(self.error(format!("expected `{expected}`"))) }
     }
 
+    fn expect_ident(&mut self, expected: &str) -> Result<()> {
+        if self.cursor.consume_ident(expected) { Ok(()) } else { Err(self.error(format!("expected `{expected}`"))) }
+    }
+
     fn expect_list_separator_or_end(&mut self, end: char) -> Result<()> {
         if self.cursor.consume_symbol(',') || self.cursor.check_symbol(end) {
             Ok(())
         } else {
             Err(self.error(format!("expected `,` or `{end}`")))
         }
+    }
+
+    fn check_outputs_become_start(&self) -> bool {
+        matches!(&self.cursor.current().kind, TokenKind::Ident(actual) if actual == word::REQUIRE)
+            && matches!(self.cursor.peek_kind(1), Some(TokenKind::Ident(_)))
+            && matches!(self.cursor.peek_kind(2), Some(TokenKind::Symbol('.')))
+            && matches!(self.cursor.peek_kind(3), Some(TokenKind::Ident(actual)) if actual == word::OUTPUTS)
+            && matches!(self.cursor.peek_kind(4), Some(TokenKind::Ident(actual)) if actual == word::BECOME)
     }
 
     fn error(&self, message: impl Into<String>) -> crate::error::ArgentError {
@@ -369,7 +405,7 @@ mod tests {
         assert!(cursor.consume_ident("if"));
         assert!(cursor.consume_symbol('('));
         let span = cursor.take_balanced_after_open('(', ')').expect("condition closes");
-        assert_eq!(cursor.span_text(span), "outer(inner)");
+        assert_eq!(body.span_text(span), "outer(inner)");
         assert!(cursor.check_ident("become"));
     }
 
@@ -407,5 +443,46 @@ mod tests {
         assert_eq!(body.span_text(*condition), "done");
         assert!(matches!(then_branch.as_ref(), EntryStatement::Block { .. }));
         assert!(matches!(else_branch.as_deref(), Some(EntryStatement::Block { .. })));
+    }
+
+    #[test]
+    fn statements_keep_output_validation_and_dynamic_route_targets() {
+        let body = EntryBody::new(
+            r#"
+            require children.outputs become {
+                child <- self.child_type(next_child),
+            };
+            become next <- target(next_state);
+            "#,
+        )
+        .expect("body parses");
+
+        let [
+            EntryStatement::ValidateOutputsBecome { group, routes: validation_routes, .. },
+            EntryStatement::Become { routes: become_routes, .. },
+        ] = body.statements()
+        else {
+            panic!("expected output validation followed by become");
+        };
+        assert_eq!(group, "children");
+        assert_eq!(body.span_text(validation_routes[0].actor).trim(), "self.child_type");
+        assert_eq!(body.span_text(validation_routes[0].state).trim(), "next_child");
+        assert_eq!(body.span_text(become_routes[0].actor).trim(), "target");
+        assert_eq!(body.span_text(become_routes[0].state).trim(), "next_state");
+    }
+
+    #[test]
+    fn route_target_does_not_cross_a_route_separator() {
+        let err = EntryBody::new(
+            r#"
+            become {
+                first <- A,
+                second <- B(next),
+            };
+            "#,
+        )
+        .expect_err("a route target without state arguments must not consume the next route");
+
+        assert!(err.to_string().contains("expected `(` after become target"), "unexpected error: {err}");
     }
 }

--- a/src/entry_body.rs
+++ b/src/entry_body.rs
@@ -207,6 +207,9 @@ impl EntryStatementParser<'_> {
     fn parse_sequence(&mut self, end: Option<char>) -> Result<Vec<EntryStatement>> {
         let mut statements = Vec::new();
         while !self.cursor.is_eof() && !end.is_some_and(|symbol| self.cursor.check_symbol(symbol)) {
+            if self.cursor.check_symbol('}') {
+                return Err(self.error("unexpected `}`"));
+            }
             if self.cursor.consume_symbol(';') {
                 continue;
             }
@@ -563,5 +566,12 @@ mod tests {
         .expect_err("a route target without state arguments must not consume the next route");
 
         assert!(err.to_string().contains("expected `(` after become target"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn unexpected_closing_brace_is_rejected() {
+        let err = EntryBody::new("}").expect_err("an unmatched closing brace must be rejected");
+
+        assert!(err.to_string().contains("unexpected `}`"), "unexpected error: {err}");
     }
 }

--- a/src/entry_body.rs
+++ b/src/entry_body.rs
@@ -1,20 +1,24 @@
 //! Canonical source text and tokens for an Argent entry body.
 
 use crate::error::Result;
+use crate::language::word;
 use crate::lexer::{Span, Token, TokenKind, lex};
 
-/// Keeps one token stream shared by body analysis and lowering.
+/// Keeps source, tokens, and structural body syntax together.
 #[derive(Debug, Clone)]
 pub struct EntryBody {
     text: String,
     tokens: Vec<Token>,
+    statements: Vec<EntryStatement>,
 }
 
 impl EntryBody {
     pub fn new(text: impl Into<String>) -> Result<Self> {
         let text = text.into();
         let tokens = lex(&text)?;
-        Ok(Self { text, tokens })
+        let mut body = Self { text, tokens, statements: Vec::new() };
+        body.statements = EntryStatementParser { cursor: body.cursor() }.parse_sequence(None)?;
+        Ok(body)
     }
 
     pub fn text(&self) -> &str {
@@ -23,6 +27,14 @@ impl EntryBody {
 
     pub fn tokens(&self) -> &[Token] {
         &self.tokens
+    }
+
+    pub(crate) fn statements(&self) -> &[EntryStatement] {
+        &self.statements
+    }
+
+    pub(crate) fn span_text(&self, span: Span) -> &str {
+        &self.text[span.start..span.end]
     }
 
     pub(crate) fn cursor(&self) -> EntryBodyCursor<'_> {
@@ -34,6 +46,46 @@ impl Default for EntryBody {
     fn default() -> Self {
         Self::new(String::new()).expect("empty entry body lexes")
     }
+}
+
+/// The structural statements Argent needs to understand before full Sil parsing.
+#[derive(Debug, Clone)]
+pub(crate) enum EntryStatement {
+    If {
+        // Kept for the lowering pass that will consume this structure next.
+        #[allow(dead_code)]
+        condition: Span,
+        then_branch: Box<EntryStatement>,
+        else_branch: Option<Box<EntryStatement>>,
+        span: Span,
+    },
+    Block {
+        statements: Vec<EntryStatement>,
+        span: Span,
+    },
+    Become {
+        routes: Vec<EntryRoute>,
+        span: Span,
+    },
+    Plain {
+        span: Span,
+    },
+}
+
+impl EntryStatement {
+    pub(crate) fn span(&self) -> Span {
+        match self {
+            Self::If { span, .. } | Self::Block { span, .. } | Self::Become { span, .. } | Self::Plain { span } => *span,
+        }
+    }
+}
+
+/// One parsed route in a `become` statement.
+#[derive(Debug, Clone)]
+pub(crate) struct EntryRoute {
+    pub(crate) output: String,
+    pub(crate) actor: String,
+    pub(crate) state: Span,
 }
 
 /// Traverses a body's shared tokens while retaining access to their source text.
@@ -113,11 +165,16 @@ impl<'a> EntryBodyCursor<'a> {
     }
 
     pub(crate) fn span_text(&self, span: Span) -> &'a str {
-        &self.body.text[span.start..span.end]
+        self.body.span_text(span)
     }
 
     pub(crate) fn span_to_current(&self, start: usize) -> Span {
         Span { start, end: self.byte_offset() }
+    }
+
+    fn consumed_span_from(&self, start: usize) -> Span {
+        let end = self.pos.checked_sub(1).and_then(|previous| self.body.tokens.get(previous)).map_or(start, |token| token.span.end);
+        Span { start, end }
     }
 
     pub(crate) fn byte_offset(&self) -> usize {
@@ -129,9 +186,180 @@ impl<'a> EntryBodyCursor<'a> {
     }
 }
 
+struct EntryStatementParser<'a> {
+    cursor: EntryBodyCursor<'a>,
+}
+
+impl EntryStatementParser<'_> {
+    fn parse_sequence(&mut self, end: Option<char>) -> Result<Vec<EntryStatement>> {
+        let mut statements = Vec::new();
+        while !self.cursor.is_eof() && !end.is_some_and(|symbol| self.cursor.check_symbol(symbol)) {
+            if self.cursor.consume_symbol(';') {
+                continue;
+            }
+            statements.push(self.parse_statement()?);
+        }
+        Ok(statements)
+    }
+
+    fn parse_statement(&mut self) -> Result<EntryStatement> {
+        let start = self.cursor.byte_offset();
+        if self.cursor.consume_ident(word::IF) {
+            self.expect_symbol('(')?;
+            let condition = self.cursor.take_balanced_after_open('(', ')').ok_or_else(|| self.error("unterminated `(` group"))?;
+            let then_branch = Box::new(self.parse_block_or_statement()?);
+            let else_branch =
+                if self.cursor.consume_ident(word::ELSE) { Some(Box::new(self.parse_block_or_statement()?)) } else { None };
+            let end = else_branch.as_deref().unwrap_or(&then_branch).span().end;
+            Ok(EntryStatement::If { condition, then_branch, else_branch, span: Span { start, end } })
+        } else if self.cursor.consume_ident(word::BECOME) {
+            let routes = self.parse_become_tail()?;
+            Ok(EntryStatement::Become { routes, span: self.cursor.consumed_span_from(start) })
+        } else if self.cursor.consume_symbol('{') {
+            self.parse_block_after_open(start)
+        } else {
+            self.skip_until_statement_end()?;
+            Ok(EntryStatement::Plain { span: self.cursor.consumed_span_from(start) })
+        }
+    }
+
+    fn parse_block_or_statement(&mut self) -> Result<EntryStatement> {
+        if self.cursor.check_symbol('{') {
+            let start = self.cursor.byte_offset();
+            self.cursor.advance();
+            self.parse_block_after_open(start)
+        } else {
+            self.parse_statement()
+        }
+    }
+
+    fn parse_block_after_open(&mut self, start: usize) -> Result<EntryStatement> {
+        let statements = self.parse_sequence(Some('}'))?;
+        self.expect_symbol('}')?;
+        Ok(EntryStatement::Block { statements, span: self.cursor.consumed_span_from(start) })
+    }
+
+    fn parse_become_tail(&mut self) -> Result<Vec<EntryRoute>> {
+        if self.cursor.consume_symbol('{') {
+            let mut routes = Vec::new();
+            while !self.cursor.check_symbol('}') && !self.cursor.is_eof() {
+                if self.cursor.check_ident(word::BECOME) {
+                    return Err(self.error("nested `become` blocks are not supported yet"));
+                }
+                routes.push(self.parse_route()?);
+                self.expect_list_separator_or_end('}')?;
+            }
+            self.expect_symbol('}')?;
+            self.cursor.consume_symbol(';');
+            return Ok(routes);
+        }
+
+        let route = self.parse_route()?;
+        self.cursor.consume_symbol(';');
+        Ok(vec![route])
+    }
+
+    fn parse_route(&mut self) -> Result<EntryRoute> {
+        let output = self.expect_any_ident()?;
+        if !self.consume_left_arrow() {
+            return Err(self.error("every `become` route must name its output with `output <- Actor(state)`"));
+        }
+        let actor = self.parse_actor_name()?;
+
+        self.expect_symbol('(')?;
+        let state = self.cursor.take_balanced_after_open('(', ')').ok_or_else(|| self.error("unterminated route state expression"))?;
+        Ok(EntryRoute { output, actor, state })
+    }
+
+    fn parse_actor_name(&mut self) -> Result<String> {
+        let first = self.expect_any_ident()?;
+        if !self.cursor.consume_symbol(':') {
+            return Ok(first);
+        }
+        self.expect_symbol(':')?;
+        Ok(format!("{first}::{}", self.expect_any_ident()?))
+    }
+
+    fn consume_left_arrow(&mut self) -> bool {
+        match self.cursor.current().kind {
+            TokenKind::LeftArrow => {
+                self.cursor.advance();
+                true
+            }
+            TokenKind::Symbol('<') if matches!(self.cursor.peek_kind(1), Some(TokenKind::Symbol('-'))) => {
+                self.cursor.advance();
+                self.cursor.advance();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn expect_any_ident(&mut self) -> Result<String> {
+        match self.cursor.current().kind.clone() {
+            TokenKind::Ident(name) => {
+                self.cursor.advance();
+                Ok(name)
+            }
+            _ => Err(self.error("expected identifier in `become` route")),
+        }
+    }
+
+    fn skip_until_statement_end(&mut self) -> Result<()> {
+        while !self.cursor.is_eof() {
+            match self.cursor.current().kind {
+                TokenKind::Symbol(';') => {
+                    self.cursor.advance();
+                    return Ok(());
+                }
+                TokenKind::Symbol('{') => {
+                    self.cursor.advance();
+                    self.skip_balanced_after_open('{', '}')?;
+                }
+                TokenKind::Symbol('(') => {
+                    self.cursor.advance();
+                    self.skip_balanced_after_open('(', ')')?;
+                }
+                TokenKind::Symbol('[') => {
+                    self.cursor.advance();
+                    self.skip_balanced_after_open('[', ']')?;
+                }
+                TokenKind::Symbol('}') => return Ok(()),
+                _ => self.cursor.advance(),
+            }
+        }
+        Ok(())
+    }
+
+    fn skip_balanced_after_open(&mut self, open: char, close: char) -> Result<()> {
+        if self.cursor.take_balanced_after_open(open, close).is_some() {
+            Ok(())
+        } else {
+            Err(self.error(format!("unterminated `{open}` group")))
+        }
+    }
+
+    fn expect_symbol(&mut self, expected: char) -> Result<()> {
+        if self.cursor.consume_symbol(expected) { Ok(()) } else { Err(self.error(format!("expected `{expected}`"))) }
+    }
+
+    fn expect_list_separator_or_end(&mut self, end: char) -> Result<()> {
+        if self.cursor.consume_symbol(',') || self.cursor.check_symbol(end) {
+            Ok(())
+        } else {
+            Err(self.error(format!("expected `,` or `{end}`")))
+        }
+    }
+
+    fn error(&self, message: impl Into<String>) -> crate::error::ArgentError {
+        let preview = self.cursor.remaining_text().lines().next().unwrap_or("").trim().chars().take(80).collect::<String>();
+        crate::error::ArgentError::new(format!("{} at body byte {} near `{}`", message.into(), self.cursor.byte_offset(), preview))
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::EntryBody;
+    use super::{EntryBody, EntryStatement, lex};
 
     #[test]
     fn cursor_takes_nested_balanced_source() {
@@ -147,11 +375,37 @@ mod tests {
 
     #[test]
     fn cursor_returns_none_for_an_unterminated_group() {
-        let body = EntryBody::new("(state").expect("body lexes");
+        let text = "(state".to_string();
+        let body = EntryBody { tokens: lex(&text).expect("body lexes"), text, statements: Vec::new() };
         let mut cursor = body.cursor();
 
         assert!(cursor.consume_symbol('('));
         assert_eq!(cursor.take_balanced_after_open('(', ')'), None);
         assert!(cursor.is_eof());
+    }
+
+    #[test]
+    fn statements_keep_structure_and_source_spans() {
+        let body = EntryBody::new(
+            r#"
+            int next = value;
+            if (done) {
+                become output <- Done(next);
+            } else {
+                become output <- Live(next);
+            }
+            "#,
+        )
+        .expect("body lexes");
+
+        let [EntryStatement::Plain { span: plain }, EntryStatement::If { condition, then_branch, else_branch, .. }] =
+            body.statements()
+        else {
+            panic!("expected one plain statement followed by an if");
+        };
+        assert_eq!(body.span_text(*plain).trim(), "int next = value;");
+        assert_eq!(body.span_text(*condition), "done");
+        assert!(matches!(then_branch.as_ref(), EntryStatement::Block { .. }));
+        assert!(matches!(else_branch.as_deref(), Some(EntryStatement::Block { .. })));
     }
 }

--- a/src/entry_body.rs
+++ b/src/entry_body.rs
@@ -172,6 +172,31 @@ impl<'a> EntryBodyCursor<'a> {
     fn remaining_text(&self) -> &'a str {
         self.body.text.get(self.byte_offset()..).unwrap_or("")
     }
+
+    /// Distinguishes Sil destructuring assignments from standalone blocks.
+    fn check_braced_assignment_start(&self) -> bool {
+        if !self.check_symbol('{') {
+            return false;
+        }
+        let mut depth = 0usize;
+        for (offset, token) in self.body.tokens[self.pos..].iter().enumerate() {
+            match token.kind {
+                TokenKind::Symbol('{') => depth += 1,
+                TokenKind::Symbol('}') => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return matches!(
+                            self.body.tokens.get(self.pos + offset + 1).map(|token| &token.kind),
+                            Some(TokenKind::Symbol('='))
+                        );
+                    }
+                }
+                TokenKind::Eof => return false,
+                _ => {}
+            }
+        }
+        false
+    }
 }
 
 struct EntryStatementParser<'a> {
@@ -212,6 +237,9 @@ impl EntryStatementParser<'_> {
         } else if self.check_outputs_become_start() {
             let (group, routes) = self.parse_outputs_become()?;
             Ok(EntryStatement::ValidateOutputsBecome { group, routes, span: self.cursor.consumed_span_from(start) })
+        } else if self.cursor.check_braced_assignment_start() {
+            self.skip_until_statement_end()?;
+            Ok(EntryStatement::Plain { span: self.cursor.consumed_span_from(start) })
         } else if self.cursor.consume_symbol('{') {
             self.parse_block_after_open(start)
         } else {
@@ -472,6 +500,28 @@ mod tests {
         assert_eq!(body.span_text(*header), "i, 0, count, MAX_COUNT");
         assert!(matches!(loop_body.as_ref(), EntryStatement::Block { .. }));
         assert_eq!(body.span_text(*following).trim(), "require(done);");
+    }
+
+    #[test]
+    fn statements_distinguish_brace_assignments_from_standalone_blocks() {
+        let body = EntryBody::new(
+            r#"
+            {left: int first, right: int second} = pair;
+            {count: int current} = readInputState(index);
+            {
+                require(first == current);
+            }
+            "#,
+        )
+        .expect("body lexes");
+
+        let [EntryStatement::Plain { span: destructure }, EntryStatement::Plain { span: state_read }, EntryStatement::Block { .. }] =
+            body.statements()
+        else {
+            panic!("expected two brace assignments followed by one standalone block");
+        };
+        assert_eq!(body.span_text(*destructure).trim(), "{left: int first, right: int second} = pair;");
+        assert_eq!(body.span_text(*state_read).trim(), "{count: int current} = readInputState(index);");
     }
 
     #[test]

--- a/src/entry_body.rs
+++ b/src/entry_body.rs
@@ -52,11 +52,11 @@ impl Default for EntryBody {
 #[derive(Debug, Clone)]
 pub(crate) enum EntryStatement {
     If { condition: Span, then_branch: Box<EntryStatement>, else_branch: Option<Box<EntryStatement>>, span: Span },
-    For { header: Span, body: Box<EntryStatement>, span: Span },
+    For { binding: EntryBinding, header: Span, body: Box<EntryStatement>, span: Span },
     Block { statements: Vec<EntryStatement>, span: Span },
     Become { routes: Vec<EntryRoute>, span: Span },
     ValidateOutputsBecome { group: String, routes: Vec<EntryRoute>, span: Span },
-    Plain { span: Span },
+    Plain { bindings: Vec<EntryBinding>, span: Span },
 }
 
 impl EntryStatement {
@@ -67,9 +67,16 @@ impl EntryStatement {
             | Self::Block { span, .. }
             | Self::Become { span, .. }
             | Self::ValidateOutputsBecome { span, .. }
-            | Self::Plain { span } => *span,
+            | Self::Plain { span, .. } => *span,
         }
     }
+}
+
+/// One lexically scoped value introduced by ordinary Sil syntax.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EntryBinding {
+    pub(crate) name: String,
+    pub(crate) source_type: String,
 }
 
 /// One parsed route in a `become` statement.
@@ -219,6 +226,7 @@ impl EntryStatementParser<'_> {
     }
 
     fn parse_statement(&mut self) -> Result<EntryStatement> {
+        let token_start = self.cursor.pos;
         let start = self.cursor.byte_offset();
         if self.cursor.consume_ident(word::IF) {
             self.expect_symbol('(')?;
@@ -230,10 +238,14 @@ impl EntryStatementParser<'_> {
             Ok(EntryStatement::If { condition, then_branch, else_branch, span: Span { start, end } })
         } else if self.cursor.consume_ident(word::FOR) {
             self.expect_symbol('(')?;
+            let binding = match self.cursor.current().kind.clone() {
+                TokenKind::Ident(name) => EntryBinding { name, source_type: "int".to_string() },
+                _ => return Err(self.error("expected loop binding identifier")),
+            };
             let header = self.cursor.take_balanced_after_open('(', ')').ok_or_else(|| self.error("unterminated `(` group"))?;
             let body = Box::new(self.parse_block_or_statement()?);
             let span = Span { start, end: body.span().end };
-            Ok(EntryStatement::For { header, body, span })
+            Ok(EntryStatement::For { binding, header, body, span })
         } else if self.cursor.consume_ident(word::BECOME) {
             let routes = self.parse_become_tail()?;
             Ok(EntryStatement::Become { routes, span: self.cursor.consumed_span_from(start) })
@@ -242,13 +254,19 @@ impl EntryStatementParser<'_> {
             Ok(EntryStatement::ValidateOutputsBecome { group, routes, span: self.cursor.consumed_span_from(start) })
         } else if self.cursor.check_braced_assignment_start() {
             self.skip_until_statement_end()?;
-            Ok(EntryStatement::Plain { span: self.cursor.consumed_span_from(start) })
+            Ok(self.plain_statement(token_start, start))
         } else if self.cursor.consume_symbol('{') {
             self.parse_block_after_open(start)
         } else {
             self.skip_until_statement_end()?;
-            Ok(EntryStatement::Plain { span: self.cursor.consumed_span_from(start) })
+            Ok(self.plain_statement(token_start, start))
         }
+    }
+
+    fn plain_statement(&self, token_start: usize, byte_start: usize) -> EntryStatement {
+        let span = self.cursor.consumed_span_from(byte_start);
+        let bindings = PlainBindingParser::new(self.cursor.body, &self.cursor.body.tokens[token_start..self.cursor.pos]).parse();
+        EntryStatement::Plain { bindings, span }
     }
 
     fn parse_block_or_statement(&mut self) -> Result<EntryStatement> {
@@ -432,9 +450,153 @@ impl EntryStatementParser<'_> {
     }
 }
 
+/// Recognizes the binding surfaces of ordinary Sil statements while leaving
+/// their expressions and semantics to Silverscript.
+struct PlainBindingParser<'a> {
+    body: &'a EntryBody,
+    tokens: &'a [Token],
+    pos: usize,
+}
+
+impl<'a> PlainBindingParser<'a> {
+    fn new(body: &'a EntryBody, tokens: &'a [Token]) -> Self {
+        Self { body, tokens, pos: 0 }
+    }
+
+    fn parse(mut self) -> Vec<EntryBinding> {
+        if self.consume_symbol('{') {
+            return self.parse_struct_bindings().unwrap_or_default();
+        }
+        if self.consume_symbol('(') {
+            return self.parse_parenthesized_bindings().unwrap_or_default();
+        }
+        self.parse_leading_bindings().unwrap_or_default()
+    }
+
+    fn parse_struct_bindings(&mut self) -> Option<Vec<EntryBinding>> {
+        let mut bindings = Vec::new();
+        loop {
+            self.take_ident()?;
+            self.consume_symbol(':').then_some(())?;
+            bindings.push(self.parse_typed_binding()?);
+            if self.consume_symbol('}') {
+                break;
+            }
+            self.consume_symbol(',').then_some(())?;
+            if self.consume_symbol('}') {
+                break;
+            }
+        }
+        self.consume_symbol('=').then_some(bindings)
+    }
+
+    fn parse_parenthesized_bindings(&mut self) -> Option<Vec<EntryBinding>> {
+        let mut bindings = vec![self.parse_typed_binding()?];
+        while self.consume_symbol(',') {
+            if self.check_symbol(')') {
+                break;
+            }
+            bindings.push(self.parse_typed_binding()?);
+        }
+        self.consume_symbol(')').then_some(())?;
+        self.consume_symbol('=').then_some(bindings)
+    }
+
+    fn parse_leading_bindings(&mut self) -> Option<Vec<EntryBinding>> {
+        if self.check_ident("return") {
+            return None;
+        }
+        let first = self.parse_variable_binding()?;
+        if self.consume_symbol(',') {
+            let second = self.parse_typed_binding()?;
+            return self.consume_symbol('=').then_some(vec![first, second]);
+        }
+        (self.check_symbol('=') || self.check_symbol(';')).then_some(vec![first])
+    }
+
+    fn parse_variable_binding(&mut self) -> Option<EntryBinding> {
+        let source_type = self.parse_type()?;
+        while self.consume_ident("constant") {}
+        let name = self.take_ident()?;
+        Some(EntryBinding { name, source_type })
+    }
+
+    fn parse_typed_binding(&mut self) -> Option<EntryBinding> {
+        let source_type = self.parse_type()?;
+        let name = self.take_ident()?;
+        Some(EntryBinding { name, source_type })
+    }
+
+    fn parse_type(&mut self) -> Option<String> {
+        let start = self.current()?.span.start;
+        let base = self.take_ident()?;
+        if base == word::ACTOR_TYPE && self.consume_symbol('<') {
+            self.take_ident()?;
+            self.consume_symbol('>').then_some(())?;
+        }
+        while self.consume_symbol('[') {
+            while !self.check_symbol(']') {
+                self.advance()?;
+            }
+            self.consume_symbol(']').then_some(())?;
+        }
+        let end = self.tokens.get(self.pos.checked_sub(1)?)?.span.end;
+        Some(self.body.text[start..end].to_string())
+    }
+
+    fn current(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn advance(&mut self) -> Option<()> {
+        self.current()?;
+        self.pos += 1;
+        Some(())
+    }
+
+    fn check_ident(&self, expected: &str) -> bool {
+        matches!(self.current().map(|token| &token.kind), Some(TokenKind::Ident(actual)) if actual == expected)
+    }
+
+    fn consume_ident(&mut self, expected: &str) -> bool {
+        if self.check_ident(expected) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn take_ident(&mut self) -> Option<String> {
+        let TokenKind::Ident(name) = &self.current()?.kind else {
+            return None;
+        };
+        let name = name.clone();
+        self.pos += 1;
+        Some(name)
+    }
+
+    fn check_symbol(&self, expected: char) -> bool {
+        matches!(self.current().map(|token| &token.kind), Some(TokenKind::Symbol(actual)) if *actual == expected)
+    }
+
+    fn consume_symbol(&mut self, expected: char) -> bool {
+        if self.check_symbol(expected) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{EntryBody, EntryStatement, lex};
+    use super::{EntryBinding, EntryBody, EntryStatement, lex};
+
+    fn binding(name: &str, source_type: &str) -> EntryBinding {
+        EntryBinding { name: name.to_string(), source_type: source_type.to_string() }
+    }
 
     #[test]
     fn cursor_takes_nested_balanced_source() {
@@ -473,7 +635,7 @@ mod tests {
         )
         .expect("body lexes");
 
-        let [EntryStatement::Plain { span: plain }, EntryStatement::If { condition, then_branch, else_branch, .. }] =
+        let [EntryStatement::Plain { span: plain, .. }, EntryStatement::If { condition, then_branch, else_branch, .. }] =
             body.statements()
         else {
             panic!("expected one plain statement followed by an if");
@@ -496,13 +658,52 @@ mod tests {
         )
         .expect("body lexes");
 
-        let [EntryStatement::For { header, body: loop_body, .. }, EntryStatement::Plain { span: following }] = body.statements()
+        let [
+            EntryStatement::For { binding: loop_binding, header, body: loop_body, .. },
+            EntryStatement::Plain { span: following, .. },
+        ] = body.statements()
         else {
             panic!("expected one for loop followed by one plain statement");
         };
+        assert_eq!(loop_binding, &binding("i", "int"));
         assert_eq!(body.span_text(*header), "i, 0, count, MAX_COUNT");
         assert!(matches!(loop_body.as_ref(), EntryStatement::Block { .. }));
         assert_eq!(body.span_text(*following).trim(), "require(done);");
+    }
+
+    #[test]
+    fn plain_statements_record_sil_bindings() {
+        let body = EntryBody::new(
+            r#"
+            int value = 1;
+            byte[32] constant hash = digest;
+            (int left, bool right,) = pair();
+            int first, int second = pair();
+            {item: int unpacked, hash: byte[32] unpacked_hash,} = state;
+            require(value == first);
+            value = second;
+            return value;
+            "#,
+        )
+        .expect("body parses");
+
+        let expected = [
+            vec![binding("value", "int")],
+            vec![binding("hash", "byte[32]")],
+            vec![binding("left", "int"), binding("right", "bool")],
+            vec![binding("first", "int"), binding("second", "int")],
+            vec![binding("unpacked", "int"), binding("unpacked_hash", "byte[32]")],
+            vec![],
+            vec![],
+            vec![],
+        ];
+        assert_eq!(body.statements().len(), expected.len());
+        for (statement, expected) in body.statements().iter().zip(expected) {
+            let EntryStatement::Plain { bindings, .. } = statement else {
+                panic!("expected a plain statement");
+            };
+            assert_eq!(bindings, &expected);
+        }
     }
 
     #[test]
@@ -518,8 +719,11 @@ mod tests {
         )
         .expect("body lexes");
 
-        let [EntryStatement::Plain { span: destructure }, EntryStatement::Plain { span: state_read }, EntryStatement::Block { .. }] =
-            body.statements()
+        let [
+            EntryStatement::Plain { span: destructure, .. },
+            EntryStatement::Plain { span: state_read, .. },
+            EntryStatement::Block { .. },
+        ] = body.statements()
         else {
             panic!("expected two brace assignments followed by one standalone block");
         };

--- a/src/entry_routes.rs
+++ b/src/entry_routes.rs
@@ -98,6 +98,13 @@ fn analyze_statement(body: &EntryBody, statement: &EntryStatement) -> Result<Ter
         EntryStatement::Become { routes, .. } => {
             Ok(TerminalInfo::terminal(routes.iter().map(|route| route_call(body, route)).collect()))
         }
+        EntryStatement::For { body: loop_body, .. } => {
+            let result = analyze_statement(body, loop_body)?;
+            if result.info.contains_become {
+                return Err(body_error(body, loop_body.span().start, "`become` cannot be nested in a `for` loop"));
+            }
+            Ok(TerminalResult::empty())
+        }
         EntryStatement::Block { statements, span } => analyze_sequence(body, statements, span.end.saturating_sub(1)),
         EntryStatement::ValidateOutputsBecome { .. } | EntryStatement::Plain { .. } => Ok(TerminalResult::empty()),
     }
@@ -207,6 +214,20 @@ mod tests {
         .expect_err("one-sided conditional become must be rejected");
 
         assert!(err.to_string().contains("explicit `else`"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_become_nested_in_for_loop() {
+        let err = collect_routes(
+            r#"
+            for (i, 0, count, MAX_COUNT) {
+                become next <- Done(states[i]);
+            }
+            "#,
+        )
+        .expect_err("a loop cannot provide one terminal route for the entry");
+
+        assert!(err.to_string().contains("cannot be nested in a `for` loop"), "unexpected error: {err}");
     }
 
     #[test]

--- a/src/entry_routes.rs
+++ b/src/entry_routes.rs
@@ -99,12 +99,16 @@ fn analyze_statement(body: &EntryBody, statement: &EntryStatement) -> Result<Ter
             Ok(TerminalInfo::terminal(routes.iter().map(|route| route_call(body, route)).collect()))
         }
         EntryStatement::Block { statements, span } => analyze_sequence(body, statements, span.end.saturating_sub(1)),
-        EntryStatement::Plain { .. } => Ok(TerminalResult::empty()),
+        EntryStatement::ValidateOutputsBecome { .. } | EntryStatement::Plain { .. } => Ok(TerminalResult::empty()),
     }
 }
 
 fn route_call(body: &EntryBody, route: &EntryRoute) -> RouteCall {
-    RouteCall { output: route.output.clone(), actor: route.actor.clone(), state: body.span_text(route.state).trim().to_string() }
+    RouteCall {
+        output: route.output.clone(),
+        actor: body.span_text(route.actor).trim().to_string(),
+        state: body.span_text(route.state).trim().to_string(),
+    }
 }
 
 fn body_error(body: &EntryBody, byte_offset: usize, message: &str) -> crate::error::ArgentError {

--- a/src/entry_routes.rs
+++ b/src/entry_routes.rs
@@ -1,10 +1,8 @@
 //! Extracts body routes and verifies that every `become` is terminal.
 
 use crate::ast::{EntryBody, RouteCall};
-use crate::entry_body::EntryBodyCursor;
-use crate::error::{ArgentError, Result};
-use crate::language::word;
-use crate::lexer::TokenKind;
+use crate::entry_body::{EntryRoute, EntryStatement};
+use crate::error::Result;
 
 #[derive(Debug, Clone)]
 pub struct RouteAnalysis {
@@ -21,14 +19,9 @@ pub fn analyze_routes(body: &str) -> Result<RouteAnalysis> {
 }
 
 pub(crate) fn analyze_entry_routes(body: &EntryBody) -> Result<RouteAnalysis> {
-    let mut parser = TerminalParser { cursor: body.cursor() };
-    let info = parser.parse_sequence(None)?;
+    let info = analyze_sequence(body, body.statements(), body.text().len())?;
     let routes = info.terminal_route_sets.iter().flatten().cloned().collect();
     Ok(RouteAnalysis { routes, terminal_route_sets: info.terminal_route_sets })
-}
-
-struct TerminalParser<'a> {
-    cursor: EntryBodyCursor<'a>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -59,191 +52,64 @@ impl TerminalResult {
     }
 }
 
-impl TerminalParser<'_> {
-    fn parse_sequence(&mut self, end: Option<char>) -> Result<TerminalResult> {
-        let mut result = TerminalResult::empty();
-        while !self.cursor.is_eof() && !end.is_some_and(|symbol| self.cursor.check_symbol(symbol)) {
-            let stmt = self.parse_statement()?;
-            result.info.contains_become |= stmt.info.contains_become;
-            result.terminal_route_sets.extend(stmt.terminal_route_sets);
+fn analyze_sequence(body: &EntryBody, statements: &[EntryStatement], end_offset: usize) -> Result<TerminalResult> {
+    let mut result = TerminalResult::empty();
+    for (index, statement) in statements.iter().enumerate() {
+        let statement_result = analyze_statement(body, statement)?;
+        result.info.contains_become |= statement_result.info.contains_become;
+        result.terminal_route_sets.extend(statement_result.terminal_route_sets);
 
-            if stmt.info.all_paths_terminal {
-                while self.cursor.consume_symbol(';') {}
-                if self.cursor.is_eof() || end.is_some_and(|symbol| self.cursor.check_symbol(symbol)) {
-                    result.info.all_paths_terminal = true;
-                    break;
-                }
-                return Err(self.error("`become` must be terminal; move following code into an explicit `else` branch"));
+        if statement_result.info.all_paths_terminal {
+            if let Some(next) = statements.get(index + 1) {
+                return Err(body_error(
+                    body,
+                    next.span().start,
+                    "`become` must be terminal; move following code into an explicit `else` branch",
+                ));
             }
-            if stmt.info.contains_become {
-                return Err(self.error("conditional `become` must be terminal on every branch; add an explicit `else` branch"));
-            }
+            result.info.all_paths_terminal = true;
+            break;
         }
-        Ok(result)
+        if statement_result.info.contains_become {
+            let next_offset = statements.get(index + 1).map_or(end_offset, |next| next.span().start);
+            return Err(body_error(
+                body,
+                next_offset,
+                "conditional `become` must be terminal on every branch; add an explicit `else` branch",
+            ));
+        }
     }
+    Ok(result)
+}
 
-    fn parse_statement(&mut self) -> Result<TerminalResult> {
-        if self.cursor.consume_ident(word::IF) {
-            self.expect_symbol('(')?;
-            self.skip_balanced_after_open('(', ')')?;
-            let then_info = self.parse_block_or_statement()?;
-            let else_info =
-                if self.cursor.consume_ident(word::ELSE) { self.parse_block_or_statement()? } else { TerminalResult::empty() };
-            let contains_become = then_info.info.contains_become || else_info.info.contains_become;
-            let all_paths_terminal = then_info.info.all_paths_terminal && else_info.info.all_paths_terminal;
-            let mut terminal_route_sets = then_info.terminal_route_sets;
-            terminal_route_sets.extend(else_info.terminal_route_sets);
+fn analyze_statement(body: &EntryBody, statement: &EntryStatement) -> Result<TerminalResult> {
+    match statement {
+        EntryStatement::If { condition: _, then_branch, else_branch, .. } => {
+            let then_result = analyze_statement(body, then_branch)?;
+            let else_result =
+                if let Some(else_branch) = else_branch { analyze_statement(body, else_branch)? } else { TerminalResult::empty() };
+            let contains_become = then_result.info.contains_become || else_result.info.contains_become;
+            let all_paths_terminal = then_result.info.all_paths_terminal && else_result.info.all_paths_terminal;
+            let mut terminal_route_sets = then_result.terminal_route_sets;
+            terminal_route_sets.extend(else_result.terminal_route_sets);
 
             Ok(TerminalResult { info: TerminalInfo { contains_become, all_paths_terminal }, terminal_route_sets })
-        } else if self.cursor.consume_ident(word::BECOME) {
-            let routes = self.parse_become_tail()?;
-            Ok(TerminalInfo::terminal(routes))
-        } else if self.cursor.consume_symbol('{') {
-            let result = self.parse_sequence(Some('}'))?;
-            self.expect_symbol('}')?;
-            Ok(result)
-        } else {
-            self.skip_statement()?;
-            Ok(TerminalResult::empty())
         }
-    }
-
-    fn parse_block_or_statement(&mut self) -> Result<TerminalResult> {
-        if self.cursor.consume_symbol('{') {
-            let result = self.parse_sequence(Some('}'))?;
-            self.expect_symbol('}')?;
-            Ok(result)
-        } else {
-            self.parse_statement()
+        EntryStatement::Become { routes, .. } => {
+            Ok(TerminalInfo::terminal(routes.iter().map(|route| route_call(body, route)).collect()))
         }
+        EntryStatement::Block { statements, span } => analyze_sequence(body, statements, span.end.saturating_sub(1)),
+        EntryStatement::Plain { .. } => Ok(TerminalResult::empty()),
     }
+}
 
-    fn parse_become_tail(&mut self) -> Result<Vec<RouteCall>> {
-        if self.cursor.consume_symbol('{') {
-            let mut routes = Vec::new();
-            while !self.cursor.check_symbol('}') && !self.cursor.is_eof() {
-                if self.cursor.check_ident(word::BECOME) {
-                    return Err(self.error("nested `become` blocks are not supported yet"));
-                }
-                routes.push(self.parse_route()?);
-                self.expect_list_separator_or_end('}')?;
-            }
-            self.expect_symbol('}')?;
-            self.cursor.consume_symbol(';');
-            return Ok(routes);
-        }
+fn route_call(body: &EntryBody, route: &EntryRoute) -> RouteCall {
+    RouteCall { output: route.output.clone(), actor: route.actor.clone(), state: body.span_text(route.state).trim().to_string() }
+}
 
-        let route = self.parse_route()?;
-        self.cursor.consume_symbol(';');
-        Ok(vec![route])
-    }
-
-    fn parse_route(&mut self) -> Result<RouteCall> {
-        let output = self.expect_any_ident()?;
-        if !self.consume_left_arrow() {
-            return Err(self.error("every `become` route must name its output with `output <- Actor(state)`"));
-        }
-        let actor = self.parse_actor_name()?;
-
-        self.expect_symbol('(')?;
-        let state_span =
-            self.cursor.take_balanced_after_open('(', ')').ok_or_else(|| self.error("unterminated route state expression"))?;
-        let state = self.cursor.span_text(state_span).trim().to_string();
-        Ok(RouteCall { output, actor, state })
-    }
-
-    fn parse_actor_name(&mut self) -> Result<String> {
-        let first = self.expect_any_ident()?;
-        self.parse_qualified_tail(first)
-    }
-
-    fn parse_qualified_tail(&mut self, first: String) -> Result<String> {
-        if !self.cursor.consume_symbol(':') {
-            return Ok(first);
-        }
-        self.expect_symbol(':')?;
-        Ok(format!("{first}::{}", self.expect_any_ident()?))
-    }
-
-    fn consume_left_arrow(&mut self) -> bool {
-        match self.cursor.current().kind {
-            TokenKind::LeftArrow => {
-                self.cursor.advance();
-                true
-            }
-            TokenKind::Symbol('<') if matches!(self.cursor.peek_kind(1), Some(TokenKind::Symbol('-'))) => {
-                self.cursor.advance();
-                self.cursor.advance();
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn expect_any_ident(&mut self) -> Result<String> {
-        match self.cursor.current().kind.clone() {
-            TokenKind::Ident(name) => {
-                self.cursor.advance();
-                Ok(name)
-            }
-            _ => Err(self.error("expected identifier in `become` route")),
-        }
-    }
-
-    fn skip_statement(&mut self) -> Result<()> {
-        self.skip_until_statement_end()
-    }
-
-    fn skip_until_statement_end(&mut self) -> Result<()> {
-        while !self.cursor.is_eof() {
-            match self.cursor.current().kind {
-                TokenKind::Symbol(';') => {
-                    self.cursor.advance();
-                    return Ok(());
-                }
-                TokenKind::Symbol('{') => {
-                    self.cursor.advance();
-                    self.skip_balanced_after_open('{', '}')?;
-                }
-                TokenKind::Symbol('(') => {
-                    self.cursor.advance();
-                    self.skip_balanced_after_open('(', ')')?;
-                }
-                TokenKind::Symbol('[') => {
-                    self.cursor.advance();
-                    self.skip_balanced_after_open('[', ']')?;
-                }
-                TokenKind::Symbol('}') => return Ok(()),
-                _ => self.cursor.advance(),
-            }
-        }
-        Ok(())
-    }
-
-    fn skip_balanced_after_open(&mut self, open: char, close: char) -> Result<()> {
-        if self.cursor.take_balanced_after_open(open, close).is_some() {
-            Ok(())
-        } else {
-            Err(self.error(format!("unterminated `{open}` group")))
-        }
-    }
-
-    fn expect_symbol(&mut self, expected: char) -> Result<()> {
-        if self.cursor.consume_symbol(expected) { Ok(()) } else { Err(self.error(format!("expected `{expected}`"))) }
-    }
-
-    fn expect_list_separator_or_end(&mut self, end: char) -> Result<()> {
-        if self.cursor.consume_symbol(',') || self.cursor.check_symbol(end) {
-            Ok(())
-        } else {
-            Err(self.error(format!("expected `,` or `{end}`")))
-        }
-    }
-
-    fn error(&self, message: impl Into<String>) -> ArgentError {
-        let preview = self.cursor.remaining_text().lines().next().unwrap_or("").trim().chars().take(80).collect::<String>();
-        ArgentError::new(format!("{} at body byte {} near `{}`", message.into(), self.cursor.byte_offset(), preview))
-    }
+fn body_error(body: &EntryBody, byte_offset: usize, message: &str) -> crate::error::ArgentError {
+    let preview = body.text()[byte_offset..].lines().next().unwrap_or("").trim().chars().take(80).collect::<String>();
+    crate::error::ArgentError::new(format!("{message} at body byte {byte_offset} near `{preview}`"))
 }
 
 #[cfg(test)]

--- a/src/language.rs
+++ b/src/language.rs
@@ -19,6 +19,7 @@ pub(crate) mod word {
     pub const ENUM: &str = "enum";
     pub const EXPANDS: &str = "expands";
     pub const FN: &str = "fn";
+    pub const FOR: &str = "for";
     pub const FROM: &str = "from";
     pub const IF: &str = "if";
     pub const IMPORT: &str = "import";

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -27,6 +27,12 @@ pub struct Span {
     pub end: usize,
 }
 
+impl std::fmt::Display for Span {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}..{}", self.start, self.end)
+    }
+}
+
 pub fn lex(source: &str) -> Result<Vec<Token>> {
     lex_with_policy(source, IdentifierPolicy::Any)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,7 +190,7 @@ impl Parser {
         let (observes, consumes, spawns) = self.parse_entry_clauses()?;
         self.expect_ident(word::EMITS)?;
         let emits = self.parse_emits()?;
-        let body = EntryBody::new(self.consume_block_text()?)?;
+        let body = EntryBody::new(self.consume_block_text()?).map_err(|err| err.with_path(self.path.clone()))?;
         let route_analysis = analyze_entry_routes(&body).map_err(|err| ArgentError::at(&self.path, err.message))?;
         Ok(EntryDecl {
             kind: EntryKind::Leader,
@@ -211,7 +211,7 @@ impl Parser {
         let name = self.expect_any_ident()?;
         let params = self.parse_param_list()?;
         let (observes, consumes, spawns) = self.parse_entry_clauses()?;
-        let body = EntryBody::new(self.consume_block_text()?)?;
+        let body = EntryBody::new(self.consume_block_text()?).map_err(|err| err.with_path(self.path.clone()))?;
         let route_analysis = analyze_entry_routes(&body).map_err(|err| ArgentError::at(&self.path, err.message))?;
         Ok(EntryDecl {
             kind: EntryKind::Delegate,

--- a/tests/body_lowering_scopes.rs
+++ b/tests/body_lowering_scopes.rs
@@ -320,15 +320,34 @@ fn selector_binding_does_not_escape_a_for_body() {
     );
 }
 
+#[test]
+fn nested_actor_type_does_not_replace_a_same_named_integer_parameter() {
+    let source = SCOPED_SELECTOR_SOURCE.replace("entry choose(bool choose)", "entry choose(int target, bool choose)").replace(
+        "__SELECTOR_SCOPE__",
+        r#"
+            if (choose) {
+                actor_type<BoardState> target = NextActor::Alpha;
+            }
+            "#,
+    );
+    assert_selector_source_rejected("selector-int-parameter-collision", &source);
+}
+
 fn assert_selector_scope_rejected(name: &str, selector_scope: &str) {
     let source = SCOPED_SELECTOR_SOURCE.replace("__SELECTOR_SCOPE__", selector_scope);
+    assert_selector_source_rejected(name, &source);
+}
+
+fn assert_selector_source_rejected(name: &str, source: &str) {
     let out_dir = std::env::temp_dir().join(format!("argent-{name}-scope-test-{}", std::process::id()));
     if out_dir.exists() {
         fs::remove_dir_all(&out_dir).expect("old scope test output is removed");
     }
 
-    let err = argent::build_inline(PathBuf::from(format!("{name}.ag")), &source, &out_dir)
-        .expect_err("selector binding must not escape its lexical scope");
+    let err = match argent::build_inline(PathBuf::from(format!("{name}.ag")), source, &out_dir) {
+        Ok(_) => panic!("selector binding must not escape its lexical scope"),
+        Err(err) => err,
+    };
     if out_dir.exists() {
         fs::remove_dir_all(&out_dir).expect("scope test output is removed");
     }

--- a/tests/body_lowering_scopes.rs
+++ b/tests/body_lowering_scopes.rs
@@ -1,0 +1,298 @@
+use std::{fs, path::PathBuf};
+
+use argent::builder::{Artifact, EntryCall, TxBuilder, TxContext, actor, args, state};
+use kaspa_consensus_core::{
+    Hash,
+    tx::{CovenantBinding, TransactionId, TransactionOutpoint},
+};
+
+const APP_SOURCE: &str = r#"
+state CounterState {
+    int count;
+    cov_id guard;
+}
+
+state ShadowState {
+    bool marker;
+}
+
+actor Counter owns CounterState {
+    entry bump(bool choose, int iterations) emits next: Counter {
+        unrestricted(next.value);
+
+        __BODY__
+    }
+}
+
+actor Shadow owns ShadowState {
+    entry inspect() emits none {
+        require(marker);
+    }
+}
+
+app ScopeMatrix {
+    actor Counter;
+    actor Shadow;
+}
+"#;
+
+const SELECTOR_APP_SOURCE: &str = r#"
+state BoardState {
+    int count;
+}
+
+actor enum NextActor {
+    Alpha;
+    Beta;
+}
+
+actor Router owns BoardState {
+    entry choose(NextActor target, bool first_branch) emits next: NextActor {
+        unrestricted(next.value);
+        BoardState next_state = {
+            count: count + 1,
+        };
+
+        if (first_branch) {
+            become next <- target(next_state);
+        } else {
+            become next <- target(next_state);
+        }
+    }
+}
+
+actor Alpha owns BoardState {
+    entry inspect() emits none {
+        require(count >= 0);
+    }
+}
+
+actor Beta owns BoardState {
+    entry inspect() emits none {
+        require(count >= 0);
+    }
+}
+
+app SelectorScope {
+    actor Router;
+    actor Alpha;
+    actor Beta;
+}
+"#;
+
+#[test]
+fn state_local_scope_survives_a_standalone_block() {
+    execute_scope_flows(
+        "state-standalone-block",
+        r#"
+        CounterState next_state = {
+            count: count + 1,
+            guard: guard,
+        };
+        {
+            ShadowState next_state = {
+                marker: true,
+            };
+            require(next_state.marker);
+        }
+
+        become next <- Counter(next_state);
+        "#,
+        &[(true, 1)],
+    );
+}
+
+#[test]
+fn state_local_scope_survives_both_if_paths() {
+    execute_scope_flows(
+        "state-if-branch",
+        r#"
+        CounterState next_state = {
+            count: count + 1,
+            guard: guard,
+        };
+        if (choose) {
+            ShadowState next_state = {
+                marker: true,
+            };
+            require(next_state.marker);
+        }
+
+        become next <- Counter(next_state);
+        "#,
+        &[(false, 1), (true, 1)],
+    );
+}
+
+#[test]
+fn state_local_scope_survives_zero_and_nonzero_loop_iterations() {
+    execute_scope_flows(
+        "state-for-body",
+        r#"
+        CounterState next_state = {
+            count: count + 1,
+            guard: guard,
+        };
+        for (i, 0, iterations, 8) {
+            ShadowState next_state = {
+                marker: i >= 0,
+            };
+            require(next_state.marker);
+        }
+
+        become next <- Counter(next_state);
+        "#,
+        &[(true, 0), (true, 3)],
+    );
+}
+
+#[test]
+fn cov_id_local_scope_survives_a_standalone_block() {
+    execute_scope_flows(
+        "cov-id-standalone-block",
+        r#"
+        cov_id relevant = guard;
+        {
+            int relevant = 1;
+            require(relevant == 1);
+        }
+        require(relevant.co_spent());
+
+        CounterState next_state = {
+            count: count + 1,
+            guard: guard,
+        };
+        become next <- Counter(next_state);
+        "#,
+        &[(true, 1)],
+    );
+}
+
+#[test]
+fn cov_id_local_scope_survives_both_if_paths() {
+    execute_scope_flows(
+        "cov-id-if-branch",
+        r#"
+        cov_id relevant = guard;
+        if (choose) {
+            int relevant = 1;
+            require(relevant == 1);
+        }
+        require(relevant.co_spent());
+
+        CounterState next_state = {
+            count: count + 1,
+            guard: guard,
+        };
+        become next <- Counter(next_state);
+        "#,
+        &[(false, 1), (true, 1)],
+    );
+}
+
+#[test]
+fn cov_id_local_scope_survives_zero_and_nonzero_loop_iterations() {
+    execute_scope_flows(
+        "cov-id-for-body",
+        r#"
+        cov_id relevant = guard;
+        for (i, 0, iterations, 8) {
+            int relevant = i;
+            require(relevant >= 0);
+        }
+        require(relevant.co_spent());
+
+        CounterState next_state = {
+            count: count + 1,
+            guard: guard,
+        };
+        become next <- Counter(next_state);
+        "#,
+        &[(true, 0), (true, 3)],
+    );
+}
+
+#[test]
+fn selector_materialization_is_independent_between_if_branches() {
+    let artifact = compile_app("selector-if-branches", SELECTOR_APP_SOURCE);
+    let builder = TxBuilder::new(&artifact).expect("builder accepts selector scope fixture");
+    let covenant_id = Hash::from_bytes([0x61; 32]);
+    let input_value = 1_000;
+
+    for (index, (target, first_branch)) in [("Alpha", false), ("Alpha", true), ("Beta", false), ("Beta", true)].into_iter().enumerate()
+    {
+        let initial_state = state! { count: 4 };
+        let input_utxo = builder
+            .covenant_utxo("Router", initial_state.clone(), input_value, 0, false, Some(covenant_id))
+            .expect("Router UTXO builds");
+        let context = TxContext::new()
+            .actor_input(
+                "Router",
+                initial_state,
+                EntryCall::new("choose").args(args![actor(target), first_branch]),
+                TransactionOutpoint::new(TransactionId::from_bytes([0x70 + index as u8; 32]), 0),
+                input_utxo,
+                0,
+            )
+            .actor_output(target, state! { count: 5 }, CovenantBinding::new(0, covenant_id), input_value);
+
+        builder
+            .build(&context)
+            .unwrap_or_else(|err| panic!("selector scope flow target={target}, first_branch={first_branch} failed: {err}"));
+    }
+}
+
+fn execute_scope_flows(name: &str, body: &str, flows: &[(bool, i64)]) {
+    let artifact = compile_scope_app(name, body);
+    let builder = TxBuilder::new(&artifact).expect("builder accepts scope fixture");
+    let covenant_id = Hash::from_bytes([0x41; 32]);
+    let input_value = 1_000;
+
+    for (index, &(choose, iterations)) in flows.iter().enumerate() {
+        let initial_state = state! {
+            count: 4,
+            guard: covenant_id,
+        };
+        let input_utxo = builder
+            .covenant_utxo("Counter", initial_state.clone(), input_value, 0, false, Some(covenant_id))
+            .expect("Counter UTXO builds");
+        let context = TxContext::new()
+            .actor_input(
+                "Counter",
+                initial_state,
+                EntryCall::new("bump").args(args![choose, iterations]),
+                TransactionOutpoint::new(TransactionId::from_bytes([0x50 + index as u8; 32]), 0),
+                input_utxo,
+                0,
+            )
+            .actor_output(
+                "Counter",
+                state! {
+                    count: 5,
+                    guard: covenant_id,
+                },
+                CovenantBinding::new(0, covenant_id),
+                input_value,
+            );
+
+        builder.build(&context).unwrap_or_else(|err| panic!("scope flow choose={choose}, iterations={iterations} failed: {err}"));
+    }
+}
+
+fn compile_scope_app(name: &str, body: &str) -> Artifact {
+    let source = APP_SOURCE.replace("__BODY__", body);
+    compile_app(name, &source)
+}
+
+fn compile_app(name: &str, source: &str) -> Artifact {
+    let out_dir = std::env::temp_dir().join(format!("argent-{name}-scope-test-{}", std::process::id()));
+    if out_dir.exists() {
+        fs::remove_dir_all(&out_dir).expect("old scope test output is removed");
+    }
+
+    let result = argent::build_inline(PathBuf::from(format!("{name}.ag")), source, &out_dir);
+    if out_dir.exists() {
+        fs::remove_dir_all(&out_dir).expect("scope test output is removed");
+    }
+    result.unwrap_or_else(|err| panic!("scope fixture `{name}` must compile: {err}"))
+}

--- a/tests/body_lowering_scopes.rs
+++ b/tests/body_lowering_scopes.rs
@@ -80,6 +80,48 @@ app SelectorScope {
 }
 "#;
 
+const SCOPED_SELECTOR_SOURCE: &str = r#"
+state BoardState {
+    int count;
+}
+
+actor enum NextActor {
+    Alpha;
+    Beta;
+}
+
+actor Router owns BoardState {
+    entry choose(bool choose) emits next: NextActor {
+        unrestricted(next.value);
+        BoardState next_state = {
+            count: count + 1,
+        };
+
+        __SELECTOR_SCOPE__
+
+        become next <- target(next_state);
+    }
+}
+
+actor Alpha owns BoardState {
+    entry inspect() emits none {
+        require(count >= 0);
+    }
+}
+
+actor Beta owns BoardState {
+    entry inspect() emits none {
+        require(count >= 0);
+    }
+}
+
+app ScopedSelector {
+    actor Router;
+    actor Alpha;
+    actor Beta;
+}
+"#;
+
 #[test]
 fn state_local_scope_survives_a_standalone_block() {
     execute_scope_flows(
@@ -240,6 +282,57 @@ fn selector_materialization_is_independent_between_if_branches() {
             .build(&context)
             .unwrap_or_else(|err| panic!("selector scope flow target={target}, first_branch={first_branch} failed: {err}"));
     }
+}
+
+#[test]
+fn selector_binding_does_not_escape_a_standalone_block() {
+    assert_selector_scope_rejected(
+        "selector-standalone-block",
+        r#"
+        {
+            actor_type<BoardState> target = NextActor::Alpha;
+        }
+        "#,
+    );
+}
+
+#[test]
+fn selector_binding_does_not_escape_an_if_branch() {
+    assert_selector_scope_rejected(
+        "selector-if-branch",
+        r#"
+        if (choose) {
+            actor_type<BoardState> target = NextActor::Alpha;
+        }
+        "#,
+    );
+}
+
+#[test]
+fn selector_binding_does_not_escape_a_for_body() {
+    assert_selector_scope_rejected(
+        "selector-for-body",
+        r#"
+        for (i, 0, 1, 1) {
+            actor_type<BoardState> target = NextActor::Alpha;
+        }
+        "#,
+    );
+}
+
+fn assert_selector_scope_rejected(name: &str, selector_scope: &str) {
+    let source = SCOPED_SELECTOR_SOURCE.replace("__SELECTOR_SCOPE__", selector_scope);
+    let out_dir = std::env::temp_dir().join(format!("argent-{name}-scope-test-{}", std::process::id()));
+    if out_dir.exists() {
+        fs::remove_dir_all(&out_dir).expect("old scope test output is removed");
+    }
+
+    let err = argent::build_inline(PathBuf::from(format!("{name}.ag")), &source, &out_dir)
+        .expect_err("selector binding must not escape its lexical scope");
+    if out_dir.exists() {
+        fs::remove_dir_all(&out_dir).expect("scope test output is removed");
+    }
+    assert!(err.to_string().contains("actor handle `target` is not visible in this scope"), "unexpected selector scope error: {err}");
 }
 
 fn execute_scope_flows(name: &str, body: &str, flows: &[(bool, i64)]) {

--- a/tests/body_lowering_scopes.rs
+++ b/tests/body_lowering_scopes.rs
@@ -122,6 +122,57 @@ app ScopedSelector {
 }
 "#;
 
+const SELECTOR_SHADOW_SOURCE: &str = r#"
+state BoardState {
+    int count;
+}
+
+state PairState {
+    int item;
+}
+
+actor enum NextActor {
+    Alpha;
+    Beta;
+}
+
+fn identity(int value) -> int {
+    return value;
+}
+
+actor Router owns BoardState {
+    entry choose(NextActor target, byte[] data) emits next: NextActor {
+        unrestricted(next.value);
+        BoardState next_state = {
+            count: count + 1,
+        };
+        PairState pair = {
+            item: count,
+        };
+
+        __SHADOW__
+    }
+}
+
+actor Alpha owns BoardState {
+    entry inspect() emits none {
+        require(count >= 0);
+    }
+}
+
+actor Beta owns BoardState {
+    entry inspect() emits none {
+        require(count >= 0);
+    }
+}
+
+app SelectorShadow {
+    actor Router;
+    actor Alpha;
+    actor Beta;
+}
+"#;
+
 #[test]
 fn state_local_scope_survives_a_standalone_block() {
     execute_scope_flows(
@@ -330,15 +381,102 @@ fn nested_actor_type_does_not_replace_a_same_named_integer_parameter() {
             }
             "#,
     );
-    assert_selector_source_rejected("selector-int-parameter-collision", &source);
+    assert_selector_source_rejected(
+        "selector-int-parameter-collision",
+        &source,
+        "actor handle `target` is shadowed by a non-selector binding in this scope",
+    );
+}
+
+#[test]
+fn typed_local_shadows_an_outer_selector() {
+    assert_selector_shadow_rejected(
+        "selector-typed-local-shadow",
+        r#"
+        {
+            int target = 0;
+            become next <- target(next_state);
+        }
+        "#,
+    );
+}
+
+#[test]
+fn destructured_local_shadows_an_outer_selector() {
+    assert_selector_shadow_rejected(
+        "selector-destructured-local-shadow",
+        r#"
+        {
+            {item: int target} = pair;
+            become next <- target(next_state);
+        }
+        "#,
+    );
+}
+
+#[test]
+fn tuple_local_shadows_an_outer_selector() {
+    assert_selector_shadow_rejected(
+        "selector-tuple-local-shadow",
+        r#"
+        {
+            (byte[] target, byte[] remainder) = data.split(1);
+            become next <- target(next_state);
+        }
+        "#,
+    );
+}
+
+#[test]
+fn unparenthesized_tuple_local_shadows_an_outer_selector() {
+    assert_selector_shadow_rejected(
+        "selector-unparenthesized-tuple-local-shadow",
+        r#"
+        {
+            byte[] target, byte[] remainder = data.split(1);
+            become next <- target(next_state);
+        }
+        "#,
+    );
+}
+
+#[test]
+fn function_result_local_shadows_an_outer_selector() {
+    assert_selector_shadow_rejected(
+        "selector-function-result-local-shadow",
+        r#"
+        {
+            (int target) = identity(0);
+            become next <- target(next_state);
+        }
+        "#,
+    );
+}
+
+#[test]
+fn outer_selector_is_restored_after_a_same_named_loop_binding() {
+    let source = SCOPED_SELECTOR_SOURCE.replace("entry choose(bool choose)", "entry choose(NextActor target)").replace(
+        "__SELECTOR_SCOPE__",
+        r#"
+        for (target, 0, 1, 1) {
+            require(target >= 0);
+        }
+        "#,
+    );
+    compile_app("selector-loop-binding-scope", &source);
+}
+
+fn assert_selector_shadow_rejected(name: &str, shadow: &str) {
+    let source = SELECTOR_SHADOW_SOURCE.replace("__SHADOW__", shadow);
+    assert_selector_source_rejected(name, &source, "actor handle `target` is shadowed by a non-selector binding in this scope");
 }
 
 fn assert_selector_scope_rejected(name: &str, selector_scope: &str) {
     let source = SCOPED_SELECTOR_SOURCE.replace("__SELECTOR_SCOPE__", selector_scope);
-    assert_selector_source_rejected(name, &source);
+    assert_selector_source_rejected(name, &source, "actor handle `target` is not visible in this scope");
 }
 
-fn assert_selector_source_rejected(name: &str, source: &str) {
+fn assert_selector_source_rejected(name: &str, source: &str, expected: &str) {
     let out_dir = std::env::temp_dir().join(format!("argent-{name}-scope-test-{}", std::process::id()));
     if out_dir.exists() {
         fs::remove_dir_all(&out_dir).expect("old scope test output is removed");
@@ -351,7 +489,7 @@ fn assert_selector_source_rejected(name: &str, source: &str) {
     if out_dir.exists() {
         fs::remove_dir_all(&out_dir).expect("scope test output is removed");
     }
-    assert!(err.to_string().contains("actor handle `target` is not visible in this scope"), "unexpected selector scope error: {err}");
+    assert!(err.to_string().contains(expected), "unexpected selector scope error: {err}");
 }
 
 fn execute_scope_flows(name: &str, body: &str, flows: &[(bool, i64)]) {

--- a/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
+++ b/tests/fixtures/runtime/context_static_actor_spawn/Child.sil
@@ -58,17 +58,21 @@ contract Child(
         // :: output next: Launcher
         int gen__next_output_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
 
-        Gen__LauncherState next = {
+        LauncherState next = {
+            // :: user declared fields
+            launches: 0,
+        };
+        Gen__LauncherState gen__state_next_gen__launcher_state = {
             // :: generated fields
             gen__child_template: gen__child_template,
             gen__launcher_template: gen__launcher_template,
             // :: user declared fields
-            launches: 0,
+            launches: next.launches,
         };
         // :: become Launcher
         validateOutputStateWithTemplate(
             gen__next_output_idx,
-            next,
+            gen__state_next_gen__launcher_state,
             gen__launcher_prefix,
             gen__launcher_suffix,
             gen__launcher_template


### PR DESCRIPTION
## Context

Argent previously scanned each entry body independently during route analysis and code generation. Both passes had to rediscover `if`, blocks, and `become` boundaries from the same raw text.

This duplication made ordinary Sil constructs fragile. In particular, a `for` loop could consume following statements as part of one opaque statement.

## Change

`EntryBody` now parses the shared token stream into a small structural statement tree.

Argent recognizes only the structure it needs:

- `if` and `else`
- `for`
- standalone lexical blocks
- entry `become`
- observe and spawn output validation

Ordinary Sil statements remain opaque source spans. Argent lowers their known references and otherwise passes their contents through to Silverscript.

Route analysis and body generation now traverse the same structure. This gives both passes the same statement boundaries without introducing a second full Sil parser.

The change also:

- preserves nested blocks during generated Sil emission
- distinguishes brace-leading Sil destructuring from standalone blocks
- rejects `become` inside loops
- reports lowering errors against the current statement span
- restores type and materialization metadata when a lexical scope ends
- rejects unmatched closing braces instead of leaving the parser without progress

## Coverage

The tests cover:

- nested conditions, loops, expressions, and blocks
- Sil `for` loops followed by ordinary statements
- standalone blocks
- state-read and struct destructuring assignments
- state and `cov_id` shadowing across blocks, branches, and loops
- selector materialization in both branches
- runtime execution across zero and nonzero loop iterations and both conditional paths

Some generated .sil files have minor structural changes; compiled scripts, artifacts, and manifests remain unchanged.

`./check.sh` passes in both Argent and Argent Playground, including all playground transaction flows.

## Follow-ups

[Body lowering notes](https://github.com/argent-lang/argent/blob/entry-body-parsing/docs/body-lowering-notes.md) records the remaining boundaries, including helper-function lowering, lexer coverage, shadowing, binder tracking, statement policy, diagnostics, and a future scoped binding table.

This is one step in the broader body-lowering refactor. The goal is to make features such as entry ranges primarily local code-generation work rather than another round of raw-body parsing.