### PR TITLE
Support state vectors in args! conversions

### DIFF
--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -174,6 +174,12 @@ impl IntoArtifactValue for BTreeMap<String, ArtifactValue> {
     }
 }
 
+impl IntoArtifactValue for Vec<BTreeMap<String, ArtifactValue>> {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Array(self.into_iter().map(ArtifactValue::Object).collect())
+    }
+}
+
 /// Build an Argent source-state object for `TxBuilder` calls.
 ///
 /// Returns a `BTreeMap<String, ArtifactValue>` keyed by Argent source field
@@ -214,6 +220,18 @@ macro_rules! state {
 /// // Builds:
 /// // vec![ArgValue::Value(ArtifactValue::Int(3)), ArgValue::Actor("Alpha".to_string())]
 /// let args = args![3, actor("Alpha")];
+/// ```
+///
+/// A vector of source-state maps becomes one array argument; a byte vector
+/// remains one bytes argument.
+///
+/// ```
+/// use argent_runtime::{args, state};
+///
+/// let next_states = vec![state! { amount: 90 }, state! { amount: 10 }];
+/// let witness = vec![0u8; 65];
+/// let arguments = args![next_states, witness];
+/// assert_eq!(arguments.len(), 2);
 /// ```
 #[macro_export]
 macro_rules! args {
@@ -2086,6 +2104,25 @@ mod tests {
                 ArgValue::Actor("Alpha".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn args_macro_converts_state_vectors_and_preserves_bytes() {
+        let first = state! { amount: 90 };
+        let second = state! { amount: 10 };
+        assert_eq!(
+            args![vec![first.clone(), second.clone()], vec![0u8, 1]],
+            vec![
+                ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Object(first), ArtifactValue::Object(second)])),
+                ArgValue::Value(ArtifactValue::Bytes(vec![0, 1])),
+            ]
+        );
+    }
+
+    #[test]
+    fn args_macro_converts_empty_state_vectors() {
+        let states: Vec<BTreeMap<String, ArtifactValue>> = Vec::new();
+        assert_eq!(args![states], vec![ArgValue::Value(ArtifactValue::Array(Vec::new()))]);
     }
 
     #[test]

--- a/src/builder/tests.rs
+++ b/src/builder/tests.rs
@@ -655,8 +655,7 @@ fn context_executes_source_state_arguments_without_exposing_generated_fields() {
     let covenant_id = Hash::from_bytes([0x45; 32]);
     let input_value = 1_000;
     let initial = state! { nonce: 0 };
-    let state_array =
-        |nonces: &[i64]| ArtifactValue::Array(nonces.iter().map(|nonce| ArtifactValue::Object(state! { nonce: *nonce })).collect());
+    let state_array = |nonces: &[i64]| nonces.iter().map(|nonce| state! { nonce: *nonce }).collect::<Vec<_>>();
 
     let scalar_utxo =
         builder.covenant_utxo("Note", initial.clone(), input_value, 0, false, Some(covenant_id)).expect("scalar Note UTXO builds");


### PR DESCRIPTION
Passing a `Vec<BTreeMap<String, ArtifactValue>>` to `args!` currently fails because source-state vectors do not implement `IntoArtifactValue`. Add that conversion so a vector of `state!` maps becomes one `ArtifactValue::Array` argument, preserving element order. Existing byte-vector conversion remains unchanged.

### Example

Before:
```rust
let next_states = ArtifactValue::Array(vec![
    ArtifactValue::Object(alice_after.clone()),
    ArtifactValue::Object(bob_after.clone()),
]);
```

After:
```rust
use argent_runtime::{args, state, EntryCall};

let alice_after = state! { amount: 90 };
let bob_after = state! { amount: 10 };
let next_states = vec![alice_after, bob_after];
let witness = vec![0u8; 65]; // Placeholder witness for this argument-construction example.
let transfer = EntryCall::new("transfer").args(args![next_states, witness]);
```

The entry receives two arguments: an array of state objects and witness bytes. With `args_with`, use `args![next_states.clone(), witness]` inside the callback to retain the captured vector across calls. State order must match the contract's expected output order.

This specifically supports vectors of source-state maps; it does not add nested `args!` conversion or a blanket `Vec<T>` implementation that would overlap with `Vec<u8>`.

### Validation

- Added regression tests for state ordering, a separate byte-vector argument, and empty state vectors.
- Updated the existing transaction execution test to pass plain vectors for fixed and dynamic source-state array arguments.
- Added a compiling `args!` documentation example.
- Full `./check.sh` passed with Rust 1.94.1: formatting, workspace check, 471 tests, 3 doctests, Clippy with warnings denied, and diff whitespace checks.
