### PR TITLE
Support void helper functions

### DIFF
--- a/src/compiler/codegen/emitter.rs
+++ b/src/compiler/codegen/emitter.rs
@@ -269,7 +269,8 @@ fn emit_shared_functions(out: &mut String, model: &Model<'_>) {
                 .map(|param| format!("{} {}", lower_type_ref(&param.ty, model), param.name))
                 .collect::<Vec<_>>()
                 .join(", ");
-            out.push_str(&format!("    function {}({}) : {} {{\n", function.name, params, lower_type_ref(&function.return_ty, model)));
+            let return_type = function.return_ty.as_ref().map(|ty| format!(" : {}", lower_type_ref(ty, model))).unwrap_or_default();
+            out.push_str(&format!("    function {}({}){return_type} {{\n", function.name, params));
             out.push_str(&indent_block_body(&function.body, 8));
             out.push_str("    }\n");
         }

--- a/src/compiler/codegen/emitter/tests.rs
+++ b/src/compiler/codegen/emitter/tests.rs
@@ -351,14 +351,14 @@ fn rejects_duplicate_function_declarations() {
     program.modules[0].functions.push(FunctionDecl {
         name: "helper".to_string(),
         params: Vec::new(),
-        return_ty: TypeRef::new("int"),
+        return_ty: Some(TypeRef::new("int")),
         body: "1".to_string(),
     });
     let mut duplicate = empty_module("second.ag");
     duplicate.functions.push(FunctionDecl {
         name: "helper".to_string(),
         params: Vec::new(),
-        return_ty: TypeRef::new("int"),
+        return_ty: Some(TypeRef::new("int")),
         body: "2".to_string(),
     });
     program.modules.push(duplicate);
@@ -373,7 +373,7 @@ fn rejects_function_named_unrestricted() {
     program.modules[0].functions.push(FunctionDecl {
         name: word::UNRESTRICTED.to_string(),
         params: Vec::new(),
-        return_ty: TypeRef::new("int"),
+        return_ty: Some(TypeRef::new("int")),
         body: "0".to_string(),
     });
 

--- a/src/compiler/syntax/mod.rs
+++ b/src/compiler/syntax/mod.rs
@@ -74,7 +74,7 @@ pub struct StateDigestExpansionDecl {
 pub struct FunctionDecl {
     pub name: String,
     pub params: Vec<ParamDecl>,
-    pub return_ty: TypeRef,
+    pub return_ty: Option<TypeRef>,
     pub body: String,
 }
 

--- a/src/compiler/syntax/parser.rs
+++ b/src/compiler/syntax/parser.rs
@@ -141,8 +141,7 @@ impl Parser {
         self.expect_ident(word::FN)?;
         let name = self.expect_any_ident()?;
         let params = self.parse_param_list()?;
-        self.expect_arrow()?;
-        let return_ty = self.parse_type()?;
+        let return_ty = if self.consume_arrow() { Some(self.parse_type()?) } else { None };
         let body = self.consume_block_text()?;
         Ok(FunctionDecl { name, params, return_ty, body })
     }
@@ -593,13 +592,12 @@ impl Parser {
         matches!(self.current().kind, TokenKind::Symbol(actual) if actual == expected)
     }
 
-    fn expect_arrow(&mut self) -> Result<()> {
-        match self.current().kind {
-            TokenKind::Arrow => {
-                self.advance();
-                Ok(())
-            }
-            _ => Err(self.error(format!("expected `->`, found {}", self.describe_current()))),
+    fn consume_arrow(&mut self) -> bool {
+        if matches!(self.current().kind, TokenKind::Arrow) {
+            self.advance();
+            true
+        } else {
+            false
         }
     }
 

--- a/src/compiler/syntax/parser/tests.rs
+++ b/src/compiler/syntax/parser/tests.rs
@@ -61,6 +61,7 @@ fn parses_type_first_function_entry_and_delegate_parameters() {
     assert_eq!(module.functions[0].params[0].ty, TypeRef::array("byte", 32));
     assert_eq!(module.functions[0].params[1].name, "amount");
     assert_eq!(module.functions[0].params[1].ty, TypeRef::new("int"));
+    assert_eq!(module.functions[0].return_ty, Some(TypeRef::new("int")));
 
     let actor = &module.actors[0];
     assert_eq!(actor.entries[0].params[0].name, "amount");
@@ -69,6 +70,27 @@ fn parses_type_first_function_entry_and_delegate_parameters() {
     assert_eq!(actor.entries[0].params[1].ty, TypeRef::actor_type("State"));
     assert_eq!(actor.entries[1].params[0].name, "owner_sig");
     assert_eq!(actor.entries[1].params[0].ty, TypeRef::new("sig"));
+}
+
+#[test]
+fn parses_helper_functions_without_return_types() {
+    let module = parse_module(
+        PathBuf::from("helpers.ag"),
+        r#"
+            fn authorize(int value) {
+                require(value > 0);
+            }
+
+            fn identity(int value) -> int {
+                return value;
+            }
+            "#
+        .to_string(),
+    )
+    .expect("void and value-returning helpers parse");
+
+    assert_eq!(module.functions[0].return_ty, None);
+    assert_eq!(module.functions[1].return_ty, Some(TypeRef::new("int")));
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -108,6 +108,37 @@ fn compile_inline_returns_artifact_without_a_user_output_dir() {
 }
 
 #[test]
+fn compile_inline_supports_helpers_without_return_types() {
+    let source = r#"
+        fn authorize(int value) {
+            require(value > 0);
+        }
+
+        state CounterState {
+            int count;
+        }
+
+        actor Counter owns CounterState {
+            entry bump(int delta) emits next: Counter {
+                authorize(delta);
+                unrestricted(next.value);
+                CounterState next_state = {
+                    count: count + delta,
+                };
+                become next <- Counter(next_state);
+            }
+        }
+
+        app CounterApp {
+            actor Counter;
+        }
+    "#;
+
+    let artifact = compile_inline("void-helper.ag", source).expect("void helper compiles through Silverscript");
+    assert!(artifact.sil_abi.contract("Counter").is_some());
+}
+
+#[test]
 fn build_inline_writes_outputs_and_returns_artifact() {
     let out_dir = std::env::temp_dir().join(format!("argent-build-inline-test-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&out_dir);


### PR DESCRIPTION
## Problem

Argent required every helper function to declare a return type:

```js
fn identity(int value) -> int {
    return value;
}
```

This prevented validation-only helpers, even though Silverscript supports functions without a return value.

## Change

Helper functions may now omit the return type:

```js
fn authorize(int value) {
    require(value > 0);
}
```

Value-returning helpers continue to use the existing `-> Type` syntax.

Argent records the return type as optional and omits the Sil return annotation when no type is declared.

## Coverage

Tests cover both helper forms and compile a call to a void helper through Silverscript.

`./check.sh` passes in Argent and Argent Playground, including all transaction flows.

fixes https://github.com/argent-lang/argent/issues/41