### PR TITLE
Support temporal values across Argent

### DIFF
--- a/crates/silverscript-abi/src/lib.rs
+++ b/crates/silverscript-abi/src/lib.rs
@@ -136,6 +136,7 @@ pub struct ParamArtifact {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TypeArtifact {
     Int,
+    Temporal,
     Bool,
     Byte,
     Bytes,
@@ -175,6 +176,7 @@ impl TypeArtifact {
     fn scalar(name: &str) -> Self {
         match name {
             "int" => Self::Int,
+            "temporal" => Self::Temporal,
             "bool" => Self::Bool,
             "byte" => Self::Byte,
             "bytes" => Self::Bytes,
@@ -576,7 +578,7 @@ fn push_sig_arg(
         TypeArtifact::DynamicArray { item } if matches!(item.as_ref(), TypeArtifact::Struct { .. }) => {
             push_struct_array_fields(builder, ctx, item, None, value)
         }
-        TypeArtifact::Int => push_i64(builder, expect_int(value)?),
+        TypeArtifact::Int | TypeArtifact::Temporal => push_i64(builder, expect_int(value)?),
         TypeArtifact::Bool => push_i64(builder, i64::from(expect_bool(value)?)),
         TypeArtifact::Byte => {
             push_data(builder, &[expect_byte(value)?])?;
@@ -681,7 +683,7 @@ fn encode_struct_fields_payload(state: &StateArtifact, fields: &BTreeMap<String,
 
 fn decode_state_payload(name: &str, ty: &TypeArtifact, payload: &[u8]) -> CodecResult<ArtifactValue> {
     match ty {
-        TypeArtifact::Int => {
+        TypeArtifact::Int | TypeArtifact::Temporal => {
             require_len(name, 8, payload.len())?;
             Ok(ArtifactValue::Int(deserialize_fixed_i64(payload)?))
         }
@@ -749,7 +751,7 @@ fn encode_array_payload(name: &str, item: &TypeArtifact, expected_len: Option<us
 
 fn encode_fixed_payload(name: &str, ty: &TypeArtifact, value: &ArtifactValue) -> CodecResult<Vec<u8>> {
     match ty {
-        TypeArtifact::Int => serialize_fixed_i64(expect_int(value)?, 8),
+        TypeArtifact::Int | TypeArtifact::Temporal => serialize_fixed_i64(expect_int(value)?, 8),
         TypeArtifact::Bool => Ok(vec![u8::from(expect_bool(value)?)]),
         TypeArtifact::Byte => Ok(vec![expect_byte(value)?]),
         TypeArtifact::Pubkey => fixed_bytes(name, value, 32),
@@ -765,7 +767,7 @@ fn encode_fixed_payload(name: &str, ty: &TypeArtifact, value: &ArtifactValue) ->
 
 fn fixed_payload_len(ty: &TypeArtifact) -> Option<usize> {
     match ty {
-        TypeArtifact::Int => Some(8),
+        TypeArtifact::Int | TypeArtifact::Temporal => Some(8),
         TypeArtifact::Bool => Some(1),
         TypeArtifact::Byte => Some(1),
         TypeArtifact::Pubkey => Some(32),
@@ -942,6 +944,7 @@ fn require_len(name: &str, expected: usize, actual: usize) -> CodecResult<()> {
 fn type_name(ty: &TypeArtifact) -> String {
     match ty {
         TypeArtifact::Int => "int".to_string(),
+        TypeArtifact::Temporal => "temporal".to_string(),
         TypeArtifact::Bool => "bool".to_string(),
         TypeArtifact::Byte => "byte".to_string(),
         TypeArtifact::Bytes => "bytes".to_string(),
@@ -1095,6 +1098,42 @@ mod tests {
         .expect("sigscript encodes");
 
         assert_eq!(encode_hex(&sigscript), "011104010203045151042c49ed65");
+    }
+
+    #[test]
+    fn encodes_temporal_values_with_integer_payloads() {
+        assert_eq!(TypeArtifact::from_parts("temporal", None), TypeArtifact::Temporal);
+        assert_eq!(serde_json::to_value(TypeArtifact::Temporal).unwrap(), serde_json::json!({ "kind": "temporal" }));
+
+        let mut artifact = tiny_sil_abi();
+        artifact.contracts[0].entries[1].params =
+            vec![param("at", TypeArtifact::Temporal), param("history", TypeArtifact::dynamic_array(TypeArtifact::Temporal))];
+        let history = ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(-2)]);
+        let sigscript = encode_contract_entry_sig_script(&artifact, "Foo", "other", &[ArtifactValue::Int(-5), history.clone()])
+            .expect("temporal arguments encode");
+        let pushes = parse_pushes(&sigscript).expect("signature script contains only data pushes");
+        assert_eq!(
+            pushes.iter().map(|(_, data)| data.clone()).collect::<Vec<_>>(),
+            vec![
+                vec![0x85],
+                [serialize_fixed_i64(1, 8).unwrap(), serialize_fixed_i64(-2, 8).unwrap()].concat(),
+                vec![0xde, 0xad, 0xbe, 0xef],
+            ]
+        );
+
+        let runtime_state = RuntimeStateArtifact {
+            source: "ClockState".to_string(),
+            fields: vec![
+                RuntimeFieldArtifact { name: "at".to_string(), ty: TypeArtifact::Temporal },
+                RuntimeFieldArtifact {
+                    name: "history".to_string(),
+                    ty: TypeArtifact::FixedArray { item: Box::new(TypeArtifact::Temporal), len: 2 },
+                },
+            ],
+        };
+        let values = BTreeMap::from([("at".to_string(), ArtifactValue::Int(-5)), ("history".to_string(), history)]);
+        let encoded = encode_runtime_state_script(&runtime_state, &values).expect("temporal state encodes");
+        assert_eq!(decode_runtime_state_script(&runtime_state, &encoded).expect("temporal state decodes"), values);
     }
 
     #[test]

--- a/docs/argent-design.md
+++ b/docs/argent-design.md
@@ -17,7 +17,7 @@ those pieces usable from Argent.
 - `emits` declares authorized output shape.
 - `become` is tail-dispatch into successor actor state.
 - Typed covenant inputs hide `readInputStateWithTemplate` boilerplate.
-- Basic Silverscript data types stay visible as-is, such as `sig` and `pubkey`;
+- Basic Silverscript data types stay visible as-is, such as `temporal`, `sig`, and `pubkey`;
   Argent does not invent wrapper primitive types for them.
 - Prefix/suffix witnesses are generated Silverscript ABI, not Argent source
   surface.

--- a/src/builder/tests.rs
+++ b/src/builder/tests.rs
@@ -411,6 +411,105 @@ fn context_executes_expanded_bool_transition_to_false() {
 }
 
 #[test]
+fn context_executes_temporal_state_and_expansion_transition() {
+    let artifact = inline_artifact(
+        "context-temporal-transition",
+        r#"
+            state Timing {
+                temporal nested_at;
+            }
+
+            state ClockCapsule {
+                temporal updated_at;
+                virtual timing;
+            }
+
+            state ClockState expands ClockCapsule {
+                timing: Timing;
+            }
+
+            actor Clock owns ClockState {
+                entry advance(temporal next_at, temporal[2] checkpoints, temporal[] history) emits next: Clock {
+                    require(next_at > updated_at);
+                    require(checkpoints[0] == updated_at);
+                    require(checkpoints[1] == next_at);
+                    require(history.length == 2);
+                    require(history[0] == updated_at);
+                    require(history[1] == next_at);
+                    ClockState next_state = {
+                        updated_at: next_at,
+                        timing: Timing {
+                            nested_at: next_at,
+                        },
+                    };
+
+                    unrestricted(next.value);
+                    become next <- Clock(next_state);
+                }
+            }
+
+            app ClockApp {
+                actor Clock;
+            }
+            "#,
+    );
+    let contract = artifact.sil_abi.contract("Clock").expect("Clock contract exists");
+    assert_eq!(
+        contract.runtime_state.fields.iter().find(|field| field.name == "updated_at").map(|field| &field.ty),
+        Some(&TypeArtifact::Temporal)
+    );
+    let advance = contract.entry("advance").expect("advance entry exists");
+    assert_eq!(
+        advance.params.iter().take(3).map(|param| param.ty.clone()).collect::<Vec<_>>(),
+        vec![
+            TypeArtifact::Temporal,
+            TypeArtifact::FixedArray { item: Box::new(TypeArtifact::Temporal), len: 2 },
+            TypeArtifact::dynamic_array(TypeArtifact::Temporal),
+        ]
+    );
+    assert_eq!(
+        artifact
+            .sil_abi
+            .states
+            .iter()
+            .find(|state| state.name == "Timing")
+            .and_then(|state| state.fields.iter().find(|field| field.name == "nested_at"))
+            .map(|field| &field.ty),
+        Some(&TypeArtifact::Temporal)
+    );
+
+    let builder = TxBuilder::new(&artifact).expect("builder accepts temporal artifact");
+    let covenant_id = Hash::from_bytes([0x46; 32]);
+    let input_value = 1_000;
+    let initial = state! {
+        updated_at: 1_000_i64,
+        timing: state! { nested_at: 900_i64 },
+    };
+    let next = state! {
+        updated_at: 2_000_i64,
+        timing: state! { nested_at: 2_000_i64 },
+    };
+    let input_utxo =
+        builder.covenant_utxo("Clock", initial.clone(), input_value, 0, false, Some(covenant_id)).expect("Clock UTXO builds");
+    let context = TxContext::new()
+        .actor_input(
+            "Clock",
+            initial,
+            EntryCall::new("advance").args(args![
+                2_000_i64,
+                ArtifactValue::Array(vec![ArtifactValue::Int(1_000), ArtifactValue::Int(2_000)]),
+                ArtifactValue::Array(vec![ArtifactValue::Int(1_000), ArtifactValue::Int(2_000)]),
+            ]),
+            TransactionOutpoint::new(TransactionId::from_bytes([0x47; 32]), 0),
+            input_utxo,
+            0,
+        )
+        .actor_output("Clock", next, CovenantBinding::new(0, covenant_id), input_value);
+
+    builder.build(&context).expect("temporal state and expansion transition executes");
+}
+
+#[test]
 fn context_executes_source_state_arguments_without_exposing_generated_fields() {
     let artifact = inline_artifact(
         "context-source-state-arguments",
@@ -1417,6 +1516,7 @@ fn linked_expanded_actor_uses_a_clean_state_qualified_physical_layout() {
         r#"
 state ChildStorage {
     int amount;
+    temporal updated_at;
     virtual detail;
 }
 
@@ -1432,6 +1532,7 @@ actor Child owns ChildState {
     entry advance() emits next: Child {
         ChildState next_state = {
             amount: amount + 1,
+            updated_at: updated_at + temporal(1),
             detail: ChildDetail { count: 1 },
         };
         unrestricted(next.value);
@@ -1491,6 +1592,7 @@ actor Launcher owns LauncherState {
     emits next: Launcher {
         ChildState child_state = {
             amount: child.inputs.before.state.amount + 1,
+            updated_at: child.inputs.before.state.updated_at + temporal(1),
             detail: ChildDetail { count: 1 },
         };
 
@@ -1529,13 +1631,17 @@ app LauncherApp {
         .map(|(layout, _)| layout)
         .expect("Launcher declares the linked Child physical state");
     let linked_fields = linked_layout.lines().map(str::trim).filter(|line| line.ends_with(';')).collect::<Vec<_>>();
-    assert_eq!(linked_fields, ["int amount;", "byte[32] detail;"], "linked state layout must contain only physical storage fields");
+    assert_eq!(
+        linked_fields,
+        ["int amount;", "temporal updated_at;", "byte[32] detail;"],
+        "linked state layout must contain only physical storage fields"
+    );
 
     let child_artifact = compiled.app("ChildApp").expect("compiled bundle contains ChildApp");
     let child_contract = child_artifact.sil_abi.contract("Child").expect("Child contract exists");
     assert_eq!(
         child_contract.runtime_state.fields.iter().map(|field| field.name.as_str()).collect::<Vec<_>>(),
-        ["gen__archive_template", "amount", "detail"],
+        ["gen__archive_template", "amount", "updated_at", "detail"],
         "the defining Child contract must exercise an in-app route field before its storage fields"
     );
     let child_handle = child_artifact
@@ -1558,10 +1664,12 @@ app LauncherApp {
     let launcher_next = state! { launches: 1 };
     let child_initial = state! {
         amount: 4,
+        updated_at: 100_i64,
         detail: state! { count: 0 },
     };
     let child_next = state! {
         amount: 5,
+        updated_at: 101_i64,
         detail: state! { count: 1 },
     };
     let launcher_utxo =

--- a/src/compiler/codegen/emitter.rs
+++ b/src/compiler/codegen/emitter.rs
@@ -681,6 +681,7 @@ pub(super) fn packed_field_expr(ty: &TypeRef, expr: &str) -> Result<String> {
     }
     match (ty.name.as_str(), ty.array) {
         ("int", None) => Ok(format!("(({expr}) as byte[8])")),
+        ("temporal", None) => Ok(format!("((int({expr})) as byte[8])")),
         // Sil booleans use the VM's numeric representation, where false is
         // empty. Normalize through int before fixing the one-byte state width.
         ("bool", None) => Ok(format!("((({expr}) as int) as byte[1])")),
@@ -701,6 +702,7 @@ fn unpack_packed_field_expr(ty: &TypeRef, slice_expr: &str) -> Result<String> {
     }
     match (ty.name.as_str(), ty.array) {
         ("int", None) => Ok(format!("OpBin2Num({slice_expr})")),
+        ("temporal", None) => Ok(format!("temporal(OpBin2Num({slice_expr}))")),
         ("bool", None) => Ok(format!("OpBin2Num({slice_expr}) != 0")),
         ("byte", None) => Ok(format!("byte({slice_expr})")),
         ("byte", Some(ArrayDim::Fixed(len))) => Ok(format!("byte[{len}]({slice_expr})")),
@@ -2251,6 +2253,7 @@ fn placeholder_expr_for_type<'i>(ty: &TypeRef) -> Result<SilExpr<'i>> {
         }
         (_, Some(ArrayDim::Dynamic)) => Err(ArgentError::new("dynamic arrays are not supported in actor state")),
         ("int", None) => Ok(SilExpr::int(0)),
+        ("temporal", None) => Ok(SilExpr::temporal(0)),
         ("bool", None) => Ok(SilExpr::bool(false)),
         ("byte", None) => Ok(SilExpr::byte(0)),
         ("string", None) => Ok(SilExpr::string("")),

--- a/src/compiler/model/layout.rs
+++ b/src/compiler/model/layout.rs
@@ -10,7 +10,7 @@ pub(crate) fn packed_field_len(ty: &TypeRef) -> Result<usize> {
         return Ok(32);
     }
     match (ty.name.as_str(), ty.array) {
-        ("int", None) => Ok(8),
+        ("int" | "temporal", None) => Ok(8),
         ("bool", None) | ("byte", None) => Ok(1),
         ("byte", Some(ArrayDim::Fixed(len))) => Ok(len),
         ("pubkey", None) | (word::COVENANT_ID, None) => Ok(32),

--- a/src/compiler/model/link.rs
+++ b/src/compiler/model/link.rs
@@ -267,6 +267,7 @@ fn linked_type_ref(ty: &TypeArtifact) -> Result<TypeRef> {
     let scalar = |name: &str| Ok(TypeRef::new(name));
     match ty {
         TypeArtifact::Int => scalar("int"),
+        TypeArtifact::Temporal => scalar("temporal"),
         TypeArtifact::Bool => scalar("bool"),
         TypeArtifact::Byte => scalar("byte"),
         TypeArtifact::Bytes => Ok(TypeRef::dynamic_array("byte")),

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -429,7 +429,7 @@ fn merge_estimates(estimates: &[SizeEstimate]) -> Option<SizeEstimate> {
 
 fn type_size(artifact: &Artifact, contract: &SilContractArtifact, ty: &TypeArtifact) -> SizeEstimate {
     match ty {
-        TypeArtifact::Int => SizeEstimate::range(1, 9),
+        TypeArtifact::Int | TypeArtifact::Temporal => SizeEstimate::range(1, 9),
         TypeArtifact::Bool => SizeEstimate::exact(1),
         TypeArtifact::Byte => SizeEstimate::range(1, 2),
         TypeArtifact::Bytes | TypeArtifact::Text | TypeArtifact::DynamicArray { .. } => SizeEstimate::variable(1),
@@ -469,7 +469,7 @@ fn type_size(artifact: &Artifact, contract: &SilContractArtifact, ty: &TypeArtif
 
 fn fixed_payload_len(ty: &TypeArtifact) -> Option<usize> {
     match ty {
-        TypeArtifact::Int => Some(8),
+        TypeArtifact::Int | TypeArtifact::Temporal => Some(8),
         TypeArtifact::Bool | TypeArtifact::Byte => Some(1),
         TypeArtifact::Pubkey => Some(32),
         TypeArtifact::Sig => Some(65),
@@ -510,6 +510,7 @@ fn param_label(param: &ParamArtifact) -> String {
 fn type_label(ty: &TypeArtifact) -> String {
     match ty {
         TypeArtifact::Int => "int".to_string(),
+        TypeArtifact::Temporal => "temporal".to_string(),
         TypeArtifact::Bool => "bool".to_string(),
         TypeArtifact::Byte => "byte".to_string(),
         TypeArtifact::Bytes => "bytes".to_string(),
@@ -630,8 +631,9 @@ app Show {
     }
 
     #[test]
-    fn reports_variable_integer_argument_size() {
+    fn reports_variable_numeric_argument_sizes() {
         assert_eq!(type_size_for_test(&TypeArtifact::Int), SizeEstimate::range(1, 9));
+        assert_eq!(type_size_for_test(&TypeArtifact::Temporal), SizeEstimate::range(1, 9));
     }
 
     fn type_size_for_test(ty: &TypeArtifact) -> SizeEstimate {

--- a/vscode/argent-syntax/README.md
+++ b/vscode/argent-syntax/README.md
@@ -10,8 +10,8 @@ Features:
   use keyword scopes.
 - Current language words such as `delegate`, `actor enum`, `virtual`,
   `expands`, `const`, `inputs`, `outputs`, and `as` are highlighted.
-- Current primitive/source types such as `int`, `byte`, `bool`, `sig`, `pubkey`,
-  `cov_id`, `datasig`, and `actor_type<State>` are highlighted.
+- Current primitive/source types such as `int`, `temporal`, `byte`, `bool`, `sig`,
+  `pubkey`, `cov_id`, `datasig`, and `actor_type<State>` are highlighted.
 - The rest of the file falls through to Rust TextMate highlighting.
 - Completion includes Argent keywords, primitive types, builtins, top-level
   `state`, `actor`, `actor enum`, `fn`, `const`, and `app` declarations, plus

--- a/vscode/argent-syntax/language-service.js
+++ b/vscode/argent-syntax/language-service.js
@@ -44,6 +44,7 @@ const PRIMITIVE_TYPES = Object.freeze([
   'pubkey',
   'sig',
   'string',
+  'temporal',
 ]);
 
 const PRIMITIVE_DOCUMENTATION = Object.freeze({

--- a/vscode/argent-syntax/language-service.test.js
+++ b/vscode/argent-syntax/language-service.test.js
@@ -7,10 +7,15 @@ const test = require('node:test');
 const {
   BUILTINS,
   PRIMITIVE_DOCUMENTATION,
+  PRIMITIVE_TYPES,
   scanDocument,
   standardModuleRelativePath,
   tokenize,
 } = require('./language-service');
+
+test('includes temporal among Argent primitive types', () => {
+  assert.ok(PRIMITIVE_TYPES.includes('temporal'));
+});
 
 test('resolves compiler-standard modules for import navigation and symbol indexing', () => {
   const relativePath = standardModuleRelativePath('std::core');

--- a/vscode/argent-syntax/syntaxes/argent.tmLanguage.json
+++ b/vscode/argent-syntax/syntaxes/argent.tmLanguage.json
@@ -52,7 +52,7 @@
         },
         {
           "name": "storage.type.argent",
-          "match": "\\b(actor_type|bool|byte|bytes|cov_id|datasig|int|pubkey|sig|string)\\b"
+          "match": "\\b(actor_type|bool|byte|bytes|cov_id|datasig|int|pubkey|sig|string|temporal)\\b"
         }
       ]
     },


### PR DESCRIPTION
Preserve temporal as a distinct artifact type while reusing integer runtime values and canonical numeric encoding.

Support temporal fields, arrays, expanded-state payloads, linked apps, inspection, and VS Code tooling. Add ABI and runtime coverage for each path.