### PR TITLE
Support state vectors and slices in args! conversions

### DIFF
--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -174,20 +174,15 @@ impl IntoArtifactValue for BTreeMap<String, ArtifactValue> {
     }
 }
 
-/// Explicitly convert an iterable into an ABI array.
-///
-/// Each item is converted through `IntoArtifactValue`. Wrap nested iterables in
-/// `Array` as well. Unwrapped byte vectors continue to convert into ABI bytes.
-#[derive(Debug, Clone, Copy)]
-pub struct Array<I>(pub I);
-
-impl<I> IntoArtifactValue for Array<I>
-where
-    I: IntoIterator,
-    I::Item: IntoArtifactValue,
-{
+impl IntoArtifactValue for Vec<BTreeMap<String, ArtifactValue>> {
     fn into_artifact_value(self) -> ArtifactValue {
-        ArtifactValue::Array(self.0.into_iter().map(IntoArtifactValue::into_artifact_value).collect())
+        ArtifactValue::Array(self.into_iter().map(ArtifactValue::Object).collect())
+    }
+}
+
+impl IntoArtifactValue for &[BTreeMap<String, ArtifactValue>] {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Array(self.iter().cloned().map(ArtifactValue::Object).collect())
     }
 }
 
@@ -233,15 +228,16 @@ macro_rules! state {
 /// let args = args![3, actor("Alpha")];
 /// ```
 ///
-/// Wrap an iterable in `Array` to pass it as one array argument; an unwrapped
-/// byte vector remains one bytes argument.
+/// Vectors and slices of source-state maps become one array argument. Byte
+/// vectors and slices retain their bytes representation. Borrowed state maps
+/// are cloned into owned ABI objects.
 ///
 /// ```
-/// use argent_runtime::{Array, args, state};
+/// use argent_runtime::{args, state};
 ///
 /// let next_states = vec![state! { amount: 90 }, state! { amount: 10 }];
 /// let witness = vec![0u8; 65];
-/// let arguments = args![Array(next_states), witness];
+/// let arguments = args![next_states.as_slice(), witness];
 /// assert_eq!(arguments.len(), 2);
 /// ```
 #[macro_export]
@@ -2118,44 +2114,25 @@ mod tests {
     }
 
     #[test]
-    fn args_macro_converts_wrapped_states_and_preserves_bytes() {
+    fn args_macro_converts_state_vectors_and_slices_and_preserves_bytes() {
         let first = state! { amount: 90 };
         let second = state! { amount: 10 };
-        assert_eq!(
-            args![Array(vec![first.clone(), second.clone()]), vec![0u8, 1]],
-            vec![
-                ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Object(first), ArtifactValue::Object(second)])),
-                ArgValue::Value(ArtifactValue::Bytes(vec![0, 1])),
-            ]
-        );
+        let states = vec![first.clone(), second.clone()];
+        let bytes = vec![0u8, 1];
+        let expected = vec![
+            ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Object(first), ArtifactValue::Object(second)])),
+            ArgValue::Value(ArtifactValue::Bytes(bytes.clone())),
+        ];
+        assert_eq!(args![states.as_slice(), bytes.as_slice()], expected);
+        assert_eq!(args![states, bytes], expected);
     }
 
     #[test]
