### PR TITLE
Formalize leader and delegate group security and update to Silverscript v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,7 +3342,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 [[package]]
 name = "silverscript-abi"
 version = "0.1.0"
-source = "git+https://github.com/kaspanet/silverscript?rev=158534d606e9d5541e932c7575ff331e12699fb5#158534d606e9d5541e932c7575ff331e12699fb5"
+source = "git+https://github.com/kaspanet/silverscript?rev=3ed973335b59269293564805cc2c58a14595ec03#3ed973335b59269293564805cc2c58a14595ec03"
 dependencies = [
  "blake3",
  "faster-hex 0.10.0",
@@ -3355,8 +3355,8 @@ dependencies = [
 
 [[package]]
 name = "silverscript-lang"
-version = "0.1.0"
-source = "git+https://github.com/kaspanet/silverscript?rev=158534d606e9d5541e932c7575ff331e12699fb5#158534d606e9d5541e932c7575ff331e12699fb5"
+version = "1.0.0"
+source = "git+https://github.com/kaspanet/silverscript?rev=3ed973335b59269293564805cc2c58a14595ec03#3ed973335b59269293564805cc2c58a14595ec03"
 dependencies = [
  "blake2b_simd",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,7 +3342,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 [[package]]
 name = "silverscript-abi"
 version = "0.1.0"
-source = "git+https://github.com/kaspanet/silverscript?rev=c7d17a15ac88610d013ec9ffffa9520aeb69929b#c7d17a15ac88610d013ec9ffffa9520aeb69929b"
+source = "git+https://github.com/kaspanet/silverscript?rev=158534d606e9d5541e932c7575ff331e12699fb5#158534d606e9d5541e932c7575ff331e12699fb5"
 dependencies = [
  "blake3",
  "faster-hex 0.10.0",
@@ -3356,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "silverscript-lang"
 version = "0.1.0"
-source = "git+https://github.com/kaspanet/silverscript?rev=c7d17a15ac88610d013ec9ffffa9520aeb69929b#c7d17a15ac88610d013ec9ffffa9520aeb69929b"
+source = "git+https://github.com/kaspanet/silverscript?rev=158534d606e9d5541e932c7575ff331e12699fb5#158534d606e9d5541e932c7575ff331e12699fb5"
 dependencies = [
  "blake2b_simd",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
-[package]
-name = "argent"
+[workspace]
+members = [".", "crates/argent-artifact", "crates/argent-runtime"]
+resolver = "3"
+
+[workspace.package]
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.94.0"
 license = "ISC"
 authors = ["Argent-lang developers"]
-
-[workspace]
-members = [".", "crates/argent-artifact", "crates/argent-runtime"]
-resolver = "3"
+repository = "https://github.com/argent-lang/argent"
 
 [workspace.dependencies]
 argent-artifact = { path = "crates/argent-artifact" }
@@ -27,6 +27,15 @@ serde_json = "1"
 silverscript-abi = { git = "https://github.com/kaspanet/silverscript", rev = "158534d606e9d5541e932c7575ff331e12699fb5", package = "silverscript-abi" }
 silverscript-lang = { git = "https://github.com/kaspanet/silverscript", rev = "158534d606e9d5541e932c7575ff331e12699fb5", package = "silverscript-lang" }
 thiserror = "2"
+
+[package]
+name = "argent"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
 
 [lib]
 name = "argent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ secp256k1 = { version = "0.29.0", features = ["global-context"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"
-silverscript-abi = { git = "https://github.com/kaspanet/silverscript", rev = "158534d606e9d5541e932c7575ff331e12699fb5", package = "silverscript-abi" }
-silverscript-lang = { git = "https://github.com/kaspanet/silverscript", rev = "158534d606e9d5541e932c7575ff331e12699fb5", package = "silverscript-lang" }
+# Silverscript v1.0.0: https://github.com/kaspanet/silverscript/releases/tag/v1.0.0
+silverscript-abi = { git = "https://github.com/kaspanet/silverscript", rev = "3ed973335b59269293564805cc2c58a14595ec03", package = "silverscript-abi" }
+silverscript-lang = { git = "https://github.com/kaspanet/silverscript", rev = "3ed973335b59269293564805cc2c58a14595ec03", package = "silverscript-lang" }
 thiserror = "2"
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ secp256k1 = { version = "0.29.0", features = ["global-context"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"
-silverscript-abi = { git = "https://github.com/kaspanet/silverscript", rev = "c7d17a15ac88610d013ec9ffffa9520aeb69929b", package = "silverscript-abi" }
-silverscript-lang = { git = "https://github.com/kaspanet/silverscript", rev = "c7d17a15ac88610d013ec9ffffa9520aeb69929b", package = "silverscript-lang" }
+silverscript-abi = { git = "https://github.com/kaspanet/silverscript", rev = "158534d606e9d5541e932c7575ff331e12699fb5", package = "silverscript-abi" }
+silverscript-lang = { git = "https://github.com/kaspanet/silverscript", rev = "158534d606e9d5541e932c7575ff331e12699fb5", package = "silverscript-lang" }
 thiserror = "2"
 
 [lib]

--- a/crates/argent-artifact/Cargo.toml
+++ b/crates/argent-artifact/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "argent-artifact"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.94.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 blake2b_simd = { workspace = true }

--- a/crates/argent-artifact/src/cardinality.rs
+++ b/crates/argent-artifact/src/cardinality.rs
@@ -1,0 +1,298 @@
+//! Checks interaction cardinalities stored in portable Argent artifacts.
+//! The checks cover valid bounds and the range shapes supported by the current
+//! compiler and runtime.
+
+use thiserror::Error;
+
+use crate::{Artifact, CardinalityArtifact, EmitArtifact, EntryKindArtifact};
+
+/// Maximum range cardinality accepted by Argent compilers and runtimes.
+///
+/// Keeping the limit in the portable artifact layer prevents compiler and
+/// consumer implementations from drifting on generated-loop resource bounds.
+pub const MAX_ENTRY_RANGE_CARDINALITY: i64 = 512;
+
+/// Invalid or currently unsupported entry cardinality in an Argent artifact.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ArtifactCardinalityError {
+    #[error("entry `{actor}::{entry}` has invalid cardinality {minimum}..={maximum} for {section} `{handle}`")]
+    InvalidRange { actor: String, entry: String, section: &'static str, handle: String, minimum: i64, maximum: i64 },
+    #[error("entry `{actor}::{entry}` uses unsupported ranged {section} interaction `{handle}`")]
+    UnsupportedRange { actor: String, entry: String, section: &'static str, handle: String },
+}
+
+impl Artifact {
+    /// Checks that every interaction range has valid bounds and uses a
+    /// cardinality shape supported by the current compiler and runtime.
+    ///
+    /// A leader entry may have at most one ranged consume and at most one
+    /// ranged emit. A ranged emit must resolve to one actor, not an actor union
+    /// or actor-enum domain. Delegate consumes, observe inputs and outputs, and
+    /// spawn outputs must be singletons.
+    ///
+    /// Transaction-specific input and output counts are checked when a runtime
+    /// context is bound.
+    pub fn check_cardinality_consistency(&self) -> Result<(), ArtifactCardinalityError> {
+        for actor in &self.argent.actors {
+            for entry in &actor.entries {
+                let check = |section, handle: &str, cardinality| {
+                    if let CardinalityArtifact::Range { minimum, maximum } = cardinality
+                        && (minimum < 0 || minimum > maximum || maximum > MAX_ENTRY_RANGE_CARDINALITY)
+                    {
+                        return Err(ArtifactCardinalityError::InvalidRange {
+                            actor: actor.name.clone(),
+                            entry: entry.name.clone(),
+                            section,
+                            handle: handle.to_string(),
+                            minimum,
+                            maximum,
+                        });
+                    }
+                    Ok(())
+                };
+                let reject_unsupported_range = |section, handle: &str, cardinality| {
+                    check(section, handle, cardinality)?;
+                    if matches!(cardinality, CardinalityArtifact::Range { .. }) {
+                        return Err(ArtifactCardinalityError::UnsupportedRange {
+                            actor: actor.name.clone(),
+                            entry: entry.name.clone(),
+                            section,
+                            handle: handle.to_string(),
+                        });
+                    }
+                    Ok(())
+                };
+
+                let mut has_consume_range = false;
+                for consume in &entry.consumes {
+                    if entry.kind == EntryKindArtifact::Delegate {
+                        reject_unsupported_range("delegate consume", &consume.name, consume.cardinality)?;
+                    } else {
+                        check("consume", &consume.name, consume.cardinality)?;
+                        if matches!(consume.cardinality, CardinalityArtifact::Range { .. }) {
+                            if has_consume_range {
+                                reject_unsupported_range("consume", &consume.name, consume.cardinality)?;
+                            }
+                            has_consume_range = true;
+                        }
+                    }
+                }
+                if let EmitArtifact::Outputs { outputs } = &entry.emits {
+                    let mut has_emit_range = false;
+                    for output in outputs {
+                        check("emit", &output.name, output.cardinality)?;
+                        if matches!(output.cardinality, CardinalityArtifact::Range { .. }) {
+                            if has_emit_range || output.actors.len() != 1 {
+                                reject_unsupported_range("emit", &output.name, output.cardinality)?;
+                            }
+                            has_emit_range = true;
+                        }
+                    }
+                }
+                for observe in &entry.observes {
+                    for input in &observe.inputs {
+                        reject_unsupported_range("observed input", &format!("{}.{}", observe.name, input.name), input.cardinality)?;
+                    }
+                    for output in &observe.outputs {
+                        reject_unsupported_range("observed output", &format!("{}.{}", observe.name, output.name), output.cardinality)?;
+                    }
+                }
+                for spawn in &entry.spawns {
+                    for output in &spawn.outputs {
+                        reject_unsupported_range("spawn output", &format!("{}.{}", spawn.name, output.name), output.cardinality)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::{
+        ARTIFACT_SCHEMA_VERSION, ActorAbiRefArtifact, ActorArtifact, ActorTargetArtifact, ArgentArtifact, ConsumeArtifact,
+        CovenantIdSourceArtifact, EmitOutputArtifact, EntryAbiRefArtifact, EntryArtifact, EntryRoutePlanArtifact, GeneratorArtifact,
+        InterfaceSetArtifact, ObserveArtifact, ObservedActorArtifact, SIL_ABI_SCHEMA_VERSION, SilAbiArtifact, SpawnArtifact,
+        SpawnOutputArtifact, TemplatePlanArtifact,
+    };
+
+    #[test]
+    fn accepts_supported_entry_ranges() {
+        let mut artifact = artifact_with_entry();
+        let entry = &mut artifact.argent.actors[0].entries[0];
+        entry.consumes.push(ranged_consume("accounts", 0, 3));
+        entry.emits = EmitArtifact::Outputs { outputs: vec![ranged_emit("next", &["Counter"], 1, 3)] };
+
+        artifact.check_cardinality_consistency().expect("supported input and output ranges are consistent");
+    }
+
+    #[test]
+    fn rejects_invalid_ranges() {
+        for (minimum, maximum) in [(-1, 3), (4, 3), (0, MAX_ENTRY_RANGE_CARDINALITY + 1)] {
+            let mut artifact = artifact_with_entry();
+            artifact.argent.actors[0].entries[0].consumes.push(ranged_consume("accounts", minimum, maximum));
+
+            assert_eq!(
+                artifact.check_cardinality_consistency().expect_err("invalid range must be rejected"),
+                ArtifactCardinalityError::InvalidRange {
+                    actor: "Counter".to_string(),
+                    entry: "merge".to_string(),
+                    section: "consume",
+                    handle: "accounts".to_string(),
+                    minimum,
+                    maximum,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_range_shapes() {
+        let mut delegate = artifact_with_entry();
+        let entry = &mut delegate.argent.actors[0].entries[0];
+        entry.kind = EntryKindArtifact::Delegate;
+        entry.consumes.push(ranged_consume("accounts", 1, 3));
+        assert_unsupported(delegate, "delegate consume", "accounts");
+
+        let mut consumes = artifact_with_entry();
+        consumes.argent.actors[0].entries[0].consumes = vec![ranged_consume("first", 0, 2), ranged_consume("second", 0, 2)];
+        assert_unsupported(consumes, "consume", "second");
+
+        let mut emits = artifact_with_entry();
+        emits.argent.actors[0].entries[0].emits = EmitArtifact::Outputs {
+            outputs: vec![ranged_emit("first", &["Counter"], 0, 2), ranged_emit("second", &["Counter"], 0, 2)],
+        };
+        assert_unsupported(emits, "emit", "second");
+
+        let mut dynamic_emit = artifact_with_entry();
+        dynamic_emit.argent.actors[0].entries[0].emits =
+            EmitArtifact::Outputs { outputs: vec![ranged_emit("next", &["Counter", "Archive"], 0, 2)] };
+        assert_unsupported(dynamic_emit, "emit", "next");
+
+        let mut observed_input = artifact_with_entry();
+        observed_input.argent.actors[0].entries[0].observes.push(ObserveArtifact {
+            name: "asset".to_string(),
+            covenant_expr: "asset_id".to_string(),
+            covenant_id_source: CovenantIdSourceArtifact::StateField { field: "asset_id".to_string() },
+            inputs: vec![ranged_observed_actor("inputs")],
+            outputs: Vec::new(),
+        });
+        assert_unsupported(observed_input, "observed input", "asset.inputs");
+
+        let mut observed_output = artifact_with_entry();
+        observed_output.argent.actors[0].entries[0].observes.push(ObserveArtifact {
+            name: "asset".to_string(),
+            covenant_expr: "asset_id".to_string(),
+            covenant_id_source: CovenantIdSourceArtifact::StateField { field: "asset_id".to_string() },
+            inputs: Vec::new(),
+            outputs: vec![ranged_observed_actor("outputs")],
+        });
+        assert_unsupported(observed_output, "observed output", "asset.outputs");
+
+        let mut spawn = artifact_with_entry();
+        spawn.argent.actors[0].entries[0].spawns.push(SpawnArtifact {
+            name: "children".to_string(),
+            covenant: "child_id".to_string(),
+            outputs: vec![SpawnOutputArtifact {
+                name: "items".to_string(),
+                actor: "Counter".to_string(),
+                state: "CounterState".to_string(),
+                group_index: 0,
+                cardinality: CardinalityArtifact::Range { minimum: 1, maximum: 3 },
+                target: Some(static_actor_target()),
+            }],
+        });
+        assert_unsupported(spawn, "spawn output", "children.items");
+    }
+
+    fn artifact_with_entry() -> Artifact {
+        Artifact {
+            schema_version: ARTIFACT_SCHEMA_VERSION,
+            id: String::new(),
+            generator: GeneratorArtifact { name: "argentc".to_string(), version: "0.1.0".to_string() },
+            app: "Tiny".to_string(),
+            dependencies: Vec::new(),
+            root: "tiny.ag".to_string(),
+            modules: Vec::new(),
+            argent: ArgentArtifact {
+                templates: Vec::new(),
+                template_plan: TemplatePlanArtifact::default(),
+                interfaces: InterfaceSetArtifact::default(),
+                states: Vec::new(),
+                state_expansions: Vec::new(),
+                actor_enums: Vec::new(),
+                actors: vec![ActorArtifact {
+                    name: "Counter".to_string(),
+                    state: "CounterState".to_string(),
+                    abi: ActorAbiRefArtifact { contract: "Counter".to_string() },
+                    leader_for: Vec::new(),
+                    entries: vec![EntryArtifact {
+                        name: "merge".to_string(),
+                        kind: EntryKindArtifact::Leader,
+                        abi: EntryAbiRefArtifact { contract: "Counter".to_string(), entry: "merge".to_string() },
+                        route_plan: EntryRoutePlanArtifact::default(),
+                        hidden_params: Vec::new(),
+                        template_selectors: Vec::new(),
+                        observes: Vec::new(),
+                        spawns: Vec::new(),
+                        witnesses: Vec::new(),
+                        consumes: Vec::new(),
+                        emits: EmitArtifact::None,
+                        routes: Vec::new(),
+                    }],
+                }],
+            },
+            sil_abi: SilAbiArtifact {
+                schema_version: SIL_ABI_SCHEMA_VERSION,
+                compiler_version: "test".to_string(),
+                structs: BTreeMap::new(),
+                contracts: BTreeMap::new(),
+            },
+        }
+    }
+
+    fn ranged_consume(name: &str, minimum: i64, maximum: i64) -> ConsumeArtifact {
+        ConsumeArtifact {
+            name: name.to_string(),
+            actor: "Counter".to_string(),
+            cardinality: CardinalityArtifact::Range { minimum, maximum },
+        }
+    }
+
+    fn ranged_emit(name: &str, actors: &[&str], minimum: i64, maximum: i64) -> EmitOutputArtifact {
+        EmitOutputArtifact {
+            name: name.to_string(),
+            auth_index: None,
+            actors: actors.iter().map(|actor| (*actor).to_string()).collect(),
+            cardinality: CardinalityArtifact::Range { minimum, maximum },
+        }
+    }
+
+    fn ranged_observed_actor(name: &str) -> ObservedActorArtifact {
+        ObservedActorArtifact {
+            name: name.to_string(),
+            target: static_actor_target(),
+            cardinality: CardinalityArtifact::Range { minimum: 1, maximum: 3 },
+        }
+    }
+
+    fn static_actor_target() -> ActorTargetArtifact {
+        ActorTargetArtifact::StaticActor { app: "Tiny".to_string(), actor: "Counter".to_string() }
+    }
+
+    fn assert_unsupported(artifact: Artifact, section: &'static str, handle: &str) {
+        assert_eq!(
+            artifact.check_cardinality_consistency().expect_err("unsupported range shape must be rejected"),
+            ArtifactCardinalityError::UnsupportedRange {
+                actor: "Counter".to_string(),
+                entry: "merge".to_string(),
+                section,
+                handle: handle.to_string(),
+            }
+        );
+    }
+}

--- a/crates/argent-artifact/src/lib.rs
+++ b/crates/argent-artifact/src/lib.rs
@@ -9,9 +9,11 @@
 //! families, or hidden-field roles into `silverscript-abi`. Store them here as
 //! metadata that points at Sil ABI contract and field names.
 
+mod cardinality;
 mod template_frames;
 mod verify_spawns;
 
+pub use cardinality::{ArtifactCardinalityError, MAX_ENTRY_RANGE_CARDINALITY};
 pub use template_frames::{TemplateFrameLengths, TemplateFrameVerificationError};
 
 use serde::{Deserialize, Serialize};
@@ -43,6 +45,8 @@ pub struct Artifact {
 pub enum ArtifactVerificationError {
     #[error(transparent)]
     Version(#[from] ArtifactVersionError),
+    #[error(transparent)]
+    Cardinality(#[from] ArtifactCardinalityError),
     #[error(transparent)]
     SilAbi(#[from] SilAbiVerificationError),
     #[error(transparent)]
@@ -116,10 +120,10 @@ fn is_false(value: &bool) -> bool {
 impl Artifact {
     /// Checks the complete portable Argent artifact for internal consistency.
     ///
-    /// The check compares the artifact's schema, ABI, template plan, compiled
-    /// frames, and declared identity. It assumes the artifact was produced by
-    /// supported Argent and Silverscript compilers and may rely on their
-    /// representation invariants.
+    /// The check compares the artifact's schema, interaction cardinalities,
+    /// ABI, template plan, compiled frames, and declared identity. It assumes
+    /// the artifact was produced by supported Argent and Silverscript compilers
+    /// and may rely on their representation invariants.
     ///
     /// This method does not prove that the embedded bytecode was generated from
     /// the recorded source or make an attacker-supplied artifact trustworthy.
@@ -130,6 +134,7 @@ impl Artifact {
         self.check_sil_abi_consistency()?;
         self.verify_template_frames()?;
         self.check_template_plan_consistency()?;
+        self.check_cardinality_consistency()?;
         self.verify_id()?;
         Ok(())
     }
@@ -746,12 +751,6 @@ pub struct EmitOutputArtifact {
     #[serde(default, skip_serializing_if = "CardinalityArtifact::is_one")]
     pub cardinality: CardinalityArtifact,
 }
-
-/// Maximum range cardinality accepted by Argent compilers and runtimes.
-///
-/// Keeping the limit in the portable artifact layer prevents compiler and
-/// consumer implementations from drifting on generated-loop resource bounds.
-pub const MAX_ENTRY_RANGE_CARDINALITY: i64 = 512;
 
 /// Resolved transaction cardinality of one named interaction handle.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/argent-artifact/src/lib.rs
+++ b/crates/argent-artifact/src/lib.rs
@@ -114,22 +114,22 @@ fn is_false(value: &bool) -> bool {
 }
 
 impl Artifact {
-    /// Verifies the complete portable Argent artifact.
+    /// Checks the complete portable Argent artifact for internal consistency.
     ///
-    /// Verification checks consistency between the artifact's schema, ABI,
-    /// template plan, compiled frames, and declared identity. It assumes the
-    /// artifact was produced by supported Argent and Silverscript compilers and
-    /// may rely on their representation invariants.
+    /// The check compares the artifact's schema, ABI, template plan, compiled
+    /// frames, and declared identity. It assumes the artifact was produced by
+    /// supported Argent and Silverscript compilers and may rely on their
+    /// representation invariants.
     ///
     /// This method does not prove that the embedded bytecode was generated from
     /// the recorded source or make an attacker-supplied artifact trustworthy.
     /// Consumers must obtain the artifact from a trusted build or compare its
     /// computed identity with a separately trusted identity.
-    pub fn verify(&self) -> std::result::Result<(), ArtifactVerificationError> {
+    pub fn check_consistency(&self) -> std::result::Result<(), ArtifactVerificationError> {
         self.check_schema_version()?;
-        self.verify_sil_abi()?;
+        self.check_sil_abi_consistency()?;
         self.verify_template_frames()?;
-        self.verify_template_plan()?;
+        self.check_template_plan_consistency()?;
         self.verify_id()?;
         Ok(())
     }
@@ -145,12 +145,12 @@ impl Artifact {
         self.sil_abi.check_schema_version()
     }
 
-    pub fn verify_template_plan(&self) -> std::result::Result<(), TemplatePlanError> {
-        self.argent.template_plan.verify(self)
+    pub fn check_template_plan_consistency(&self) -> std::result::Result<(), TemplatePlanError> {
+        self.argent.template_plan.check_consistency(self)
     }
 
-    pub fn verify_sil_abi(&self) -> std::result::Result<(), SilAbiVerificationError> {
-        self.sil_abi.verify()
+    pub fn check_sil_abi_consistency(&self) -> std::result::Result<(), SilAbiVerificationError> {
+        self.sil_abi.check_consistency()
     }
 
     /// Verifies that local actor frames are unambiguous under Argent's
@@ -936,7 +936,7 @@ pub enum ArtifactIdentityError {
 }
 
 impl TemplatePlanArtifact {
-    /// Verifies that this template plan is a complete and internally consistent
+    /// Checks that this template plan is a complete and internally consistent
     /// coordination view of the containing artifact.
     ///
     /// Within supported compiler output, the embedded Silverscript ABI is the
@@ -944,10 +944,10 @@ impl TemplatePlanArtifact {
     /// that template receipts, actor-type handles, route metadata, spawn groups,
     /// and witness recipes agree with that ABI and with each other.
     ///
-    /// Like `Artifact::verify`, this is a consistency check that may rely on
+    /// Like `Artifact::check_consistency`, this check may rely on
     /// compiler-enforced invariants. It does not attest compilation provenance or
     /// validate arbitrary attacker-supplied bytecode.
-    pub fn verify(&self, artifact: &Artifact) -> std::result::Result<(), TemplatePlanError> {
+    pub fn check_consistency(&self, artifact: &Artifact) -> std::result::Result<(), TemplatePlanError> {
         use std::collections::{BTreeMap, BTreeSet};
 
         // TODO: Extract template receipt and actor-type handle verification into dedicated helpers.
@@ -2163,7 +2163,7 @@ mod tests {
         let mut artifact = empty_artifact();
         artifact.id = artifact.computed_id_hex().expect("artifact id computes");
 
-        artifact.verify().expect("complete artifact verifies");
+        artifact.check_consistency().expect("complete artifact is consistent");
     }
 
     #[test]
@@ -2183,7 +2183,7 @@ mod tests {
         });
 
         assert!(matches!(
-            artifact.verify(),
+            artifact.check_consistency(),
             Err(ArtifactVerificationError::TemplatePlan(TemplatePlanError::UnknownContract(contract)))
                 if contract == "Missing"
         ));
@@ -2194,7 +2194,7 @@ mod tests {
         let artifact = empty_artifact();
 
         assert!(matches!(
-            artifact.verify(),
+            artifact.check_consistency(),
             Err(ArtifactVerificationError::Identity(ArtifactIdentityError::MissingArtifactId { app }))
                 if app == "Tiny"
         ));
@@ -2305,7 +2305,7 @@ mod tests {
             },
         };
 
-        artifact.verify_template_plan().expect("missing runtime state plan means all fields are source");
+        artifact.check_template_plan_consistency().expect("missing runtime state plan means all fields are source");
     }
 
     #[test]
@@ -2319,7 +2319,7 @@ mod tests {
             actors: vec!["Mux".to_string(), "Mux".to_string()],
         }]);
 
-        let err = artifact.verify_template_plan().expect_err("duplicate actor must be rejected");
+        let err = artifact.check_template_plan_consistency().expect_err("duplicate actor must be rejected");
         assert_eq!(
             err,
             TemplatePlanError::DuplicateRouteFamilyActor { id: "route_family/BoardState/mux".to_string(), actor: "Mux".to_string() }
@@ -2337,7 +2337,7 @@ mod tests {
             actors: vec!["Mux".to_string(), "Player".to_string()],
         }]);
 
-        let err = artifact.verify_template_plan().expect_err("foreign representative must be rejected");
+        let err = artifact.check_template_plan_consistency().expect_err("foreign representative must be rejected");
         assert_eq!(
             err,
             TemplatePlanError::RouteFamilyRepresentativeOutsideFamily {
@@ -2358,7 +2358,7 @@ mod tests {
             actors: vec!["Mux".to_string(), "Player".to_string()],
         }]);
 
-        let err = artifact.verify_template_plan().expect_err("state mismatch must be rejected");
+        let err = artifact.check_template_plan_consistency().expect_err("state mismatch must be rejected");
         assert_eq!(
             err,
             TemplatePlanError::RouteFamilyStateMismatch {
@@ -2549,7 +2549,7 @@ mod tests {
             },
         };
 
-        let err = artifact.verify_template_plan().expect_err("nested family tables must be rejected");
+        let err = artifact.check_template_plan_consistency().expect_err("nested family tables must be rejected");
         assert_eq!(
             err,
             TemplatePlanError::NestedRouteFamilyLeaf {

--- a/crates/argent-runtime/Cargo.toml
+++ b/crates/argent-runtime/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "argent-runtime"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.94.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 argent-artifact = { workspace = true }

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -1712,7 +1712,9 @@ impl<'a> TxBuilder<'a> {
 }
 
 fn validate_artifact(app: &str, artifact: &Artifact) -> BuilderResult<()> {
-    artifact.verify().map_err(|source| BuilderError::ArtifactVerification { app: app.to_string(), source: Box::new(source) })?;
+    artifact
+        .check_consistency()
+        .map_err(|source| BuilderError::ArtifactVerification { app: app.to_string(), source: Box::new(source) })?;
     validate_runtime_cardinality_support(app, artifact)?;
     Ok(())
 }

--- a/crates/argent-runtime/src/lib.rs
+++ b/crates/argent-runtime/src/lib.rs
@@ -24,11 +24,10 @@ pub use context::{
 pub use silverscript_abi::ArtifactValue;
 
 use argent_artifact::{
-    ActorArtifact, ActorInterfaceArtifact, ActorTemplateArtifact, ArgentStateArtifact, ArtifactVerificationError, CardinalityArtifact,
-    EmitArtifact, EntryArtifact, EntryKindArtifact, HiddenParamArtifact, HiddenParamPurposeArtifact, HiddenParamSubjectArtifact,
-    MAX_ENTRY_RANGE_CARDINALITY, ObserveArtifact, ObservedActorArtifact, ObservedActorSideArtifact, ObservedTargetArtifact,
-    RouteTemplateLeafArtifact, RouteTemplateProofArtifact, RuntimeFieldRoleArtifact, RuntimeStatePlanArtifact, SilContractArtifact,
-    SilEntryArtifact, fixed_runtime_context_value,
+    ActorArtifact, ActorInterfaceArtifact, ActorTemplateArtifact, ArgentStateArtifact, ArtifactVerificationError, EntryArtifact,
+    HiddenParamArtifact, HiddenParamPurposeArtifact, HiddenParamSubjectArtifact, ObserveArtifact, ObservedActorArtifact,
+    ObservedActorSideArtifact, ObservedTargetArtifact, RouteTemplateLeafArtifact, RouteTemplateProofArtifact,
+    RuntimeFieldRoleArtifact, RuntimeStatePlanArtifact, SilContractArtifact, SilEntryArtifact, fixed_runtime_context_value,
 };
 use kaspa_consensus_core::{
     Hash,
@@ -302,20 +301,6 @@ pub enum BuilderError {
     UnknownAppAlias(String),
     #[error("artifact `{app}` must be attached as `{expected}`, got `{found}`")]
     AppAliasMismatch { app: String, expected: String, found: String },
-    #[error(
-        "artifact bundle app `{app}` entry `{actor}::{entry}` has invalid cardinality {minimum}..={maximum} for {section} `{handle}`"
-    )]
-    InvalidArtifactCardinality {
-        app: Box<str>,
-        actor: String,
-        entry: String,
-        section: &'static str,
-        handle: Box<str>,
-        minimum: i64,
-        maximum: i64,
-    },
-    #[error("artifact bundle app `{app}` entry `{actor}::{entry}` uses unsupported ranged {section} interaction `{handle}`")]
-    UnsupportedArtifactCardinality { app: String, actor: String, entry: String, section: &'static str, handle: String },
     #[error(
         "artifact bundle app `{app}` requires dependency `{dependency}` artifact `{expected_artifact_id}`, but it is not attached"
     )]
@@ -670,7 +655,7 @@ impl<'a> ArtifactBundle<'a> {
         if alias != expected {
             return Err(BuilderError::AppAliasMismatch { app: primary.app.clone(), expected, found: alias });
         }
-        validate_artifact(&alias, primary)?;
+        check_artifact_consistency(&alias, primary)?;
         let apps = BTreeMap::from([(alias.clone(), primary)]);
         Ok(Self { primary_alias: alias, apps })
     }
@@ -684,7 +669,7 @@ impl<'a> ArtifactBundle<'a> {
         if self.apps.contains_key(&alias) {
             return Err(BuilderError::DuplicateAppAlias(alias));
         }
-        validate_artifact(&alias, artifact)?;
+        check_artifact_consistency(&alias, artifact)?;
         self.apps.insert(alias, artifact);
         Ok(self)
     }
@@ -1711,88 +1696,10 @@ impl<'a> TxBuilder<'a> {
     }
 }
 
-fn validate_artifact(app: &str, artifact: &Artifact) -> BuilderResult<()> {
+fn check_artifact_consistency(app: &str, artifact: &Artifact) -> BuilderResult<()> {
     artifact
         .check_consistency()
         .map_err(|source| BuilderError::ArtifactVerification { app: app.to_string(), source: Box::new(source) })?;
-    validate_runtime_cardinality_support(app, artifact)?;
-    Ok(())
-}
-
-fn validate_runtime_cardinality_support(app: &str, artifact: &Artifact) -> BuilderResult<()> {
-    for actor in &artifact.argent.actors {
-        for entry in &actor.entries {
-            let validate = |section, handle: &str, cardinality| {
-                if let CardinalityArtifact::Range { minimum, maximum } = cardinality
-                    && (minimum < 0 || minimum > maximum || maximum > MAX_ENTRY_RANGE_CARDINALITY)
-                {
-                    return Err(BuilderError::InvalidArtifactCardinality {
-                        app: app.into(),
-                        actor: actor.name.clone(),
-                        entry: entry.name.clone(),
-                        section,
-                        handle: handle.into(),
-                        minimum,
-                        maximum,
-                    });
-                }
-                Ok(())
-            };
-            let reject_unsupported_range = |section, handle: &str, cardinality| {
-                validate(section, handle, cardinality)?;
-                if matches!(cardinality, CardinalityArtifact::Range { .. }) {
-                    return Err(BuilderError::UnsupportedArtifactCardinality {
-                        app: app.to_string(),
-                        actor: actor.name.clone(),
-                        entry: entry.name.clone(),
-                        section,
-                        handle: handle.to_string(),
-                    });
-                }
-                Ok(())
-            };
-
-            let mut has_consume_range = false;
-            for consume in &entry.consumes {
-                if entry.kind == EntryKindArtifact::Delegate {
-                    reject_unsupported_range("delegate consume", &consume.name, consume.cardinality)?;
-                } else {
-                    validate("consume", &consume.name, consume.cardinality)?;
-                    if matches!(consume.cardinality, CardinalityArtifact::Range { .. }) {
-                        if has_consume_range {
-                            reject_unsupported_range("consume", &consume.name, consume.cardinality)?;
-                        }
-                        has_consume_range = true;
-                    }
-                }
-            }
-            if let EmitArtifact::Outputs { outputs } = &entry.emits {
-                let mut has_emit_range = false;
-                for output in outputs {
-                    validate("emit", &output.name, output.cardinality)?;
-                    if matches!(output.cardinality, CardinalityArtifact::Range { .. }) {
-                        if has_emit_range || output.actors.len() != 1 {
-                            reject_unsupported_range("emit", &output.name, output.cardinality)?;
-                        }
-                        has_emit_range = true;
-                    }
-                }
-            }
-            for observe in &entry.observes {
-                for input in &observe.inputs {
-                    reject_unsupported_range("observed input", &format!("{}.{}", observe.name, input.name), input.cardinality)?;
-                }
-                for output in &observe.outputs {
-                    reject_unsupported_range("observed output", &format!("{}.{}", observe.name, output.name), output.cardinality)?;
-                }
-            }
-            for spawn in &entry.spawns {
-                for output in &spawn.outputs {
-                    reject_unsupported_range("spawn output", &format!("{}.{}", spawn.name, output.name), output.cardinality)?;
-                }
-            }
-        }
-    }
     Ok(())
 }
 

--- a/crates/argent-runtime/src/resolve.rs
+++ b/crates/argent-runtime/src/resolve.rs
@@ -934,12 +934,11 @@ mod tests {
     use std::{cell::Cell, collections::BTreeMap};
 
     use argent_artifact::{
-        ARTIFACT_SCHEMA_VERSION, ActorAbiRefArtifact, ActorArtifact, ActorTargetArtifact, ArgentArtifact, CardinalityArtifact,
-        CompiledContractArtifact, ConsumeArtifact, CovenantIdSourceArtifact, DispatchTag, EmitArtifact, EmitOutputArtifact,
-        EntryAbiRefArtifact, EntryArtifact, EntryKindArtifact, EntryRefArtifact, EntryRoutePlanArtifact, GeneratorArtifact,
-        InterfaceSetArtifact, ObserveArtifact, ObservedActorArtifact, RuntimeFieldArtifact, RuntimeStateArtifact,
-        SIL_ABI_SCHEMA_VERSION, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, SpawnArtifact, SpawnOutputArtifact,
-        StateSpanArtifact, TemplatePlanArtifact, TemplateSelectorArtifact, TypeArtifact,
+        ARTIFACT_SCHEMA_VERSION, ActorAbiRefArtifact, ActorArtifact, ArgentArtifact, CardinalityArtifact, CompiledContractArtifact,
+        ConsumeArtifact, DispatchTag, EmitArtifact, EntryAbiRefArtifact, EntryArtifact, EntryKindArtifact, EntryRefArtifact,
+        EntryRoutePlanArtifact, GeneratorArtifact, InterfaceSetArtifact, RuntimeFieldArtifact, RuntimeStateArtifact,
+        SIL_ABI_SCHEMA_VERSION, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, StateSpanArtifact, TemplatePlanArtifact,
+        TemplateSelectorArtifact, TypeArtifact,
     };
     use kaspa_consensus_core::{
         Hash,
@@ -1188,146 +1187,6 @@ mod tests {
         assert!(matches!(
             builder.validate_leader_actor_input_counts(&resolved),
             Err(BuilderError::LeaderActorInputCardinalityMismatch { minimum: 2, maximum: 4, found: 5, .. })
-        ));
-    }
-
-    #[test]
-    fn artifact_attachment_rejects_invalid_or_runtime_unsupported_cardinality() {
-        let mut observed = artifact("primary", "Counter", "merge");
-        observed.argent.actors[0].entries[0].observes.push(ObserveArtifact {
-            name: "peers".to_string(),
-            covenant_expr: "peer_id".to_string(),
-            covenant_id_source: CovenantIdSourceArtifact::StateField { field: "peer_id".to_string() },
-            inputs: vec![ObservedActorArtifact {
-                name: "items".to_string(),
-                target: ActorTargetArtifact::StaticActor { app: "primary".to_string(), actor: "Counter".to_string() },
-                cardinality: CardinalityArtifact::Range { minimum: 1, maximum: 3 },
-            }],
-            outputs: Vec::new(),
-        });
-        observed.id = observed.computed_id_hex().expect("mutated artifact id computes");
-        assert!(matches!(
-            ArtifactBundle::new(&observed),
-            Err(BuilderError::UnsupportedArtifactCardinality {
-                section: "observed input",
-                ref handle,
-                ..
-            }) if handle == "peers.items"
-        ));
-
-        let mut spawned = artifact("primary", "Counter", "merge");
-        spawned.argent.actors[0].entries[0].spawns.push(SpawnArtifact {
-            name: "children".to_string(),
-            covenant: "child_id".to_string(),
-            outputs: vec![SpawnOutputArtifact {
-                name: "items".to_string(),
-                actor: "Counter".to_string(),
-                state: "CounterState".to_string(),
-                group_index: 0,
-                cardinality: CardinalityArtifact::Range { minimum: 1, maximum: 3 },
-                target: Some(ActorTargetArtifact::StaticActor { app: "primary".to_string(), actor: "Counter".to_string() }),
-            }],
-        });
-        assert!(matches!(
-            crate::validate_runtime_cardinality_support("primary", &spawned),
-            Err(BuilderError::UnsupportedArtifactCardinality {
-                section: "spawn output",
-                ref handle,
-                ..
-            }) if handle == "children.items"
-        ));
-
-        let mut delegate = artifact("primary", "Counter", "merge");
-        let entry = &mut delegate.argent.actors[0].entries[0];
-        entry.kind = EntryKindArtifact::Delegate;
-        entry.consumes.push(ConsumeArtifact {
-            name: "items".to_string(),
-            actor: "Counter".to_string(),
-            cardinality: CardinalityArtifact::Range { minimum: 1, maximum: 3 },
-        });
-        assert!(matches!(
-            crate::validate_runtime_cardinality_support("primary", &delegate),
-            Err(BuilderError::UnsupportedArtifactCardinality {
-                section: "delegate consume",
-                ref handle,
-                ..
-            }) if handle == "items"
-        ));
-
-        let mut malformed = artifact("primary", "Counter", "merge");
-        malformed.argent.actors[0].entries[0].consumes.push(ConsumeArtifact {
-            name: "items".to_string(),
-            actor: "Counter".to_string(),
-            cardinality: CardinalityArtifact::Range { minimum: -1, maximum: 3 },
-        });
-        malformed.id = malformed.computed_id_hex().expect("mutated artifact id computes");
-        assert!(matches!(
-            ArtifactBundle::new(&malformed),
-            Err(BuilderError::InvalidArtifactCardinality { section: "consume", minimum: -1, maximum: 3, .. })
-        ));
-
-        let mut oversized = artifact("primary", "Counter", "merge");
-        oversized.argent.actors[0].entries[0].consumes.push(ConsumeArtifact {
-            name: "items".to_string(),
-            actor: "Counter".to_string(),
-            cardinality: CardinalityArtifact::Range { minimum: 0, maximum: argent_artifact::MAX_ENTRY_RANGE_CARDINALITY + 1 },
-        });
-        oversized.id = oversized.computed_id_hex().expect("mutated artifact id computes");
-        assert!(matches!(
-            ArtifactBundle::new(&oversized),
-            Err(BuilderError::InvalidArtifactCardinality { section: "consume", minimum: 0, maximum, .. })
-                if maximum == argent_artifact::MAX_ENTRY_RANGE_CARDINALITY + 1
-        ));
-
-        let mut multiple_consumes = artifact("primary", "Counter", "merge");
-        multiple_consumes.argent.actors[0].entries[0].consumes = ["first", "second"]
-            .into_iter()
-            .map(|name| ConsumeArtifact {
-                name: name.to_string(),
-                actor: "Counter".to_string(),
-                cardinality: CardinalityArtifact::Range { minimum: 0, maximum: 2 },
-            })
-            .collect();
-        multiple_consumes.id = multiple_consumes.computed_id_hex().expect("mutated artifact id computes");
-        assert!(matches!(
-            ArtifactBundle::new(&multiple_consumes),
-            Err(BuilderError::UnsupportedArtifactCardinality {
-                section: "consume",
-                ref handle,
-                ..
-            }) if handle == "second"
-        ));
-
-        let ranged_output = |name: &str, actors: &[&str]| EmitOutputArtifact {
-            name: name.to_string(),
-            auth_index: None,
-            actors: actors.iter().map(|actor| (*actor).to_string()).collect(),
-            cardinality: CardinalityArtifact::Range { minimum: 0, maximum: 2 },
-        };
-        let mut multiple_outputs = artifact("primary", "Counter", "merge");
-        multiple_outputs.argent.actors[0].entries[0].emits =
-            EmitArtifact::Outputs { outputs: vec![ranged_output("first", &["Counter"]), ranged_output("second", &["Counter"])] };
-        multiple_outputs.id = multiple_outputs.computed_id_hex().expect("mutated artifact id computes");
-        assert!(matches!(
-            ArtifactBundle::new(&multiple_outputs),
-            Err(BuilderError::UnsupportedArtifactCardinality {
-                section: "emit",
-                ref handle,
-                ..
-            }) if handle == "second"
-        ));
-
-        let mut dynamic_output = artifact("primary", "Counter", "merge");
-        dynamic_output.argent.actors[0].entries[0].emits =
-            EmitArtifact::Outputs { outputs: vec![ranged_output("items", &["Counter", "Archive"])] };
-        dynamic_output.id = dynamic_output.computed_id_hex().expect("mutated artifact id computes");
-        assert!(matches!(
-            ArtifactBundle::new(&dynamic_output),
-            Err(BuilderError::UnsupportedArtifactCardinality {
-                section: "emit",
-                ref handle,
-                ..
-            }) if handle == "items"
         ));
     }
 

--- a/docs/security-invariants/README.md
+++ b/docs/security-invariants/README.md
@@ -53,85 +53,12 @@ witness and use `readInputStateWithTemplate`.
 
 ## Leader and delegate input groups
 
-Delegate entries participate in a same-covenant transition without authorizing
-outputs of their own. They must authenticate the actor coordinating the
-transition, but they cannot safely determine which entrypoint another input
-selected from that input's signature script. Argent therefore protects
-delegation at actor granularity.
+Delegate entries authenticate a coordinating actor without authorizing outputs
+of their own. Argent closes coordinated same-covenant input groups because an
+input cannot safely determine which entrypoint another input selected.
 
-The first consumed actor in a delegate's `consumes` clause is its statically
-declared leader actor. An actor named this way by any delegate is a *leader
-actor*. Its artifact records the delegate entries that trust it under
-`leader_for`. Each actor lowers to one Sil contract.
-
-### Assumptions
-
-1. Consensus provides a deterministic transaction-order index for every input
-   sharing a covenant ID.
-2. Every transaction input independently executes its selected contract
-   entrypoint.
-3. `readInputStateWithTemplate` authenticates the input's P2SH template before
-   decoding its state, under the collision resistance of the template hash.
-4. `OpCovInputCount` and `OpCovInputIdx` expose the consensus-derived covenant
-   input group.
-
-### Claim 1: a delegate cannot occupy the leader position
-
-A generated delegate requires its active input not to equal covenant input
-zero. Therefore a successful delegate is never the first input in its covenant
-group.
-
-### Claim 2: a delegate authenticates its leader actor's contract
-
-A generated delegate reads covenant input zero using the template of its first
-consumed actor. A transaction using another contract at that position fails
-template validation. The delegate therefore trusts the generated contract of
-the named leader actor, not an unauthenticated entrypoint dispatch tag.
-
-### Claim 3: covenant input zero executes a leader entry
-
-Every delegate rejects execution at covenant input zero. Since every input must
-execute successfully, the authenticated leader actor at input zero must
-execute one of its leader entries.
-
-### Claim 4: a leader actor rejects undeclared same-covenant inputs
-
-Every leader entry of a leader actor requires:
-
-```text
-OpCovInputCount(covenant_id) == 1 + declared_consumes
-```
-
-An entry with no `consumes` actors consequently requires exactly one input in
-its covenant group. An entry with declared consumes also verifies that it is
-input zero and reads each declared actor at its assigned covenant position.
-Adding an undeclared delegate or any other same-covenant input changes the count
-and fails the leader script.
-
-### Result
-
-A successful delegated transition has a leader entry of the authenticated
-leader actor at covenant input zero. That entry fixes the complete
-same-covenant input count, while each delegate independently authenticates the
-leader actor's generated contract and rejects the leader position. An unrelated
-standalone entry of the same actor cannot unknowingly carry additional
-delegates.
-
-### Leader-actor batching restriction
-
-The restriction applies to the whole leader actor because all of its entries
-share one generated contract and another input's selected entrypoint is not
-safely introspectable. Once any delegate names an actor as its leader, every
-leader entry of that actor closes its same-covenant input group, including
-otherwise independent 1:N entries.
-
-This does not prevent the transaction from containing ordinary inputs or inputs
-with other covenant IDs. `consumes`-free leader entries of non-leader actors
-retain ambient same-covenant batching. The artifact lists the delegate
-declarations that cause the restriction in `leader_for`, and the runtime
-transaction builder reports violations before constructing signature scripts.
-This runtime check is fail-fast diagnostics; the generated Sil check is the
-security boundary.
+The complete argument is in
+[Leader and delegate input groups](leader-delegate-input-groups.md).
 
 ## Genesis spawns
 

--- a/docs/security-invariants/README.md
+++ b/docs/security-invariants/README.md
@@ -54,8 +54,9 @@ witness and use `readInputStateWithTemplate`.
 ## Leader and delegate input groups
 
 Delegate entries authenticate a coordinating actor without authorizing outputs
-of their own. Argent closes coordinated same-covenant input groups because an
-input cannot safely determine which entrypoint another input selected.
+of their own. Argent closes coordinated same-covenant input and continuation
+groups because an input cannot safely determine which entrypoint another input
+selected.
 
 The complete argument is in
 [Leader and delegate input groups](leader-delegate-input-groups.md).

--- a/docs/security-invariants/leader-delegate-input-groups.md
+++ b/docs/security-invariants/leader-delegate-input-groups.md
@@ -91,6 +91,12 @@ outputs.
    `|I(c)| = 1` when `m(e) = 0`. This includes `emits none`, zero-minimum output
    ranges, and spawn-only entries.
 
+   Generated Silverscript expresses this as:
+
+   ```text
+   OpCovInputCount(c) == 1
+   ```
+
    **[NOT IMPLEMENTED]**
 
 ## Security properties

--- a/docs/security-invariants/leader-delegate-input-groups.md
+++ b/docs/security-invariants/leader-delegate-input-groups.md
@@ -1,81 +1,191 @@
 # Leader and delegate input groups
 
-Delegate entries participate in a same-covenant transition without authorizing
-outputs of their own. They must authenticate the actor coordinating the
-transition, but they cannot safely determine which entrypoint another input
-selected from that input's signature script. Argent therefore protects
-delegation at actor granularity.
+Argent lets several inputs from the same covenant participate in one
+transaction. They may form one coordinated transition, where a leader consumes
+other actors and their delegate entries approve the coordination. They may also
+be independent transitions that are only batched together. This document
+defines how Argent secures the coordinated case without unnecessarily
+restricting the independent case.
 
-The first consumed actor in a delegate's `consumes` clause is its statically
-declared leader actor. An actor named this way by any delegate is a *leader
-actor*. Its artifact records the delegate entries that trust it under
-`leader_for`. Each actor lowers to one Sil contract.
+The argument relies on one key property of
+[KIP-20](https://github.com/kaspanet/kips/blob/master/kip-0020.md): every
+covenant continuation output names exactly one authorizing input. KIP-20 also
+exposes the complete input and continuation-output groups for a covenant ID,
+and the continuation outputs authorized by each input. Genesis outputs are
+separate from these continuation groups.
 
-## Assumptions
+*Same-covenant batching* means spending several inputs with the same covenant
+ID while each input independently authorizes and validates its own continuation
+outputs.
 
-1. Consensus provides a deterministic transaction-order index for every input
-   sharing a covenant ID.
-2. Every transaction input independently executes its selected contract
-   entrypoint.
-3. `readInputStateWithTemplate` authenticates the input's P2SH template before
-   decoding its state, under the collision resistance of the template hash.
-4. `OpCovInputCount` and `OpCovInputIdx` expose the consensus-derived covenant
-   input group.
+> A key challenge: actor authentication identifies another input's contract,
+> but not the entrypoint it selected. The design must therefore account for
+> every entrypoint that can execute within an authenticated actor contract.
 
-## Claim 1: a delegate cannot occupy the leader position
+## Design principles
 
-A generated delegate requires its active input not to equal covenant input
-zero. Therefore a successful delegate is never the first input in its covenant
-group.
+- Use the narrowest consensus opcode that expresses each rule.
+- Restrict batching only where the restriction is required for delegation.
+- Prefer `OpAuthOutputCount` and `OpAuthOutputIdx` over their covenant-wide
+  equivalents when either view is sufficient. The authorization view takes an
+  input index instead of a 32-byte covenant ID and naturally separates
+  independent transitions in one batch. Use the covenant-wide view only when a
+  rule needs the complete covenant continuation group.
 
-## Claim 2: a delegate authenticates its leader actor's contract
+## Model
 
-A generated delegate reads covenant input zero using the template of its first
-consumed actor. A transaction using another contract at that position fails
-template validation. The delegate therefore trusts the generated contract of
-the named leader actor, not an unauthenticated entrypoint dispatch tag.
+- `c` is the active covenant ID.
+- `I(c)` is the ordered list of transaction inputs carrying `c`.
+- `O(c)` is the set of continuation outputs carrying `c`. Genesis outputs are
+  not members of `O(c)`.
+- `A(i)` is the set of outputs in `O(c)` authorized by input `i`.
+- Every continuation output has one authorizer. Therefore `A(i) ⊆ O(c)`, and
+  `A(i)` and `A(j)` are disjoint for distinct inputs `i` and `j`.
+- `m(e)` is the minimum number of current-covenant continuations permitted by
+  ordinary entry `e`.
+- An *actor contract* is one actor's compiled Silverscript contract. It can
+  contain several entrypoints.
+- An *ordinary entry* is declared with `entry` and may authorize continuations.
+- A *delegate entry* is declared with `delegate`. It names its leader actor as
+  its first consume and authorizes no continuations.
+- A *leader actor* is an actor named as the leader by any delegate.
+- A *delegate-capable actor* declares at least one delegate entry.
+- A *coordinated leader entry* is an ordinary entry with a `consumes` clause.
+- The *leader input* is `l = I(c)[0]`.
+- A *delegate input* `d` occupies a nonzero consumed position whose actor
+  declares a delegate for the leader actor.
+- A *zero-capable entry* has `m(e) = 0`.
 
-## Claim 3: covenant input zero executes a leader entry
+## Compiler rules
 
-Every delegate rejects execution at covenant input zero. Since every input must
-execute successfully, the authenticated leader actor at input zero must
-execute one of its leader entries.
+1. **Rule 1 — Actor identity.** Every cross-actor input position authenticates
+   its expected actor contract. In-app actor frames are unambiguous under the
+   [template identity invariant](template-frame-identity.md).
+2. **Rule 2 — Delegate shape.** A delegate authenticates its declared leader
+   actor at `I(c)[0]`, rejects execution at `I(c)[0]`, requires `A(d) = ∅`, and
+   cannot use `become` or `spawns`.
+3. **Rule 3 — Input-group closure.** Every coordinated leader entry executes at
+   `I(c)[0]`, covers the complete `I(c)` group with its resolved `consumes`
+   cardinalities, and authenticates every consumed actor. Every ordinary entry
+   of a leader actor also closes its input group; without `consumes`, it
+   requires `|I(c)| = 1`.
+4. **Rule 4 — Authorized-output integrity.** Every ordinary entry enforces the
+   resolved cardinality of `A(i)` and validates every successor in `A(i)`.
+5. **Rule 5 — Continuation closure.** Every coordinated leader input `l`
+   requires:
 
-## Claim 4: a leader actor rejects undeclared same-covenant inputs
+   ```text
+   |O(c)| = |A(l)|
+   ```
 
-Every leader entry of a leader actor requires:
+   Generated Silverscript expresses this as:
+
+   ```text
+   OpCovOutputCount(c) == OpAuthOutputCount(l)
+   ```
+
+   **[NOT IMPLEMENTED]**
+
+6. **Rule 6 — Zero-continuation isolation.** An otherwise-batchable,
+   consumes-free ordinary entry on a delegate-capable actor requires
+   `|I(c)| = 1` when `m(e) = 0`. This includes `emits none`, zero-minimum output
+   ranges, and spawn-only entries.
+
+   **[NOT IMPLEMENTED]**
+
+## Security properties
+
+1. **Property 1 — Leader integrity.** A successful delegated transition has a
+   coordinated ordinary entry of the declared leader actor at `I(c)[0]`.
+2. **Property 2 — Input closure.** Every input in the coordinated covenant group
+   belongs to the leader's declared `consumes` shape and has the expected actor
+   contract.
+3. **Property 3 — Continuation ownership.** The leader authorizes every output
+   in `O(c)`. No consumed input creates a parallel continuation.
+4. **Property 4 — Delegate-position integrity.** An ordinary entry cannot replace
+   a delegate. A successful delegate position executes an outputless delegate
+   which authenticates the leader actor.
+5. **Property 5 — Spawn compatibility.** Genesis outputs created by `spawns`
+   remain valid because they are outside `O(c)` and every `A(i)`.
+6. **Property 6 — Minimal batching restriction.** Continuation closure does not
+   restrict independent batches. Among otherwise-batchable entries, only
+   zero-capable entries on delegate-capable actors lose batching.
+7. **Property 7 — Actor-level scope.** Delegation authenticates actor contracts,
+   not entrypoint dispatch tags. Compatible leader or delegate entries on the
+   same actor remain intentionally indistinguishable.
+
+## Proofs
+
+### Claim 1: the leader owns the continuation group
+
+For the coordinated leader input `l`, Rule 5 gives:
 
 ```text
-OpCovInputCount(covenant_id) == 1 + declared_consumes
+|O(c)| = |A(l)|
 ```
 
-An entry with no `consumes` actors consequently requires exactly one input in
-its covenant group. An entry with declared consumes also verifies that it is
-input zero and reads each declared actor at its assigned covenant position.
-Adding an undeclared delegate or any other same-covenant input changes the count
-and fails the leader script.
+By definition, `A(l) ⊆ O(c)`. The sets are finite and have the same size, so:
 
-## Result
+```text
+A(l) = O(c)
+```
 
-A successful delegated transition has a leader entry of the authenticated
-leader actor at covenant input zero. That entry fixes the complete
-same-covenant input count, while each delegate independently authenticates the
-leader actor's generated contract and rejects the leader position. An unrelated
-standalone entry of the same actor cannot unknowingly carry additional
-delegates.
+This proves Property 3. Genesis outputs do not participate in either set, which
+also proves Property 5.
 
-## Leader-actor batching restriction
+### Claim 2: an ordinary entry cannot occupy a delegate position
 
-The restriction applies to the whole leader actor because all of its entries
-share one generated contract and another input's selected entrypoint is not
-safely introspectable. Once any delegate names an actor as its leader, every
-leader entry of that actor closes its same-covenant input group, including
-otherwise independent 1:N entries.
+Consider an ordinary entry selected at a delegate position:
 
-This does not prevent the transaction from containing ordinary inputs or inputs
-with other covenant IDs. `consumes`-free leader entries of non-leader actors
-retain ambient same-covenant batching. The artifact lists the delegate
-declarations that cause the restriction in `leader_for`, and the runtime
-transaction builder reports violations before constructing signature scripts.
-This runtime check is fail-fast diagnostics; the generated Sil check is the
-security boundary.
+- If it has `consumes`, Rule 3 requires it to execute at `I(c)[0]`.
+- If it is consumes-free and `m(e) > 0`, Rule 4 gives it at least one output in
+  `A(i)`. That output is not in the disjoint `A(l)`, which contradicts Claim 1.
+- If it is consumes-free and `m(e) = 0`, Rule 3 already isolates it when its
+  actor is also a leader actor. Otherwise, Rule 6 isolates it because its actor
+  is delegate-capable. Both cases require `|I(c)| = 1`, while a delegated
+  transition has at least a leader and this delegate position.
+
+All cases fail. This proves the ordinary-entry exclusion in Property 4.
+
+### Claim 3: the leader and delegates form one closed group
+
+Assume a delegate executes. Rule 2 makes it authenticate the leader actor at
+`I(c)[0]` and prevents a delegate from occupying that position. Because the
+leader actor has a delegate, its consumes-free ordinary entries require
+`|I(c)| = 1` under Rule 3. They cannot execute with the delegate. The successful
+entry at `I(c)[0]` must therefore be a coordinated ordinary entry of the leader
+actor.
+
+Conversely, assume a coordinated leader entry executes with a declared delegate
+position. Rule 3 authenticates the actor contract at that position. Claim 2
+excludes every ordinary entry on that actor. A delegate for another leader
+fails Rule 2. The successful entry must therefore be an outputless delegate
+which authenticates this leader actor.
+
+Rule 3 also rejects every wrong, extra, or undeclared input. This proves
+Properties 1, 2, and 4.
+
+## Batching and scope
+
+Rule 5 applies only to coordinated leader entries, whose input groups are
+already closed by Rule 3. It does not affect a transaction that batches only
+independent ordinary entries. Those entries continue to enumerate and validate
+their own `A(i)` sets through the cheaper authorization-output opcodes.
+
+A continuing ordinary entry on a delegate-capable actor also remains batchable.
+If it replaces a delegate in a coordinated transition, its nonempty `A(i)`
+violates Claim 1. Rule 6 adds a one-input restriction only when the entry could
+produce no continuation and would otherwise look like an outputless delegate.
+This proves Property 6.
+
+The remaining limit is intentional. If several delegate entries on one actor
+trust the same leader actor, any one of them may be selected. Two coordinated
+entries on the leader actor can also be indistinguishable when they accept the
+same input shape. An application that needs entry-specific authorization must
+encode it in state or transaction checks, or use separate actor contracts.
+This is Property 7.
+
+The artifact records the actor and delegate relationships used to derive these
+rules. The runtime transaction builder can report group-shape violations before
+constructing signature scripts. Runtime checks provide early diagnostics; the
+generated Silverscript checks enforce the security properties.

--- a/docs/security-invariants/leader-delegate-input-groups.md
+++ b/docs/security-invariants/leader-delegate-input-groups.md
@@ -138,8 +138,8 @@ By definition, `A(l) ⊆ O(c)`. The sets are finite and have the same size, so:
 A(l) = O(c)
 ```
 
-This proves Property 3. Genesis outputs do not participate in either set, which
-also proves Property 5.
+This proves **Property 3**. Genesis outputs do not participate in either set,
+which also proves **Property 5**.
 
 ### Claim 2: an ordinary entry cannot occupy a delegate position
 
@@ -152,7 +152,7 @@ Consider an ordinary entry selected at a delegate position:
   actor is also a leader actor. Otherwise, Rule 6 requires it to execute at
   `I(c)[0]`. Neither case permits execution at a nonzero delegate position.
 
-All cases fail. This proves the ordinary-entry exclusion in Property 4.
+All cases fail. This proves the ordinary-entry exclusion in **Property 4**.
 
 ### Claim 3: the leader and delegates form one closed group
 
@@ -170,7 +170,7 @@ fails Rule 2. The successful entry must therefore be an outputless delegate
 which authenticates this leader actor.
 
 Rule 3 also rejects every wrong, extra, or undeclared input. This proves
-Properties 1, 2, and 4.
+**Property 1**, **Property 2**, and **Property 4**.
 
 ## Batching and scope
 
@@ -184,14 +184,14 @@ If it replaces a delegate in a coordinated transition, its nonempty `A(i)`
 violates Claim 1. A zero-capable entry could otherwise look like an outputless
 delegate, so Rule 6 requires it to lead its covenant group. It may still share
 that group with other entries that remain batchable, but two entries subject to
-Rule 6 cannot both occupy its first position. This proves Property 6.
+Rule 6 cannot both occupy its first position. This proves **Property 6**.
 
 The remaining limit is intentional. If several delegate entries on one actor
 trust the same leader actor, any one of them may be selected. Two coordinated
 entries on the leader actor can also be indistinguishable when they accept the
 same input shape. An application that needs entry-specific authorization must
 encode it in state or transaction checks, or use separate actor contracts.
-This is Property 7.
+This is **Property 7**.
 
 The artifact records the actor and delegate relationships used to derive these
 rules. The runtime transaction builder can report group-shape violations before

--- a/docs/security-invariants/leader-delegate-input-groups.md
+++ b/docs/security-invariants/leader-delegate-input-groups.md
@@ -1,0 +1,81 @@
+# Leader and delegate input groups
+
+Delegate entries participate in a same-covenant transition without authorizing
+outputs of their own. They must authenticate the actor coordinating the
+transition, but they cannot safely determine which entrypoint another input
+selected from that input's signature script. Argent therefore protects
+delegation at actor granularity.
+
+The first consumed actor in a delegate's `consumes` clause is its statically
+declared leader actor. An actor named this way by any delegate is a *leader
+actor*. Its artifact records the delegate entries that trust it under
+`leader_for`. Each actor lowers to one Sil contract.
+
+## Assumptions
+
+1. Consensus provides a deterministic transaction-order index for every input
+   sharing a covenant ID.
+2. Every transaction input independently executes its selected contract
+   entrypoint.
+3. `readInputStateWithTemplate` authenticates the input's P2SH template before
+   decoding its state, under the collision resistance of the template hash.
+4. `OpCovInputCount` and `OpCovInputIdx` expose the consensus-derived covenant
+   input group.
+
+## Claim 1: a delegate cannot occupy the leader position
+
+A generated delegate requires its active input not to equal covenant input
+zero. Therefore a successful delegate is never the first input in its covenant
+group.
+
+## Claim 2: a delegate authenticates its leader actor's contract
+
+A generated delegate reads covenant input zero using the template of its first
+consumed actor. A transaction using another contract at that position fails
+template validation. The delegate therefore trusts the generated contract of
+the named leader actor, not an unauthenticated entrypoint dispatch tag.
+
+## Claim 3: covenant input zero executes a leader entry
+
+Every delegate rejects execution at covenant input zero. Since every input must
+execute successfully, the authenticated leader actor at input zero must
+execute one of its leader entries.
+
+## Claim 4: a leader actor rejects undeclared same-covenant inputs
+
+Every leader entry of a leader actor requires:
+
+```text
+OpCovInputCount(covenant_id) == 1 + declared_consumes
+```
+
+An entry with no `consumes` actors consequently requires exactly one input in
+its covenant group. An entry with declared consumes also verifies that it is
+input zero and reads each declared actor at its assigned covenant position.
+Adding an undeclared delegate or any other same-covenant input changes the count
+and fails the leader script.
+
+## Result
+
+A successful delegated transition has a leader entry of the authenticated
+leader actor at covenant input zero. That entry fixes the complete
+same-covenant input count, while each delegate independently authenticates the
+leader actor's generated contract and rejects the leader position. An unrelated
+standalone entry of the same actor cannot unknowingly carry additional
+delegates.
+
+## Leader-actor batching restriction
+
+The restriction applies to the whole leader actor because all of its entries
+share one generated contract and another input's selected entrypoint is not
+safely introspectable. Once any delegate names an actor as its leader, every
+leader entry of that actor closes its same-covenant input group, including
+otherwise independent 1:N entries.
+
+This does not prevent the transaction from containing ordinary inputs or inputs
+with other covenant IDs. `consumes`-free leader entries of non-leader actors
+retain ambient same-covenant batching. The artifact lists the delegate
+declarations that cause the restriction in `leader_for`, and the runtime
+transaction builder reports violations before constructing signature scripts.
+This runtime check is fail-fast diagnostics; the generated Sil check is the
+security boundary.

--- a/docs/security-invariants/leader-delegate-input-groups.md
+++ b/docs/security-invariants/leader-delegate-input-groups.md
@@ -2,8 +2,8 @@
 
 Argent lets several inputs from the same covenant participate in one
 transaction. They may form one coordinated transition, where a leader consumes
-other actors and their delegate entries approve the coordination. They may also
-be independent transitions that are only batched together. This document
+other actors and declared delegate positions approve the coordination. They may
+also be independent transitions that are only batched together. This document
 defines how Argent secures the coordinated case without unnecessarily
 restricting the independent case.
 
@@ -66,10 +66,10 @@ outputs.
    actor at `I(c)[0]`, rejects execution at `I(c)[0]`, requires `A(d) = ∅`, and
    cannot use `become` or `spawns`.
 3. **Rule 3 — Input-group closure.** Every coordinated leader entry executes at
-   `I(c)[0]`, covers the complete `I(c)` group with its resolved `consumes`
-   cardinalities, and authenticates every consumed actor. Every ordinary entry
-   of a leader actor also closes its input group; without `consumes`, it
-   requires `|I(c)| = 1`.
+   `I(c)[0]`. Its resolved and bounds-checked `consumes` cardinalities cover
+   every nonleader position in `I(c)` exactly once and in transaction order. It
+   authenticates every consumed actor. Every ordinary entry of a leader actor
+   also closes its input group; without `consumes`, it requires `|I(c)| = 1`.
 4. **Rule 4 — Authorized-output integrity.** Every ordinary entry enforces the
    resolved cardinality of `A(i)` and validates every successor in `A(i)`.
 5. **Rule 5 — Continuation closure.** Every coordinated leader input `l`
@@ -112,8 +112,9 @@ outputs.
 4. **Property 4 — Delegate-position integrity.** An ordinary entry cannot replace
    a delegate. A successful delegate position executes an outputless delegate
    which authenticates the leader actor.
-5. **Property 5 — Spawn compatibility.** Genesis outputs created by `spawns`
-   remain valid because they are outside `O(c)` and every `A(i)`.
+5. **Property 5 — Spawn compatibility.** Genesis outputs created by `spawns` do
+   not interfere with continuation closure because they are outside `O(c)` and
+   every `A(i)`.
 6. **Property 6 — Minimal batching restriction.** Continuation closure does not
    restrict independent batches. Rule 6 requires an otherwise-batchable,
    zero-capable entry to execute first, but does not require it to be the only

--- a/docs/security-invariants/leader-delegate-input-groups.md
+++ b/docs/security-invariants/leader-delegate-input-groups.md
@@ -35,10 +35,11 @@ outputs.
 ## Model
 
 - `c` is the active covenant ID.
-- `I(c)` is the ordered list of transaction inputs carrying `c`.
+- `I(c)` is the ordered list of transaction input indices carrying `c`.
 - `O(c)` is the set of continuation outputs carrying `c`. Genesis outputs are
   not members of `O(c)`.
-- `A(i)` is the set of outputs in `O(c)` authorized by input `i`.
+- For `i ∈ I(c)`, `A(i)` is the set of outputs in `O(c)` authorized by
+  transaction input `i`.
 - Every continuation output has one authorizer. Therefore `A(i) ⊆ O(c)`, and
   `A(i)` and `A(j)` are disjoint for distinct inputs `i` and `j`.
 - `m(e)` is the minimum number of current-covenant continuations permitted by
@@ -84,20 +85,20 @@ outputs.
    OpCovOutputCount(c) == OpAuthOutputCount(l)
    ```
 
-   **[NOT IMPLEMENTED]**
+   ***[NOT IMPLEMENTED]***
 
-6. **Rule 6 — Zero-continuation isolation.** An otherwise-batchable,
-   consumes-free ordinary entry on a delegate-capable actor requires
-   `|I(c)| = 1` when `m(e) = 0`. This includes `emits none`, zero-minimum output
-   ranges, and spawn-only entries.
+6. **Rule 6 — Zero-continuation position.** An otherwise-batchable,
+   consumes-free ordinary entry on a delegate-capable actor requires its active
+   input `i` to equal `I(c)[0]` when `m(e) = 0`. This includes `emits none`,
+   zero-minimum output ranges, and spawn-only entries.
 
    Generated Silverscript expresses this as:
 
    ```text
-   OpCovInputCount(c) == 1
+   OpCovInputIdx(c, 0) == this.activeInputIndex
    ```
 
-   **[NOT IMPLEMENTED]**
+   ***[NOT IMPLEMENTED]***
 
 ## Security properties
 
@@ -114,8 +115,9 @@ outputs.
 5. **Property 5 — Spawn compatibility.** Genesis outputs created by `spawns`
    remain valid because they are outside `O(c)` and every `A(i)`.
 6. **Property 6 — Minimal batching restriction.** Continuation closure does not
-   restrict independent batches. Among otherwise-batchable entries, only
-   zero-capable entries on delegate-capable actors lose batching.
+   restrict independent batches. Rule 6 requires an otherwise-batchable,
+   zero-capable entry to execute first, but does not require it to be the only
+   input in its covenant group.
 7. **Property 7 — Actor-level scope.** Delegation authenticates actor contracts,
    not entrypoint dispatch tags. Compatible leader or delegate entries on the
    same actor remain intentionally indistinguishable.
@@ -147,9 +149,8 @@ Consider an ordinary entry selected at a delegate position:
 - If it is consumes-free and `m(e) > 0`, Rule 4 gives it at least one output in
   `A(i)`. That output is not in the disjoint `A(l)`, which contradicts Claim 1.
 - If it is consumes-free and `m(e) = 0`, Rule 3 already isolates it when its
-  actor is also a leader actor. Otherwise, Rule 6 isolates it because its actor
-  is delegate-capable. Both cases require `|I(c)| = 1`, while a delegated
-  transition has at least a leader and this delegate position.
+  actor is also a leader actor. Otherwise, Rule 6 requires it to execute at
+  `I(c)[0]`. Neither case permits execution at a nonzero delegate position.
 
 All cases fail. This proves the ordinary-entry exclusion in Property 4.
 
@@ -180,9 +181,10 @@ their own `A(i)` sets through the cheaper authorization-output opcodes.
 
 A continuing ordinary entry on a delegate-capable actor also remains batchable.
 If it replaces a delegate in a coordinated transition, its nonempty `A(i)`
-violates Claim 1. Rule 6 adds a one-input restriction only when the entry could
-produce no continuation and would otherwise look like an outputless delegate.
-This proves Property 6.
+violates Claim 1. A zero-capable entry could otherwise look like an outputless
+delegate, so Rule 6 requires it to lead its covenant group. It may still share
+that group with other entries that remain batchable, but two entries subject to
+Rule 6 cannot both occupy its first position. This proves Property 6.
 
 The remaining limit is intentional. If several delegate entries on one actor
 trust the same leader actor, any one of them may be selected. Two coordinated

--- a/src/builder/tests.rs
+++ b/src/builder/tests.rs
@@ -2091,7 +2091,7 @@ fn context_spawns_a_static_actor_from_a_linked_app() {
         launcher_artifact.argent.interfaces.imports[0].fingerprint_hex,
         child_artifact.argent.interfaces.exports[0].fingerprint_hex
     );
-    launcher_artifact.verify_template_plan().expect("linked static-spawn template plan verifies");
+    launcher_artifact.check_template_plan_consistency().expect("linked static-spawn template plan verifies");
     let mut malformed_target = launcher_artifact.clone();
     let Some(ActorTargetArtifact::StaticActor { app, .. }) =
         &mut malformed_target.argent.actors[0].entries[0].spawns[0].outputs[0].target
@@ -2100,7 +2100,7 @@ fn context_spawns_a_static_actor_from_a_linked_app() {
     };
     *app = "OtherApp".to_string();
     assert!(
-        matches!(malformed_target.verify_template_plan(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
+        matches!(malformed_target.check_template_plan_consistency(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
         "linked spawn metadata must agree with its shared actor-template witnesses"
     );
     assert_eq!(
@@ -2937,7 +2937,7 @@ fn gate_less_route_family_rejects_selector_for_appended_rep() {
 #[test]
 fn builder_rejects_template_plan_hash_mismatch() {
     let mut artifact = tickets_artifact();
-    artifact.verify_template_plan().expect("fixture receipt verifies before mutation");
+    artifact.check_template_plan_consistency().expect("fixture receipt verifies before mutation");
     let issuer_receipt = artifact
         .argent
         .template_plan
@@ -2965,7 +2965,7 @@ fn builder_rejects_template_plan_hash_mismatch() {
 #[test]
 fn builder_rejects_sil_template_hash_mismatch() {
     let mut artifact = tickets_artifact();
-    artifact.verify_sil_abi().expect("fixture Sil ABI verifies before mutation");
+    artifact.check_sil_abi_consistency().expect("fixture Sil ABI is consistent before mutation");
     let issuer_contract = artifact.sil_abi.contracts.get_mut("Issuer").expect("Issuer Sil contract exists");
     issuer_contract.compiled.template_hash = [0; 32];
     let issuer_receipt = artifact
@@ -2995,7 +2995,7 @@ fn builder_rejects_sil_template_hash_mismatch() {
 #[test]
 fn builder_rejects_route_template_table_mismatch() {
     let mut artifact = example_artifact("examples/toy_chess/app.ag", "toy-chess-route-table-plan");
-    artifact.verify_template_plan().expect("fixture receipt verifies before mutation");
+    artifact.check_template_plan_consistency().expect("fixture receipt verifies before mutation");
     let table = artifact
         .argent
         .template_plan
@@ -3027,7 +3027,7 @@ fn builder_rejects_route_template_table_mismatch() {
 #[test]
 fn builder_rejects_route_template_merkle_proof_mismatch() {
     let mut artifact = example_artifact("examples/toy_chess/app.ag", "toy-chess-route-proof-plan");
-    artifact.verify_template_plan().expect("fixture receipt verifies before mutation");
+    artifact.check_template_plan_consistency().expect("fixture receipt verifies before mutation");
     let proof = artifact
         .argent
         .template_plan

--- a/src/compiler/codegen/emitter.rs
+++ b/src/compiler/codegen/emitter.rs
@@ -2011,7 +2011,7 @@ fn emit_artifact(program: &Program, model: &Model<'_>, actor_sil: &BTreeMap<Stri
     };
     artifact.id =
         artifact.computed_id_hex().map_err(|err| ArgentError::new(format!("failed to compute generated artifact id: {err}")))?;
-    artifact.verify().map_err(|err| ArgentError::new(format!("invalid generated artifact: {err}")))?;
+    artifact.check_consistency().map_err(|err| ArgentError::new(format!("invalid generated artifact: {err}")))?;
     Ok(artifact)
 }
 

--- a/src/compiler/codegen/emitter/tests.rs
+++ b/src/compiler/codegen/emitter/tests.rs
@@ -1911,7 +1911,7 @@ fn named_exact_self_coexists_with_a_constructed_route() {
     assert_eq!(entry.routes[0].output, "current");
     assert!(matches!(entry.routes[0].successor, RouteSuccessorArtifact::ExactSelf));
     assert_eq!(artifact_constructed_actor(&entry.routes[1]), "Peer");
-    artifact.verify_template_plan().expect("exact and constructed successor metadata verifies");
+    artifact.check_template_plan_consistency().expect("exact and constructed successor metadata verifies");
 }
 
 #[test]
@@ -3743,7 +3743,7 @@ fn emits_portable_artifact_schema() {
         extract_sil_template(&artifact.sil_abi.contract("Foo").unwrap().compiled).expect("Sil template extracts"),
         "a plain actor still exports its Sil template as its source-state handle"
     );
-    artifact.verify_template_plan().expect("template plan receipt verifies");
+    artifact.check_template_plan_consistency().expect("template plan receipt verifies");
     assert!(artifact.sil_abi.structs.is_empty(), "the equivalent authored struct is absent from the exact Sil ABI");
 
     let state = artifact.argent.states.iter().find(|state| state.name == "FooState").expect("source state is present");
@@ -4441,7 +4441,7 @@ fn expanded_actor_records_sil_and_capsule_template_cuts() {
     assert!(capsule_prefix.starts_with(sil_prefix));
     assert!(capsule_prefix.len() > sil_prefix.len());
     assert_eq!(handle.template.suffix, sil_template.suffix);
-    artifact.verify_template_plan().expect("capsule template receipt verifies");
+    artifact.check_template_plan_consistency().expect("capsule template receipt verifies");
 
     // A direct template role always stores one fixed-width template hash.
     let mut dynamic_template_field = artifact.clone();
@@ -4453,7 +4453,7 @@ fn expanded_actor_records_sil_and_capsule_template_cuts() {
         .find(|field| field.name == "gen__reserve_asset_template")
         .expect("template context field exists")
         .ty = TypeArtifact::Bytes;
-    let err = dynamic_template_field.verify_template_plan().expect_err("dynamic template context is rejected");
+    let err = dynamic_template_field.check_template_plan_consistency().expect_err("dynamic template context is rejected");
     assert!(
         matches!(err, TemplatePlanError::RuntimeStatePlanMismatch { ref contract, .. } if contract == "ReserveAsset"),
         "unexpected error: {err}"
@@ -4474,7 +4474,7 @@ fn expanded_actor_records_sil_and_capsule_template_cuts() {
     handle.template.prefix = prefix.clone();
     let suffix = handle.template.suffix.clone();
     handle.template.hash = silverscript_lang::template::template_hash(&prefix, &suffix);
-    let err = corrupted.verify_template_plan().expect_err("corrupted capsule context is rejected");
+    let err = corrupted.check_template_plan_consistency().expect_err("corrupted capsule context is rejected");
     assert!(matches!(err, TemplatePlanError::ActorTypeHandleMismatch { .. }), "unexpected error: {err}");
 
     let mut corrupted = artifact.clone();
@@ -4497,14 +4497,14 @@ fn expanded_actor_records_sil_and_capsule_template_cuts() {
     let suffix = handle.template.suffix.clone();
     handle.template.prefix = noncanonical_prefix.clone();
     handle.template.hash = silverscript_lang::template::template_hash(&noncanonical_prefix, &suffix);
-    let err = corrupted.verify_template_plan().expect_err("non-canonical capsule context is rejected");
+    let err = corrupted.check_template_plan_consistency().expect_err("non-canonical capsule context is rejected");
     assert!(matches!(err, TemplatePlanError::ActorTypeHandleMismatch { .. }), "unexpected error: {err}");
 
     let mut corrupted = artifact.clone();
     let capsule =
         corrupted.argent.states.iter_mut().find(|state| state.name == "AssetCapsule").expect("AssetCapsule Argent layout exists");
     capsule.fields.last_mut().expect("AssetCapsule has fields").ty = TypeArtifact::Bool;
-    let err = corrupted.verify_template_plan().expect_err("capsule state layout mismatch is rejected");
+    let err = corrupted.check_template_plan_consistency().expect_err("capsule state layout mismatch is rejected");
     assert!(matches!(err, TemplatePlanError::ActorTypeHandleMismatch { .. }), "unexpected error: {err}");
 
     let mut corrupted = artifact.clone();
@@ -4517,7 +4517,7 @@ fn expanded_actor_records_sil_and_capsule_template_cuts() {
         .map(|template| &mut template.actor_type_handle)
         .expect("ReserveAsset capsule handle exists");
     handle.template.hash = [0; 32];
-    let err = corrupted.verify_template_plan().expect_err("corrupted capsule hash is rejected");
+    let err = corrupted.check_template_plan_consistency().expect_err("corrupted capsule hash is rejected");
     assert!(matches!(err, TemplatePlanError::ActorTypeHandleMismatch { .. }), "unexpected error: {err}");
 }
 
@@ -5016,7 +5016,7 @@ fn observed_slots_lower_to_foreign_state_checks() {
 
     let artifact_json = fs::read_to_string(out_dir.join("artifact.json")).expect("artifact json exists");
     let artifact: Artifact = serde_json::from_str(&artifact_json).expect("artifact deserializes");
-    artifact.verify_template_plan().expect("observed witness receipts verify");
+    artifact.check_template_plan_consistency().expect("observed witness receipts verify");
 
     let _ = fs::remove_dir_all(out_dir);
 }
@@ -6248,7 +6248,7 @@ fn compiler_lowers_injected_deep_forest_cuts() {
     assert!(hub_b_sil.contains("gen__hub_b_routes_digest: blake3(byte[](gen__hub_b_routes)),"), "{hub_b_sil}");
 
     let artifact = emit_artifact(&program, &model, &actor_sil).expect("deep-forest artifact emits");
-    artifact.verify_template_plan().expect("deep-forest template plan verifies");
+    artifact.check_template_plan_consistency().expect("deep-forest template plan verifies");
     assert_eq!(artifact.argent.template_plan.route_families.len(), 2);
 }
 
@@ -6615,7 +6615,7 @@ fn in_app_observed_output_opens_the_target_family_cut() {
         param.name == "gen__mux_suffix" && param.subject == HiddenParamSubjectArtifact::Actor { actor: "Mux".to_string() }
     }));
     assert!(!advance.hidden_params.iter().any(|param| matches!(param.subject, HiddenParamSubjectArtifact::ObservedActor { .. })));
-    artifact.verify_template_plan().expect("in-app observed output uses the planned target cut");
+    artifact.check_template_plan_consistency().expect("in-app observed output uses the planned target cut");
 }
 
 #[test]
@@ -6938,7 +6938,7 @@ fn selected_gates_open_from_the_family_table_and_direct_consumes_stay_concrete()
     );
 
     let artifact = emit_artifact(&program, &model, &actor_sil).expect("generated Sil compiles");
-    artifact.verify_template_plan().expect("representative actors may be stored inside their family table");
+    artifact.check_template_plan_consistency().expect("representative actors may be stored inside their family table");
 }
 
 #[test]
@@ -7175,7 +7175,7 @@ fn direct_route_families_are_inferred_without_hints() {
         vec![("target", "MoveActor", "BoardState", vec!["Pawn", "Knight"], Some("Knight"))]
     );
     assert_eq!(choose_knight_const.routes.iter().map(artifact_constructed_actor).collect::<Vec<_>>(), vec!["Knight"]);
-    artifact.verify_template_plan().expect("template plan receipt verifies inferred route family");
+    artifact.check_template_plan_consistency().expect("template plan receipt verifies inferred route family");
 }
 
 #[test]
@@ -7455,7 +7455,7 @@ fn gate_less_family_appends_rep_after_selector_variants() {
     assert!(mux_sil.contains("require(gen__target_selector < 2);"), "{mux_sil}");
     assert!(mux_sil.contains("byte[32] gen__target_template = byte[32]("), "{mux_sil}");
     assert!(mux_sil.contains("gen__mux_routes.slice(gen__target_selector * 32, gen__target_selector * 32 + 32)"), "{mux_sil}");
-    artifact.verify_template_plan().expect("template plan receipt verifies");
+    artifact.check_template_plan_consistency().expect("template plan receipt verifies");
 }
 
 #[test]
@@ -7518,7 +7518,7 @@ fn actor_enum_local_drives_selector_domain_and_route_expansion() {
     let mux_sil = actor_sil.get("Mux").expect("Mux Sil is emitted");
     assert!(mux_sil.contains("int target = index;"), "{mux_sil}");
     assert!(mux_sil.contains("int gen__target_selector = target;"), "{mux_sil}");
-    artifact.verify_template_plan().expect("local selector route plan verifies");
+    artifact.check_template_plan_consistency().expect("local selector route plan verifies");
 }
 
 #[test]
@@ -7667,7 +7667,7 @@ fn selector_can_include_its_source_actor() {
             "#,
     );
 
-    artifact.verify_template_plan().expect("self selector variant has a valid identity cut transition");
+    artifact.check_template_plan_consistency().expect("self selector variant has a valid identity cut transition");
 }
 
 #[test]
@@ -7755,7 +7755,7 @@ fn two_actor_routes_use_direct_template_fields() {
             ("gen__b_template", RuntimeFieldRoleArtifact::Template { contract: "B".to_string() }),
         ]
     );
-    artifact.verify_template_plan().expect("direct two-actor route plan verifies");
+    artifact.check_template_plan_consistency().expect("direct two-actor route plan verifies");
 }
 
 #[test]
@@ -7918,7 +7918,7 @@ fn route_family_state_can_have_multiple_disconnected_families() {
             RuntimeFieldRoleArtifact::TemplateTable { contracts: vec!["D".to_string(), "E".to_string(), "F".to_string()] }
         ),]
     );
-    artifact.verify_template_plan().expect("multi-family route state receipt verifies");
+    artifact.check_template_plan_consistency().expect("multi-family route state receipt verifies");
 }
 
 #[test]
@@ -8009,7 +8009,7 @@ fn route_family_with_one_table_actor_uses_direct_template_fields() {
             ("gen__leaf_template", RuntimeFieldRoleArtifact::Template { contract: "Leaf".to_string() }),
         ]
     );
-    artifact.verify_template_plan().expect("direct route plan verifies");
+    artifact.check_template_plan_consistency().expect("direct route plan verifies");
 }
 
 #[test]
@@ -8123,7 +8123,7 @@ fn route_family_with_multiple_external_entries_uses_first_entry_as_representativ
             ),
         ]
     );
-    artifact.verify_template_plan().expect("multi-entry route family receipt verifies");
+    artifact.check_template_plan_consistency().expect("multi-entry route family receipt verifies");
 }
 
 fn inline_artifact(name: &str, source: &str) -> Artifact {
@@ -8465,11 +8465,11 @@ fn genesis_spawn_lowers_to_pinned_sil_and_artifact_metadata() {
             "gen__actor_type_self_pair_type_suffix",
         ]
     );
-    controller_artifact.verify_template_plan().expect("spawn metadata verifies");
+    controller_artifact.check_template_plan_consistency().expect("spawn metadata verifies");
     let mut malformed = controller_artifact.clone();
     malformed.argent.actors[0].entries[0].spawns[0].outputs[1].group_index = 2;
     assert!(
-        matches!(malformed.verify_template_plan(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
+        matches!(malformed.check_template_plan_consistency(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
         "malformed spawn output order must be rejected"
     );
     let mut noncanonical_template_subject = controller_artifact.clone();
@@ -8483,7 +8483,7 @@ fn genesis_spawn_lowers_to_pinned_sil_and_artifact_metadata() {
     };
     *handle = "right".to_string();
     assert!(
-        matches!(noncanonical_template_subject.verify_template_plan(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
+        matches!(noncanonical_template_subject.check_template_plan_consistency(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
         "shared spawn template witnesses must use their first output as subject"
     );
 
@@ -8527,7 +8527,7 @@ fn multiple_genesis_spawns_lower_to_pinned_sil_and_artifact_metadata() {
             "gen__actor_type_self_pair_type_suffix",
         ]
     );
-    controller_artifact.verify_template_plan().expect("multiple-spawn metadata verifies");
+    controller_artifact.check_template_plan_consistency().expect("multiple-spawn metadata verifies");
 
     let (pair_sil, _) = emit_selected_fixture(source, "PairApp", "Pair");
     assert_eq!(pair_sil, include_str!("../../../../tests/fixtures/runtime/context_multiple_genesis_spawns/Pair.sil"));
@@ -8572,7 +8572,7 @@ fn observed_and_spawned_source_actor_share_pinned_witnesses() {
             "witness/Controller/advance/actor_type/self_pair_type/template_suffix_bytes",
         ]
     );
-    controller_artifact.verify_template_plan().expect("shared observe/spawn witness metadata verifies");
+    controller_artifact.check_template_plan_consistency().expect("shared observe/spawn witness metadata verifies");
 
     let mut malformed = controller_artifact.clone();
     let prefix = malformed.argent.actors[0].entries[0]
@@ -8585,7 +8585,7 @@ fn observed_and_spawned_source_actor_share_pinned_witnesses() {
     };
     *handle = "missing".to_string();
     assert!(
-        matches!(malformed.verify_template_plan(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
+        matches!(malformed.check_template_plan_consistency(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
         "spawn metadata rejects an invalid observed witness provider"
     );
 
@@ -8905,11 +8905,11 @@ fn fixed_actor_spawn_uses_compiler_owned_template_and_keeps_its_closure() {
                 HiddenParamPurposeArtifact::TemplatePrefixBytes | HiddenParamPurposeArtifact::TemplateSuffixBytes
             )
     }));
-    artifact.verify_template_plan().expect("fixed spawn template closure verifies");
+    artifact.check_template_plan_consistency().expect("fixed spawn template closure verifies");
     let mut malformed = artifact.clone();
     malformed.argent.actors[0].entries[0].hidden_params.retain(|param| param.name != "gen__child_suffix");
     assert!(
-        matches!(malformed.verify_template_plan(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
+        matches!(malformed.check_template_plan_consistency(), Err(TemplatePlanError::InvalidSpawnMetadata { .. })),
         "static spawn metadata must retain one complete actor-scoped template pair"
     );
 
@@ -8951,7 +8951,7 @@ fn fixed_actor_spawn_reuses_consumed_template_in_pinned_sil() {
             ),
         ]
     );
-    launcher_artifact.verify_template_plan().expect("pinned fixed-spawn template plan verifies");
+    launcher_artifact.check_template_plan_consistency().expect("pinned fixed-spawn template plan verifies");
 }
 
 #[test]
@@ -8999,7 +8999,7 @@ fn fixed_actor_self_spawn_uses_the_active_template() {
                 | HiddenParamPurposeArtifact::TemplateSuffixLen
         )
     }));
-    artifact.verify_template_plan().expect("fixed self-spawn template plan verifies");
+    artifact.check_template_plan_consistency().expect("fixed self-spawn template plan verifies");
 }
 
 #[test]
@@ -9076,7 +9076,7 @@ fn fixed_actor_spawn_opens_the_target_family_cut() {
     assert!(launch.hidden_params.iter().any(|param| {
         param.name == "gen__mux_suffix" && param.subject == HiddenParamSubjectArtifact::Actor { actor: "Mux".to_string() }
     }));
-    artifact.verify_template_plan().expect("fixed family spawn template plan verifies");
+    artifact.check_template_plan_consistency().expect("fixed family spawn template plan verifies");
 }
 
 #[test]
@@ -9557,7 +9557,7 @@ fn assert_example_build_artifact(input: &str, name: &str, expected_hashes: &[(&s
 
     let artifact = crate::build_file(input, &out_dir).expect("example builds");
     artifact.check_schema_version().expect("artifact schema version is supported");
-    artifact.verify_template_plan().expect("template plan receipt verifies");
+    artifact.check_template_plan_consistency().expect("template plan receipt verifies");
 
     let expected_hashes = expected_hashes.iter().copied().collect::<BTreeMap<_, _>>();
     assert!(!artifact.argent.actors.is_empty(), "artifact should contain Argent actors");

--- a/src/compiler/model/link.rs
+++ b/src/compiler/model/link.rs
@@ -44,7 +44,7 @@ pub(crate) fn link_imported_actors(
         if artifact.app != *app {
             return Err(ArgentError::new(format!("linked artifact for app `{app}` declares app `{}`", artifact.app)));
         }
-        artifact.verify().map_err(|err| ArgentError::new(format!("linked app `{app}` has an invalid artifact: {err}")))?;
+        artifact.check_consistency().map_err(|err| ArgentError::new(format!("linked app `{app}` has an invalid artifact: {err}")))?;
     }
 
     let mut bindings = BTreeMap::<String, (String, String)>::new();

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -89,7 +89,7 @@ pub fn inspect_path(input: impl AsRef<Path>) -> Result<InspectionReport> {
 }
 
 pub fn inspect_artifact(artifact: &Artifact) -> Result<InspectionReport> {
-    artifact.verify().map_err(|err| ArgentError::new(format!("invalid artifact: {err}")))?;
+    artifact.check_consistency().map_err(|err| ArgentError::new(format!("invalid artifact: {err}")))?;
 
     let mut actors = Vec::with_capacity(artifact.argent.actors.len());
     for actor in &artifact.argent.actors {


### PR DESCRIPTION
## Context

Delegate authentication identifies an actor contract, but not the entrypoint selected by that input. An input which a leader expects to execute a delegate can therefore select any compatible ordinary entry on the same actor.

Today, actors with delegate entries must keep their non-delegate entries aware of surrounding same-covenant activity. Otherwise, an ordinary entry can occupy a delegate position and either create a parallel continuation or terminate while the leader consumes the actor. This is a subtle application-level obligation.

## Change

Moves the leader/delegate argument into a dedicated security guide and defines:

- the leader, delegate, input-group, and continuation-group model
- the compiler rules already enforced today
- the current entrypoint-substitution gap
- continuation closure, which makes the leader authorize every continuation in the coordinated covenant group
- a first-input requirement for zero-continuation ordinary entries on delegate-capable actors, which prevents delegate substitution while allowing later continuing entries in the same batch
- the resulting security properties and short proofs
- the batching behavior preserved by these rules

The two pending compiler rules are clearly marked **[NOT IMPLEMENTED]**. Together, they move this responsibility from application code into generated contracts without unnecessarily preventing independent same-covenant batching.

This PR also updates Argent to the latest Silverscript master revision, including its latest validation and resource-limit checks.

No Argent compiler behavior implementing the new delegation rules is included in this PR.