### PR TITLE
Declare the ISC license on argent-runtime and argent-artifact

### DIFF
--- a/crates/argent-artifact/Cargo.toml
+++ b/crates/argent-artifact/Cargo.toml
@@ -3,6 +3,7 @@ name = "argent-artifact"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.94.0"
+license = "ISC"
 
 [dependencies]
 blake2b_simd = { workspace = true }

--- a/crates/argent-runtime/Cargo.toml
+++ b/crates/argent-runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "argent-runtime"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.94.0"
+license = "ISC"
 
 [dependencies]
 argent-artifact = { workspace = true }


### PR DESCRIPTION
The root manifest declares `license = "ISC"` and the repo ships `LICENSE`, but `crates/argent-runtime/Cargo.toml` and `crates/argent-artifact/Cargo.toml` carry no `license` field. When the crates are consumed as dependencies, `cargo deny check licenses` (and similar audits) reports both as **unlicensed**, because the crate directories carry neither a manifest field nor a LICENSE file.

This adds `license = "ISC"` to both crate manifests. No code changes.

Found while running a downstream dependency audit of the runtime crates at `a98debf`.