-    fn args_macro_converts_empty_wrapped_iterators() {
+    fn args_macro_converts_empty_state_vectors_and_slices() {
         let states: Vec<BTreeMap<String, ArtifactValue>> = Vec::new();
-        assert_eq!(args![Array(states.into_iter())], vec![ArgValue::Value(ArtifactValue::Array(Vec::new()))]);
-    }
-
-    #[test]
-    fn array_converts_fixed_arrays_and_iterator_adapters() {
-        assert_eq!(
-            args![Array([1i64, 2]), Array((0i64..4).filter(|value| value % 2 == 1))],
-            vec![
-                ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(2)])),
-                ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(3)])),
-            ]
-        );
-    }
-
-    #[test]
-    fn array_supports_nested_arrays_and_explicit_byte_elements() {
-        assert_eq!(
-            args![Array([Array([1u8, 2]), Array([3u8, 4])])],
-            vec![ArgValue::Value(ArtifactValue::Array(vec![
-                ArtifactValue::Array(vec![ArtifactValue::Byte(1), ArtifactValue::Byte(2)]),
-                ArtifactValue::Array(vec![ArtifactValue::Byte(3), ArtifactValue::Byte(4)]),
-            ]))]
-        );
+        let expected = vec![ArgValue::Value(ArtifactValue::Array(Vec::new()))];
+        assert_eq!(args![states.as_slice()], expected);
+        assert_eq!(args![states], expected);
     }
 
     #[test]

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -174,6 +174,12 @@ impl IntoArtifactValue for BTreeMap<String, ArtifactValue> {
     }
 }
 
+impl IntoArtifactValue for Vec<BTreeMap<String, ArtifactValue>> {
+    fn into_artifact_value(self) -> ArtifactValue {
+        ArtifactValue::Array(self.into_iter().map(ArtifactValue::Object).collect())
+    }
+}
+
 /// Build an Argent source-state object for `TxBuilder` calls.
 ///
 /// Returns a `BTreeMap<String, ArtifactValue>` keyed by Argent source field
@@ -214,6 +220,18 @@ macro_rules! state {
 /// // Builds:
 /// // vec![ArgValue::Value(ArtifactValue::Int(3)), ArgValue::Actor("Alpha".to_string())]
 /// let args = args![3, actor("Alpha")];
+/// ```
+///
+/// A vector of source-state maps becomes one array argument; a byte vector
+/// remains one bytes argument.
+///
+/// ```
+/// use argent_runtime::{args, state};
+///
+/// let next_states = vec![state! { amount: 90 }, state! { amount: 10 }];
+/// let witness = vec![0u8; 65];
+/// let arguments = args![next_states, witness];
+/// assert_eq!(arguments.len(), 2);
 /// ```
 #[macro_export]
 macro_rules! args {
@@ -2086,6 +2104,25 @@ mod tests {
                 ArgValue::Actor("Alpha".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn args_macro_converts_state_vectors_and_preserves_bytes() {
+        let first = state! { amount: 90 };
+        let second = state! { amount: 10 };
+        assert_eq!(
+            args![vec![first.clone(), second.clone()], vec![0u8, 1]],
+            vec![
+                ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Object(first), ArtifactValue::Object(second)])),
+                ArgValue::Value(ArtifactValue::Bytes(vec![0, 1])),
+            ]
+        );
+    }
+
+    #[test]
+    fn args_macro_converts_empty_state_vectors() {
+        let states: Vec<BTreeMap<String, ArtifactValue>> = Vec::new();
+        assert_eq!(args![states], vec![ArgValue::Value(ArtifactValue::Array(Vec::new()))]);
     }
 
     #[test]

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -174,9 +174,20 @@ impl IntoArtifactValue for BTreeMap<String, ArtifactValue> {
     }
 }
 
-impl IntoArtifactValue for Vec<BTreeMap<String, ArtifactValue>> {
+/// Explicitly convert an iterable into an ABI array.
+///
+/// Each item is converted through `IntoArtifactValue`. Wrap nested iterables in
+/// `Array` as well. Unwrapped byte vectors continue to convert into ABI bytes.
+#[derive(Debug, Clone, Copy)]
+pub struct Array<I>(pub I);
+
+impl<I> IntoArtifactValue for Array<I>
+where
+    I: IntoIterator,
+    I::Item: IntoArtifactValue,
+{
     fn into_artifact_value(self) -> ArtifactValue {
-        ArtifactValue::Array(self.into_iter().map(ArtifactValue::Object).collect())
+        ArtifactValue::Array(self.0.into_iter().map(IntoArtifactValue::into_artifact_value).collect())
     }
 }
 
@@ -222,15 +233,15 @@ macro_rules! state {
 /// let args = args![3, actor("Alpha")];
 /// ```
 ///
-/// A vector of source-state maps becomes one array argument; a byte vector
-/// remains one bytes argument.
+/// Wrap an iterable in `Array` to pass it as one array argument; an unwrapped
+/// byte vector remains one bytes argument.
 ///
 /// ```
-/// use argent_runtime::{args, state};
+/// use argent_runtime::{Array, args, state};
 ///
 /// let next_states = vec![state! { amount: 90 }, state! { amount: 10 }];
 /// let witness = vec![0u8; 65];
-/// let arguments = args![next_states, witness];
+/// let arguments = args![Array(next_states), witness];
 /// assert_eq!(arguments.len(), 2);
 /// ```
 #[macro_export]
@@ -2107,11 +2118,11 @@ mod tests {
     }
 
     #[test]
-    fn args_macro_converts_state_vectors_and_preserves_bytes() {
+    fn args_macro_converts_wrapped_states_and_preserves_bytes() {
         let first = state! { amount: 90 };
         let second = state! { amount: 10 };
         assert_eq!(
-            args![vec![first.clone(), second.clone()], vec![0u8, 1]],
+            args![Array(vec![first.clone(), second.clone()]), vec![0u8, 1]],
             vec![
                 ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Object(first), ArtifactValue::Object(second)])),
                 ArgValue::Value(ArtifactValue::Bytes(vec![0, 1])),
@@ -2120,9 +2131,31 @@ mod tests {
     }
 
     #[test]
-    fn args_macro_converts_empty_state_vectors() {
+    fn args_macro_converts_empty_wrapped_iterators() {
         let states: Vec<BTreeMap<String, ArtifactValue>> = Vec::new();
-        assert_eq!(args![states], vec![ArgValue::Value(ArtifactValue::Array(Vec::new()))]);
+        assert_eq!(args![Array(states.into_iter())], vec![ArgValue::Value(ArtifactValue::Array(Vec::new()))]);
+    }
+
+    #[test]
+    fn array_converts_fixed_arrays_and_iterator_adapters() {
+        assert_eq!(
+            args![Array([1i64, 2]), Array((0i64..4).filter(|value| value % 2 == 1))],
+            vec![
+                ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(2)])),
+                ArgValue::Value(ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(3)])),
+            ]
+        );
+    }
+
+    #[test]
+    fn array_supports_nested_arrays_and_explicit_byte_elements() {
+        assert_eq!(
+            args![Array([Array([1u8, 2]), Array([3u8, 4])])],
+            vec![ArgValue::Value(ArtifactValue::Array(vec![
+                ArtifactValue::Array(vec![ArtifactValue::Byte(1), ArtifactValue::Byte(2)]),
+                ArtifactValue::Array(vec![ArtifactValue::Byte(3), ArtifactValue::Byte(4)]),
+            ]))]
+        );
     }
 
     #[test]

--- a/src/builder/tests.rs
+++ b/src/builder/tests.rs
@@ -700,7 +700,7 @@ fn context_executes_source_state_arguments_without_exposing_generated_fields() {
         .actor_input(
             "Note",
             initial.clone(),
-            EntryCall::new("choose_fixed").args(args![state_array(&[3, 7])]),
+            EntryCall::new("choose_fixed").args(args![Array(state_array(&[3, 7]))]),
             TransactionOutpoint::new(TransactionId::from_bytes([0x46; 32]), 0),
             fixed_utxo,
             0,
@@ -715,7 +715,7 @@ fn context_executes_source_state_arguments_without_exposing_generated_fields() {
         .actor_input(
             "Note",
             initial,
-            EntryCall::new("choose_dynamic").args(args![state_array(&[2, 5, 9])]),
+            EntryCall::new("choose_dynamic").args(args![Array(state_array(&[2, 5, 9]).into_iter())]),
             TransactionOutpoint::new(TransactionId::from_bytes([0x47; 32]), 0),
             dynamic_utxo,
             0,

--- a/src/builder/tests.rs
+++ b/src/builder/tests.rs
@@ -655,8 +655,7 @@ fn context_executes_source_state_arguments_without_exposing_generated_fields() {
     let covenant_id = Hash::from_bytes([0x45; 32]);
     let input_value = 1_000;
     let initial = state! { nonce: 0 };
-    let state_array =
-        |nonces: &[i64]| ArtifactValue::Array(nonces.iter().map(|nonce| ArtifactValue::Object(state! { nonce: *nonce })).collect());
+    let state_array = |nonces: &[i64]| nonces.iter().map(|nonce| state! { nonce: *nonce }).collect::<Vec<_>>();
 
     let scalar_utxo =
         builder.covenant_utxo("Note", initial.clone(), input_value, 0, false, Some(covenant_id)).expect("scalar Note UTXO builds");

--- a/src/builder/tests.rs
+++ b/src/builder/tests.rs
@@ -700,7 +700,7 @@ fn context_executes_source_state_arguments_without_exposing_generated_fields() {
         .actor_input(
             "Note",
             initial.clone(),
-            EntryCall::new("choose_fixed").args(args![Array(state_array(&[3, 7]))]),
+            EntryCall::new("choose_fixed").args(args![state_array(&[3, 7])]),
             TransactionOutpoint::new(TransactionId::from_bytes([0x46; 32]), 0),
             fixed_utxo,
             0,
@@ -711,11 +711,12 @@ fn context_executes_source_state_arguments_without_exposing_generated_fields() {
     let dynamic_utxo = builder
         .covenant_utxo("Note", initial.clone(), input_value, 0, false, Some(covenant_id))
         .expect("dynamic-array Note UTXO builds");
+    let dynamic_states = state_array(&[2, 5, 9]);
     let dynamic = TxContext::new()
         .actor_input(
             "Note",
             initial,
-            EntryCall::new("choose_dynamic").args(args![Array(state_array(&[2, 5, 9]).into_iter())]),
+            EntryCall::new("choose_dynamic").args_with(|_, _| args![dynamic_states.as_slice()]),
             TransactionOutpoint::new(TransactionId::from_bytes([0x47; 32]), 0),
             dynamic_utxo,
             0,


### PR DESCRIPTION
Passing a vector or borrowed slice of source-state maps to `args!` currently requires explicit `ArtifactValue::Array` and `ArtifactValue::Object` construction. Add `IntoArtifactValue` implementations for `Vec<BTreeMap<String, ArtifactValue>>` and `&[BTreeMap<String, ArtifactValue>]` so either becomes one ABI array argument directly.

The vector conversion moves its maps; the slice conversion clones them into owned ABI objects. Both preserve element order. Byte vectors and byte slices retain their existing bytes representation. No wrapper or macro changes are needed.

### Example

Before:
```rust
let next_states = ArtifactValue::Array(vec![
    ArtifactValue::Object(alice_after.clone()),
    ArtifactValue::Object(bob_after.clone()),
]);
let arguments = args![next_states, witness];
```

After, with an owned vector:
```rust
let next_states = vec![alice_after.clone(), bob_after.clone()];
let arguments = args![next_states, witness];
```

Or borrow a slice inside a transaction-dependent callback:
```rust
let next_states = vec![alice_after.clone(), bob_after.clone()];
let transfer = EntryCall::new("transfer").args_with(|tx, input_index| {
    let mut witness = vec![PATH_NORMAL];
    witness.extend(sign_input(tx, input_index, &alice));
    args![next_states.as_slice(), witness]
});
```

State order must match the contract's expected output order. Use `.as_slice()` explicitly for the borrowed form: the generic argument conversion does not automatically coerce `&Vec<_>` to a slice.

### Validation

- Regression tests cover ordered state vectors and slices, empty collections, and unchanged byte-vector and byte-slice conversions.
- Existing transaction execution coverage uses a vector for a fixed state-array argument and a borrowed slice inside `args_with` for a dynamic state-array argument.
- Added a compiling `args!` documentation example.
- Full `./check.sh` passed with Rust 1.94.1: formatting, workspace check, 471 tests, 3 doctests, Clippy with warnings denied, and diff whitespace checks.
